### PR TITLE
[POA-2004] Don't capture payloads of success requests

### DIFF
--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -286,7 +286,7 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 		}
 	}
 
-	if !c.sendWitnessPayloads {
+	if !c.sendWitnessPayloads || !hasErrorResponses(w.witness.GetMethod()) {
 		// Obfuscate the original value so type inference engine can use it on the
 		// backend without revealing the actual value.
 		obfuscate(w.witness.GetMethod())

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -289,7 +289,7 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 		}
 	}
 
-	if !c.sendWitnessPayloads || !hasErrorResponses(w.witness.GetMethod()) {
+	if !c.sendWitnessPayloads || !hasOnlyErrorResponses(w.witness.GetMethod()) {
 		// Obfuscate the original value so type inference engine can use it on the
 		// backend without revealing the actual value.
 		obfuscate(w.witness.GetMethod())

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -2,7 +2,6 @@ package trace
 
 import (
 	"encoding/base64"
-	"fmt"
 	"net/url"
 	"sync"
 	"testing"
@@ -407,6 +406,7 @@ func TestOnlyObfuscateNonErrorResponses(t *testing.T) {
 							Method:       "POST",
 							PathTemplate: "/v1/doggos",
 							Host:         "example.com",
+							Obfuscation:  pb.HTTPMethodMeta_ZERO_VALUE,
 						},
 					},
 				},
@@ -438,6 +438,7 @@ func TestOnlyObfuscateNonErrorResponses(t *testing.T) {
 							Method:       "POST",
 							PathTemplate: "/v1/doggos",
 							Host:         "example.com",
+							Obfuscation:  pb.HTTPMethodMeta_NONE,
 						},
 					},
 				},
@@ -446,7 +447,6 @@ func TestOnlyObfuscateNonErrorResponses(t *testing.T) {
 	}
 
 	for i := range expectedWitnesses {
-		fmt.Println(i)
 		expected := proto.MarshalTextString(expectedWitnesses[i])
 		actual := proto.MarshalTextString(rec.witnesses[i])
 		assert.Equal(t, expected, actual)

--- a/trace/util.go
+++ b/trace/util.go
@@ -13,7 +13,7 @@ func hasOnlyErrorResponses(method *pb.Method) bool {
 
 	for _, response := range responses {
 		responseCode := response.Meta.GetHttp().GetResponseCode()
-		if responseCode < 400 {
+		if !(400 <= responseCode && responseCode < 600) {
 			return false
 		}
 	}

--- a/trace/util.go
+++ b/trace/util.go
@@ -2,9 +2,10 @@ package trace
 
 import pb "github.com/akitasoftware/akita-ir/go/api_spec"
 
-// Determines whether a given method has error (4xx or 5xx) response codes. Returns true if the method has at least one response and all response codes are 4xx or 5xx.
+// Determines whether a given method has only error (4xx or 5xx) response codes.
+// Returns true if the method has at least one response and all response codes are 4xx or 5xx.
 // Here method will only have single response object because in agent each witness stores single request-response pair.
-func hasErrorResponses(method *pb.Method) bool {
+func hasOnlyErrorResponses(method *pb.Method) bool {
 	responses := method.GetResponses()
 	if len(responses) == 0 {
 		return false

--- a/trace/util.go
+++ b/trace/util.go
@@ -1,1 +1,21 @@
 package trace
+
+import pb "github.com/akitasoftware/akita-ir/go/api_spec"
+
+// Determines whether a given method has error (4xx or 5xx) response codes. Returns true if the method has at least one response and all response codes are 4xx or 5xx.
+// Here method will only have single response object because in agent each witness stores single request-response pair.
+func hasErrorResponses(method *pb.Method) bool {
+	responses := method.GetResponses()
+	if len(responses) == 0 {
+		return false
+	}
+
+	for _, response := range responses {
+		responseCode := response.Meta.GetHttp().GetResponseCode()
+		if responseCode < 400 {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
* Add support to obfuscate success (2xx or 3xx) responses always if the sendWitnessPayloads is enabled
* Add a `hasErrorResponses()` util function, which will check the response object of the method and return false if the response code is less than 400.