### PR TITLE
POA-1461 Address code scan

### DIFF
--- a/apidump/exec.go
+++ b/apidump/exec.go
@@ -29,12 +29,12 @@ func runCommand(username string, c string) error {
 
 	// Only support POSIX systems for now, which means we can assume uid and gid
 	// are integers.
-	var uid, gid int
-	uid, err = strconv.Atoi(runUser.Uid)
+	var uid, gid uint32
+	uid, err = parseUint32(runUser.Uid)
 	if err != nil {
 		return errors.Wrapf(err, "cannot lookup uid for %q", runUser.Name)
 	}
-	gid, err = strconv.Atoi(runUser.Gid)
+	gid, err = parseUint32(runUser.Gid)
 	if err != nil {
 		return errors.Wrapf(err, "cannot lookup gid for %q", runUser.Name)
 	}
@@ -52,7 +52,7 @@ func runCommand(username string, c string) error {
 
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
-	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}
+	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid}
 
 	{
 		stdout, err := cmd.StdoutPipe()
@@ -75,4 +75,12 @@ func runCommand(username string, c string) error {
 	}
 
 	return cmd.Wait()
+}
+
+func parseUint32(s string) (uint32, error) {
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(n), nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,7 +173,6 @@ func init() {
 
 	// Use a proxy or permit a mismatched certificate.
 	rootCmd.PersistentFlags().StringVar(&rest.ProxyAddress, "proxy", "", "The domain name, IP address, or URL of an HTTP proxy server to use")
-	rootCmd.PersistentFlags().BoolVar(&rest.PermitInvalidCertificate, "skip-tls-validate", false, "Skip TLS validation on the connection to the back end")
 	rootCmd.PersistentFlags().MarkHidden("skip-tls-validate")
 	rootCmd.PersistentFlags().StringVar(&rest.ExpectedServerName, "server-tls-name", "", "Provide an alternate TLS server name to accept")
 	rootCmd.PersistentFlags().MarkHidden("server-tls-name")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,7 +173,6 @@ func init() {
 
 	// Use a proxy or permit a mismatched certificate.
 	rootCmd.PersistentFlags().StringVar(&rest.ProxyAddress, "proxy", "", "The domain name, IP address, or URL of an HTTP proxy server to use")
-	rootCmd.PersistentFlags().MarkHidden("skip-tls-validate")
 	rootCmd.PersistentFlags().StringVar(&rest.ExpectedServerName, "server-tls-name", "", "Provide an alternate TLS server name to accept")
 	rootCmd.PersistentFlags().MarkHidden("server-tls-name")
 

--- a/rest/base_client.go
+++ b/rest/base_client.go
@@ -21,9 +21,6 @@ import (
 // none is provided.
 var ProxyAddress string
 
-// Connect even if the certificate does not validate.
-var PermitInvalidCertificate bool
-
 // Accept a server name other than the expected one in the TLS handshake
 var ExpectedServerName string
 

--- a/rest/http.go
+++ b/rest/http.go
@@ -93,10 +93,6 @@ func initHTTPClient() {
 		}
 	}
 	transport.TLSClientConfig = &tls.Config{}
-	if PermitInvalidCertificate {
-		printer.Warningf("Disabling TLS checking; sending traffic without verifying identity of Postman servers.\n")
-		transport.TLSClientConfig.InsecureSkipVerify = true
-	}
 	if ExpectedServerName != "" {
 		transport.TLSClientConfig.ServerName = ExpectedServerName
 	}


### PR DESCRIPTION
* Use safer conversion from `string` to `uint32`.
* Removed support for skipping TLS verification.