### PR TITLE
[POA-2003] Set obfuscation enum in witness method meta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
-	github.com/akitasoftware/akita-ir v0.0.0-20241008083010-10a0a96871ee
-	github.com/akitasoftware/akita-libs v0.0.0-20241008090043-a18d1f084faf
+	github.com/akitasoftware/akita-ir v0.0.0-20241008154243-b6c9139277d2
+	github.com/akitasoftware/akita-libs v0.0.0-20241008155148-e576f410f201
 	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
-	github.com/akitasoftware/akita-ir v0.0.0-20241008154243-b6c9139277d2
-	github.com/akitasoftware/akita-libs v0.0.0-20241008155148-e576f410f201
+	github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4
+	github.com/akitasoftware/akita-libs v0.0.0-20241008174225-3b01e02d3430
 	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
-	github.com/akitasoftware/akita-ir v0.0.0-20240815175436-58df31060c47
+	github.com/akitasoftware/akita-ir v0.0.0-20241008083010-10a0a96871ee
 	github.com/akitasoftware/akita-libs v0.0.0-20240820205141-dc8c30c29a5b
 	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/andybalholm/brotli v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20241008083010-10a0a96871ee
-	github.com/akitasoftware/akita-libs v0.0.0-20240820205141-dc8c30c29a5b
+	github.com/akitasoftware/akita-libs v0.0.0-20241008090043-a18d1f084faf
 	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -26,12 +26,10 @@ github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00
 github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/akitasoftware/akita-ir v0.0.0-20241008083010-10a0a96871ee h1:Ro3uTG4gNXk+c2kVYrZdI1BXlxNAhZ9O3X31Qb1gEX0=
-github.com/akitasoftware/akita-ir v0.0.0-20241008083010-10a0a96871ee/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
-github.com/akitasoftware/akita-libs v0.0.0-20240820205141-dc8c30c29a5b h1:uv2OpBVS7OQRj2oNxRjvypelKIibJhZnfXPXxdFzrm0=
-github.com/akitasoftware/akita-libs v0.0.0-20240820205141-dc8c30c29a5b/go.mod h1:a/vNhO1KQ5Qmz70Tvva4KfQKySiIpNmfJLdpArov3uc=
-github.com/akitasoftware/akita-libs v0.0.0-20241008090043-a18d1f084faf h1:7Vz4FkVoTyyvxHwmn4UZ0yYoiyG2OZFRQNfepFE7lxk=
-github.com/akitasoftware/akita-libs v0.0.0-20241008090043-a18d1f084faf/go.mod h1:OWQAlT2sj2M6ISaDClN3dVD08WpVxoWajm4jJxQmXzk=
+github.com/akitasoftware/akita-ir v0.0.0-20241008154243-b6c9139277d2 h1:P1NY6/c+Qcq9cz2Uw/2msGNBHOPTuv2kb92lU4gt/jI=
+github.com/akitasoftware/akita-ir v0.0.0-20241008154243-b6c9139277d2/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
+github.com/akitasoftware/akita-libs v0.0.0-20241008155148-e576f410f201 h1:UXB5PwD49UGDsy3lUZXmu1kD4HyZaMryHilNKKYaggM=
+github.com/akitasoftware/akita-libs v0.0.0-20241008155148-e576f410f201/go.mod h1:6Q2tAbfwf8sn4EnXs/SDE7bi0Mlc9fZsH94KQRjSYHI=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20240820200020-7289ae956f70 h1:VnU7QLDBwRujpQoHwShs5yu0Ahv1fSalNJa4UijwlmY=

--- a/go.sum
+++ b/go.sum
@@ -26,10 +26,10 @@ github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00
 github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/akitasoftware/akita-ir v0.0.0-20241008154243-b6c9139277d2 h1:P1NY6/c+Qcq9cz2Uw/2msGNBHOPTuv2kb92lU4gt/jI=
-github.com/akitasoftware/akita-ir v0.0.0-20241008154243-b6c9139277d2/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
-github.com/akitasoftware/akita-libs v0.0.0-20241008155148-e576f410f201 h1:UXB5PwD49UGDsy3lUZXmu1kD4HyZaMryHilNKKYaggM=
-github.com/akitasoftware/akita-libs v0.0.0-20241008155148-e576f410f201/go.mod h1:6Q2tAbfwf8sn4EnXs/SDE7bi0Mlc9fZsH94KQRjSYHI=
+github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4 h1:jbsA7E68G4dkK+ldQKQNPFIaRojFCn+cEB3gEEUSEU4=
+github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
+github.com/akitasoftware/akita-libs v0.0.0-20241008174225-3b01e02d3430 h1:rmeFo57G8voBffbLNBGsqpBtmc7+awRHcWSSk7XdBd4=
+github.com/akitasoftware/akita-libs v0.0.0-20241008174225-3b01e02d3430/go.mod h1:5rzkpaJI1sA9CtGELYZpf15oczAVopcyda2WsYG5xno=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20240820200020-7289ae956f70 h1:VnU7QLDBwRujpQoHwShs5yu0Ahv1fSalNJa4UijwlmY=

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00
 github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/akitasoftware/akita-ir v0.0.0-20240815175436-58df31060c47 h1:TDwN055fb5Jhki+Gefi5ltc8yuH8cnzCSfBn8EqSNcM=
