### PR TITLE
[POA-1415] Re-enable support for EC2 commands

### DIFF
--- a/cmd/internal/cmderr/checks.go
+++ b/cmd/internal/cmderr/checks.go
@@ -39,14 +39,14 @@ func CheckAPIKeyAndInsightsProjectID(projectID string) error {
 
 	// Check that project ID is provided.
 	if projectID == "" {
-		return errors.New("project ID is missiing, it must be specified")
+		return errors.New("project ID is missing, it must be specified")
 	}
 
 	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID())
 	var serviceID akid.ServiceID
 	err = akid.ParseIDAs(projectID, &serviceID)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse service ID")
+		return errors.Wrap(err, "failed to parse project ID")
 	}
 
 	_, err = util.GetServiceNameByServiceID(frontClient, serviceID)

--- a/cmd/internal/cmderr/checks.go
+++ b/cmd/internal/cmderr/checks.go
@@ -1,11 +1,14 @@
 package cmderr
 
 import (
-	"errors"
-
+	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/pkg/errors"
 	"github.com/postmanlabs/postman-insights-agent/cfg"
 	"github.com/postmanlabs/postman-insights-agent/env"
 	"github.com/postmanlabs/postman-insights-agent/printer"
+	"github.com/postmanlabs/postman-insights-agent/rest"
+	"github.com/postmanlabs/postman-insights-agent/telemetry"
+	"github.com/postmanlabs/postman-insights-agent/util"
 )
 
 // Checks that a user has configured their Postman API key and returned them.
@@ -19,9 +22,37 @@ func RequirePostmanAPICredentials(explanation string) (string, error) {
 		} else {
 			printer.Infof("Please set the POSTMAN_API_KEY environment variable, either in your shell session or prepend it to postman-insights-agent command.\n")
 		}
-		//lint:ignore ST1005 This is a user-facing error message
 		return "", AkitaErr{Err: errors.New("Could not find a Postman API key to use")}
 	}
 
 	return key, nil
+}
+
+// Checks that an API key and a project ID are provided, and that the API key is
+// valid for the project ID.
+func CheckAPIKeyAndInsightsProjectID(projectID string) error {
+	// Check for API key.
+	_, err := RequirePostmanAPICredentials("The Postman Insights Agent must have an API key in order to capture traces.")
+	if err != nil {
+		return err
+	}
+
+	// Check that project ID is provided.
+	if projectID == "" {
+		return errors.New("project ID is missiing, it must be specified")
+	}
+
+	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID())
+	var serviceID akid.ServiceID
+	err = akid.ParseIDAs(projectID, &serviceID)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse service ID")
+	}
+
+	_, err = util.GetServiceNameByServiceID(frontClient, serviceID)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/internal/ec2/README.md
+++ b/cmd/internal/ec2/README.md
@@ -14,7 +14,7 @@
 
 - Log in as root user, or use `sudo su` to enable root before running the below command
 ```
-POSTMAN_API_KEY=<postman-api-key> postman-insights-agent setup --collection <postman-collectionID>
+POSTMAN_API_KEY=<postman-api-key> postman-insights-agent ec2 --project <postman-insights-project-id>
 ```
 
 To check the status or logs please use

--- a/cmd/internal/ec2/postman-insights-agent.service
+++ b/cmd/internal/ec2/postman-insights-agent.service
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/default/postman-insights-agent
 # DO NOT CHANGE
 # "${FOO}" uses the arguement as is, while "$FOO" splits the string on white space 
 # Reference: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Command%20lines
-ExecStart=/usr/bin/postman-insights-agent apidump --collection "${COLLECTION_ID}" --interfaces "${INTERFACES}" --filter "${FILTER}" "$EXTRA_APIDUMP_ARGS"
+ExecStart=/usr/bin/postman-insights-agent apidump --project "${PROJECT_ID}" --interfaces "${INTERFACES}" --filter "${FILTER}" "$EXTRA_APIDUMP_ARGS"
 
 [Install]
 WantedBy=multi-user.target

--- a/cmd/internal/ec2/postman-insights-agent.tmpl
+++ b/cmd/internal/ec2/postman-insights-agent.tmpl
@@ -1,25 +1,26 @@
 # Add your Postman API key below. For example:
 #
