### PR TITLE
[POA-1514] Preserve POSTMAN_ENV in envFile in ec2 start

### DIFF
--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/cfg"
 	"github.com/postmanlabs/postman-insights-agent/consts"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
@@ -177,12 +178,17 @@ func configureSystemdFiles(projectID string) error {
 		return errors.Wrapf(err, "systemd env file parsing failed")
 	}
 
+	apiKey, env := cfg.GetPostmanAPIKeyAndEnvironment()
 	data := struct {
+		PostmanEnv    string
 		PostmanAPIKey string
 		ProjectID     string
 	}{
-		PostmanAPIKey: os.Getenv("POSTMAN_API_KEY"),
+		PostmanAPIKey: apiKey,
 		ProjectID:     projectID,
+	}
+	if env != "" {
+		data.PostmanEnv = env
 	}
 
 	// Ensure /etc/default exists

--- a/cmd/internal/ec2/postman-insights-agent.tmpl
+++ b/cmd/internal/ec2/postman-insights-agent.tmpl
@@ -1,3 +1,10 @@
+# POSTMAN_ENV is optional. If left blank, the agent will send witness data
+# to default Postman environment
+# For example: 
+#   POSTMAN_ENV=STAGE
+#
+POSTMAN_ENV={{.PostmanEnv}}
+
 # Add your Postman API key below. For example:
 #
 #   POSTMAN_API_KEY=PMAK-XXXXXXX

--- a/cmd/internal/ec2/postman-insights-agent.tmpl
+++ b/cmd/internal/ec2/postman-insights-agent.tmpl
@@ -1,10 +1,3 @@
-# POSTMAN_ENV is optional. If left blank, the agent will send witness data
-# to default Postman environment
-# For example: 
-#   POSTMAN_ENV=STAGE
-#
-POSTMAN_ENV={{.PostmanEnv}}
-
 # Add your Postman API key below. For example:
 #
 #   POSTMAN_API_KEY=PMAK-XXXXXXX
@@ -45,3 +38,8 @@ FILTER=
 # This is optional and can be left blank.
 
 EXTRA_APIDUMP_ARGS=
+
+{{if .PostmanEnv}}
+# POSTMAN_ENV is optional. Used for dogfooding and internal testing.
+POSTMAN_ENV={{.PostmanEnv}}
+{{end}}


### PR DESCRIPTION
If a user uses the `ec2 start` command with POSTMAN_ENV env var, its value is not set in the env file, which stores other env vars for the systemd service. This will cause an issue for the apidump command since it will then default to prod env.

In this PR, we are preserving the POSTMAN_ENV value in the env file and using that in apidump command which is running as a systemd service.