-github.com/akitasoftware/akita-ir v0.0.0-20240815175436-58df31060c47/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
+github.com/akitasoftware/akita-ir v0.0.0-20241008083010-10a0a96871ee h1:Ro3uTG4gNXk+c2kVYrZdI1BXlxNAhZ9O3X31Qb1gEX0=
+github.com/akitasoftware/akita-ir v0.0.0-20241008083010-10a0a96871ee/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20240820205141-dc8c30c29a5b h1:uv2OpBVS7OQRj2oNxRjvypelKIibJhZnfXPXxdFzrm0=
 github.com/akitasoftware/akita-libs v0.0.0-20240820205141-dc8c30c29a5b/go.mod h1:a/vNhO1KQ5Qmz70Tvva4KfQKySiIpNmfJLdpArov3uc=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/akitasoftware/akita-ir v0.0.0-20241008083010-10a0a96871ee h1:Ro3uTG4g
 github.com/akitasoftware/akita-ir v0.0.0-20241008083010-10a0a96871ee/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20240820205141-dc8c30c29a5b h1:uv2OpBVS7OQRj2oNxRjvypelKIibJhZnfXPXxdFzrm0=
 github.com/akitasoftware/akita-libs v0.0.0-20240820205141-dc8c30c29a5b/go.mod h1:a/vNhO1KQ5Qmz70Tvva4KfQKySiIpNmfJLdpArov3uc=
+github.com/akitasoftware/akita-libs v0.0.0-20241008090043-a18d1f084faf h1:7Vz4FkVoTyyvxHwmn4UZ0yYoiyG2OZFRQNfepFE7lxk=
+github.com/akitasoftware/akita-libs v0.0.0-20241008090043-a18d1f084faf/go.mod h1:OWQAlT2sj2M6ISaDClN3dVD08WpVxoWajm4jJxQmXzk=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20240820200020-7289ae956f70 h1:VnU7QLDBwRujpQoHwShs5yu0Ahv1fSalNJa4UijwlmY=

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -290,6 +290,9 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 		// Obfuscate the original value so type inference engine can use it on the
 		// backend without revealing the actual value.
 		obfuscate(w.witness.GetMethod())
+	} else {
+		// Mark the method as not obfuscated.
+		w.witness.GetMethod().GetMeta().GetHttp().Obfuscation = pb.HTTPMethodMeta_NONE
 	}
 
 	c.uploadReportBatch.Add(rawReport{

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -278,6 +278,9 @@ func (c *BackendCollector) processTLSHandshake(tls akinet.TLSHandshakeMetadata) 
 }
 
 func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
+	// Mark the method as not obfuscated.
+	w.witness.GetMethod().GetMeta().GetHttp().Obfuscation = pb.HTTPMethodMeta_NONE
+
 	for _, p := range c.plugins {
 		if err := p.Transform(w.witness.GetMethod()); err != nil {
 			// Only upload if plugins did not return error.
@@ -290,9 +293,6 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 		// Obfuscate the original value so type inference engine can use it on the
 		// backend without revealing the actual value.
 		obfuscate(w.witness.GetMethod())
-	} else {
-		// Mark the method as not obfuscated.
-		w.witness.GetMethod().GetMeta().GetHttp().Obfuscation = pb.HTTPMethodMeta_NONE
 	}
 
 	c.uploadReportBatch.Add(rawReport{

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -123,6 +123,7 @@ func TestObfuscate(t *testing.T) {
 							Method:       "POST",
 							PathTemplate: "/v1/doggos",
 							Host:         "example.com",
+							Obfuscation:  pb.HTTPMethodMeta_ZERO_VALUE,
 						},
 					},
 				},

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -11,6 +11,9 @@ import (
 func obfuscate(m *pb.Method) {
 	var ov obfuscationVisitor
 	vis.Apply(&ov, m)
+
+	// Mark the method as obfuscated.
+	m.GetMeta().GetHttp().Obfuscation = pb.HTTPMethodMeta_ZERO_VALUE
 }
 
 type obfuscationVisitor struct {


### PR DESCRIPTION
* In this PR, we have added support to identify whether a witness payload is obfuscated or not.
* We are setting the `Obfuscation` attribute to `ZERO_VALUE` in the `obfuscation()` function and `NONE` in the else branch in the `queueUpload()` function in `backend_collection.go`.
  * `ZERO_VALUE` assignment is still kept to update the value if the witness is obfuscated later in `report_buffer.go` due to the large size
* Also updated the observability-ir version.