### PR TITLE
[POA-1520] Remove preStop script for Kubernetes

### DIFF
--- a/cmd/internal/kube/inject.go
+++ b/cmd/internal/kube/inject.go
@@ -197,7 +197,7 @@ func init() {
 		"file",
 		"f",
 		"",
-		"Path to the Kubernetes YAML file to be injected. This should contain a Deployment object.",
+		"Path to the Kubernetes YAML file to be injected, or - for standard input. This should contain a Deployment object.",
 	)
 	_ = injectCmd.MarkFlagRequired("file")
 

--- a/cmd/internal/kube/injector/injector.go
+++ b/cmd/internal/kube/injector/injector.go
@@ -164,6 +164,15 @@ func fromRawObject(raw []byte) (*unstructured.Unstructured, error) {
 }
 
 func getFile(filePath string) ([]byte, error) {
+	if filePath == "-" {
+		// Read from stdin instead.
+		bytes, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not read from standard input")
+		}
+		return bytes, nil
+	}
+
 	fileDir, fileName := filepath.Split(filePath)
 
 	absOutputDir, err := filepath.Abs(fileDir)

--- a/cmd/internal/kube/print_fragment.go
+++ b/cmd/internal/kube/print_fragment.go
@@ -87,15 +87,6 @@ func createTerraformContainer(insightsProjectID string) *hclwrite.File {
 	containerBody.SetAttributeValue("name", cty.StringVal("postman-insights-agent"))
 	containerBody.SetAttributeValue("image", cty.StringVal(akitaImage))
 
-	containerBody.AppendNewBlock("lifecycle", []string{}).
-		Body().AppendNewBlock("pre_stop", []string{}).
-		Body().AppendNewBlock("exec", []string{}).
-		Body().SetAttributeValue("command", cty.ListVal([]cty.Value{
-		cty.StringVal("/bin/sh"),
-		cty.StringVal("-c"),
-		cty.StringVal("POSTMAN_INSIGHTS_AGENT_PID=$(pgrep postman-insights-agent) && kill -2 $POSTMAN_INSIGHTS_AGENT_PID && tail -f /proc/$POSTMAN_INSIGHTS_AGENT_PID/fd/1"),
-	}))
-
 	containerBody.AppendNewBlock("security_context", []string{}).
 		Body().AppendNewBlock("capabilities", []string{}).
 		Body().SetAttributeValue("add", cty.ListVal([]cty.Value{

--- a/cmd/internal/kube/util.go
+++ b/cmd/internal/kube/util.go
@@ -113,18 +113,7 @@ func createPostmanSidecar(insightsProjectID string, addAPIKeyAsSecret bool) v1.C
 		Name:  "postman-insights-agent",
 		Image: akitaImage,
 		Env:   envs,
-		Lifecycle: &v1.Lifecycle{
-			PreStop: &v1.LifecycleHandler{
-				Exec: &v1.ExecAction{
-					Command: []string{
-						"/bin/sh",
-						"-c",
-						"POSTMAN_INSIGHTS_AGENT_PID=$(pgrep postman-insights-agent) && kill -2 $POSTMAN_INSIGHTS_AGENT_PID && tail -f /proc/$POSTMAN_INSIGHTS_AGENT_PID/fd/1",
-					},
-				},
-			},
-		},
-		Args: args,
+		Args:  args,
 		SecurityContext: &v1.SecurityContext{
 			Capabilities: &v1.Capabilities{Add: []v1.Capability{"NET_RAW"}},
 		},


### PR DESCRIPTION
also includes [POA-1515] Support "-f -" to read from stdin in injector

As far as I can reconstruct, the preStop problem was that pgrep only checks the process name by default, which is limited to 15 characters.  While we could fix that, I concluded that the only point of the script was to send SIGINT to terminate the agent gracefully, but it now supports receiving SIGTERM directly from Kubernetes, so this is unnecessary.



[POA-1515]: https://postmanlabs.atlassian.net/browse/POA-1515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