-#   POSTMAN_API_KEY=PMAC-XXXXXXX
+#   POSTMAN_API_KEY=PMAK-XXXXXXX
 #
 # This is required.
 
 POSTMAN_API_KEY={{.PostmanAPIKey}}
 
 
-# Add your your Postman Collection ID. 
-#This is required.
+# Add your your Postman Project ID. 
+#
+#   PROJECT_ID=svc_XXXXXXX
+#
+# This is required.
 
-COLLECTION_ID={{.CollectionId}}
-
-# For example,
-#   COLLECTION_ID=1234567-890abcde-f123-4567-890a-bcdef1234567
+PROJECT_ID={{.ProjectID}}
 
 
 # INTERFACES is optional. If left blank, the agent will listen on all available
 # network interfaces.
 #
 # FILTER is optional. If left blank, no packet-capture filter will be applied.
+# 
 # For example
 #   INTERFACES=lo,eth0,eth1
 #   FILTER="port 80 or port 8080"

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -3,7 +3,6 @@ package ecs
 import (
 	"fmt"
 
-	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -12,9 +11,6 @@ import (
 	ecs_cloudformation_utils "github.com/postmanlabs/postman-insights-agent/aws_utils/cloudformation/ecs"
 	ecs_console_utils "github.com/postmanlabs/postman-insights-agent/aws_utils/console/ecs"
 	"github.com/postmanlabs/postman-insights-agent/cmd/internal/cmderr"
-	"github.com/postmanlabs/postman-insights-agent/rest"
-	"github.com/postmanlabs/postman-insights-agent/telemetry"
-	"github.com/postmanlabs/postman-insights-agent/util"
 	"github.com/spf13/cobra"
 )
 
@@ -141,37 +137,9 @@ func init() {
 	Cmd.AddCommand(RemoveFromECSCmd)
 }
 
-// Checks that an API key and a project ID are provided, and that the API key is
-// valid for the project ID.
-func checkAPIKeyAndProjectID() error {
-	// Check for API key.
-	_, err := cmderr.RequirePostmanAPICredentials("The Postman Insights Agent must have an API key in order to capture traces.")
-	if err != nil {
-		return err
-	}
-
-	// Check that project ID is provided.
-	if projectId == "" {
-		return errors.New("--project must be specified")
-	}
-
-	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID())
-	var serviceID akid.ServiceID
-	err = akid.ParseIDAs(projectId, &serviceID)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse service ID")
-	}
-
-	_, err = util.GetServiceNameByServiceID(frontClient, serviceID)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func addAgentToECS(cmd *cobra.Command, args []string) error {
-	err := checkAPIKeyAndProjectID()
+	// Check if the API key and Insights project ID are valid
+	err := cmderr.CheckAPIKeyAndInsightsProjectID(projectId)
 	if err != nil {
 		return err
 	}
@@ -184,7 +152,7 @@ func removeAgentFromECS(cmd *cobra.Command, args []string) error {
 }
 
 func printCloudFormationFragment(cmd *cobra.Command, args []string) error {
-	err := checkAPIKeyAndProjectID()
+	err := cmderr.CheckAPIKeyAndInsightsProjectID(projectId)
 	if err != nil {
 		return err
 	}
@@ -211,7 +179,7 @@ func printCloudFormationFragment(cmd *cobra.Command, args []string) error {
 }
 
 func printECSTaskDefinition(cmd *cobra.Command, args []string) error {
-	err := checkAPIKeyAndProjectID()
+	err := cmderr.CheckAPIKeyAndInsightsProjectID(projectId)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In this PR, we are re-enabling support for EC2 in our agent.
Changes done:
* Replaced `--collection` flag with `--project` in EC2 command
* Added a base`ec2` command since the `setup` command can be confusing.
  * So `postman-insights-agent setup ...` -> `postman-insights-agent ec2 setup ...`
  * Only `ec2` command also defaults to `ec2 setup`
* Moved the `CheckAPIKeyAndInsightsProjectID` function out from `ecs.go` to `check.go`
* Other small syntactic or typo changes