### PR TITLE
POA-1976 Add option to keep witness payloads

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -138,6 +138,9 @@ type Args struct {
 	DockerExtensionMode bool
 	// The port to be used by the Docker Extension for health checks
 	HealthCheckPort int
+
+	// Whether to include request/response payloads when uploading witnesses.
+	SendWitnessPayloads bool
 }
 
 // TODO: either remove write-to-local-HAR-file completely,
@@ -680,7 +683,7 @@ func (a *apidump) Run() error {
 			} else {
 				var backendCollector trace.Collector
 				if args.Out.AkitaURI != nil {
-					backendCollector = trace.NewBackendCollector(a.backendSvc, backendLrn, a.learnClient, optionals.Some(a.MaxWitnessSize_bytes), summary, args.Plugins)
+					backendCollector = trace.NewBackendCollector(a.backendSvc, backendLrn, a.learnClient, optionals.Some(a.MaxWitnessSize_bytes), summary, args.SendWitnessPayloads, args.Plugins)
 					collector = backendCollector
 				} else {
 					return errors.Errorf("invalid output location")

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -48,6 +48,7 @@ var (
 	dockerExtensionMode     bool
 	healthCheckPort         int
 	randomizedStart         int
+	sendWitnessPayloads     bool
 )
 
 // This function will either startup apidump normally, or never return, with probability
@@ -201,6 +202,7 @@ var Cmd = &cobra.Command{
 			MaxWitnessSize_bytes:    maxWitnessSize_bytes,
 			DockerExtensionMode:     dockerExtensionMode,
 			HealthCheckPort:         healthCheckPort,
+			SendWitnessPayloads:     sendWitnessPayloads,
 		}
 		if err := apidump.Run(args); err != nil {
 			return cmderr.AkitaErr{Err: err}
@@ -396,4 +398,12 @@ func init() {
 		"Probability that the apidump command will start intercepting traffic.",
 	)
 	_ = Cmd.Flags().MarkHidden("randomized-start")
+
+	Cmd.Flags().BoolVar(
+		&sendWitnessPayloads,
+		"send-witness-payloads",
+		false,
+		"Send request and response payloads to Postman",
+	)
+	_ = Cmd.Flags().MarkHidden("send-witness-payloads")
 }

--- a/integrations/nginx/backend.go
+++ b/integrations/nginx/backend.go
@@ -178,7 +178,7 @@ func NewNginxBackend(args *Args) (*NginxBackend, error) {
 
 	b.summary = trace.NewPacketCounter()
 	b.collector = trace.NewBackendCollector(b.backendSvc, backendLrn, b.learnClient,
-		optionals.Some(args.MaxWitnessSize_bytes), b.summary, args.Plugins)
+		optionals.Some(args.MaxWitnessSize_bytes), b.summary, false, args.Plugins)
 
 	// TODO: rate-limit
 	// TODO: session rotation

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -91,7 +91,7 @@ func TestObfuscate(t *testing.T) {
 		},
 	}
 
-	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), NewPacketCounter(), nil)
+	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), NewPacketCounter(), false, nil)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
 	assert.NoError(t, col.Close())
@@ -219,7 +219,7 @@ func TestTiming(t *testing.T) {
 		FinalPacketTime: startTime.Add(13 * time.Millisecond),
 	}
 
-	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), NewPacketCounter(), nil)
+	col := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), NewPacketCounter(), false, nil)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
 	assert.NoError(t, col.Close())
@@ -241,7 +241,7 @@ func TestMultipleInterfaces(t *testing.T) {
 		AnyTimes().
 		Return(nil)
 
-	bc := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), NewPacketCounter(), nil)
+	bc := NewBackendCollector(fakeSvc, fakeLrn, mockClient, optionals.None[int](), NewPacketCounter(), false, nil)
 
 	var wg sync.WaitGroup
 	fakeTrace := func(count int, start_seq int) {
@@ -291,7 +291,7 @@ func TestMultipleInterfaces(t *testing.T) {
 func TestFlushExit(t *testing.T) {
 	b := &BackendCollector{}
 	b.uploadReportBatch = batcher.NewInMemory[rawReport](
-		newReportBuffer(b, NewPacketCounter(), uploadBatchMaxSize_bytes, optionals.None[int]()),
+		newReportBuffer(b, NewPacketCounter(), uploadBatchMaxSize_bytes, optionals.None[int](), false),
 		uploadBatchFlushDuration,
 	)
 	b.flushDone = make(chan struct{})


### PR DESCRIPTION
Added `--send-witness-payloads` to `apidump`. When this flag is specified, witness payloads will be preserved and sent to the back end, and only witnesses that are too large (as determined by `--max-witness-size-bytes`) are obfuscated.