### PR TITLE
[POA-2083] Add support for obfuscating sensitive data by default

### DIFF
--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -142,6 +142,8 @@ type BackendCollector struct {
 	sendWitnessPayloads bool
 
 	plugins []plugin.AkitaPlugin
+
+	obfuscator *Obfuscator
 }
 
 var _ LearnSessionCollector = (*BackendCollector)(nil)
@@ -162,6 +164,7 @@ func NewBackendCollector(
 		flushDone:           make(chan struct{}),
 		plugins:             plugins,
 		sendWitnessPayloads: sendWitnessPayloads,
+		obfuscator:          NewObfuscator(),
 	}
 
 	col.uploadReportBatch = batcher.NewInMemory[rawReport](
@@ -292,7 +295,9 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 	if !c.sendWitnessPayloads || !hasOnlyErrorResponses(w.witness.GetMethod()) {
 		// Obfuscate the original value so type inference engine can use it on the
 		// backend without revealing the actual value.
-		obfuscate(w.witness.GetMethod())
+		c.obfuscator.obfuscate(w.witness.GetMethod(), true)
+	} else {
+		c.obfuscator.obfuscate(w.witness.GetMethod(), false)
 	}
 
 	c.uploadReportBatch.Add(rawReport{

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -295,9 +295,9 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 	if !c.sendWitnessPayloads || !hasOnlyErrorResponses(w.witness.GetMethod()) {
 		// Obfuscate the original value so type inference engine can use it on the
 		// backend without revealing the actual value.
-		c.obfuscator.Obfuscate(w.witness.GetMethod(), true)
+		c.obfuscator.ObfuscateData(w.witness.GetMethod())
 	} else {
-		c.obfuscator.Obfuscate(w.witness.GetMethod(), false)
+		c.obfuscator.RedactData(w.witness.GetMethod())
 	}
 
 	c.uploadReportBatch.Add(rawReport{

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -295,7 +295,7 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 	if !c.sendWitnessPayloads || !hasOnlyErrorResponses(w.witness.GetMethod()) {
 		// Obfuscate the original value so type inference engine can use it on the
 		// backend without revealing the actual value.
-		c.obfuscator.ObfuscateData(w.witness.GetMethod())
+		c.obfuscator.ObfuscateDataWithZeroValue(w.witness.GetMethod())
 	} else {
 		c.obfuscator.RedactData(w.witness.GetMethod())
 	}

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -295,9 +295,9 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 	if !c.sendWitnessPayloads || !hasOnlyErrorResponses(w.witness.GetMethod()) {
 		// Obfuscate the original value so type inference engine can use it on the
 		// backend without revealing the actual value.
-		c.obfuscator.obfuscate(w.witness.GetMethod(), true)
+		c.obfuscator.Obfuscate(w.witness.GetMethod(), true)
 	} else {
-		c.obfuscator.obfuscate(w.witness.GetMethod(), false)
+		c.obfuscator.Obfuscate(w.witness.GetMethod(), false)
 	}
 
 	c.uploadReportBatch.Add(rawReport{

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -566,28 +566,28 @@ func TestObfuscationConfigs(t *testing.T) {
 					ApiType: pb.ApiType_HTTP_REST,
 				},
 				Args: map[string]*pb.Data{
-					"4F1vWo8G_-Q=": newTestHeaderSpec(dataFromPrimitive(spec_util.NewPrimitiveString("")), "x-access-token", 0),
+					"4F1vWo8G_-Q=": newTestHeaderSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), "x-access-token", 0),
 					"KC2RO-pCNJA=": newTestHeaderSpec(dataFromPrimitive(spec_util.NewPrimitiveString("Normal-Value")), "Normal-Header", 0),
-					"xwb2G1yYVVc=": newTestHeaderSpec(dataFromPrimitive(spec_util.NewPrimitiveString("")), "pmak_in_header", 0),
-					"9NijbeQiJAg=": newTestQueryParamSpec(dataFromPrimitive(spec_util.NewPrimitiveString("")), "sso_jwt_key", 0),
-					"b5t-IaNo7Ug=": newTestQueryParamSpec(dataFromPrimitive(spec_util.NewPrimitiveString("")), "pmak_in_query", 0),
-					"k5p4y9tXMAk=": newTestAuthSpec(dataFromPrimitive(spec_util.NewPrimitiveString("")), 0),
+					"xwb2G1yYVVc=": newTestHeaderSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), "pmak_in_header", 0),
+					"9NijbeQiJAg=": newTestQueryParamSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), "sso_jwt_key", 0),
+					"b5t-IaNo7Ug=": newTestQueryParamSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), "pmak_in_query", 0),
+					"k5p4y9tXMAk=": newTestAuthSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), 0),
 					"bxitt4RTL5k=": newTestBodySpecFromStruct(0, pb.HTTPBody_JSON, "application/json", map[string]*pb.Data{
 						"name":       dataFromPrimitive(spec_util.NewPrimitiveString("error")),
 						"number":     dataFromPrimitive(spec_util.NewPrimitiveInt64(202410081550)),
-						"pmakInBody": dataFromPrimitive(spec_util.NewPrimitiveString("")),
+						"pmakInBody": dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")),
 					}),
 				},
 				Responses: map[string]*pb.Data{
-					"hAjVb_ouhwQ=": newTestCookieSpec(dataFromPrimitive(spec_util.NewPrimitiveString("")), "Random-Cookie", 404),
-					"rZob7SB3qd0=": newTestHeaderSpec(dataFromPrimitive(spec_util.NewPrimitiveString("")), "postman_sid", 404),
+					"hAjVb_ouhwQ=": newTestCookieSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), "Random-Cookie", 404),
+					"rZob7SB3qd0=": newTestHeaderSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), "postman_sid", 404),
 					"cBn6EHKhiAA=": newTestBodySpecFromStruct(404, pb.HTTPBody_JSON, "application/json", map[string]*pb.Data{
 						"homes": dataFromList(
 							dataFromPrimitive(spec_util.NewPrimitiveString("error")),
 							dataFromPrimitive(spec_util.NewPrimitiveString("happened")),
 							dataFromPrimitive(spec_util.NewPrimitiveString("here")),
 						),
-						"pmakInResponseBody": dataFromPrimitive(spec_util.NewPrimitiveString("")),
+						"pmakInResponseBody": dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")),
 					}),
 				},
 				Meta: &pb.MethodMeta{

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -590,13 +590,13 @@ func TestObfuscationConfigs(t *testing.T) {
 			},
 		},
 		{
-			name: "sensitive data in header, query param and cookie",
+			name: "sensitive data in header, query param, cookie and URL path",
 			request: akinet.HTTPRequest{
 				StreamID: streamID,
 				Seq:      1204,
 				Method:   "POST",
 				URL: &url.URL{
-					Path:     "/v1/doggos",
+					Path:     "/v1/doggos/PMAK-6717875c69335700017b1c46/api-key/PMAK-6717875c69335700017b1c46",
 					RawQuery: "sso_jwt_key=XX__X_X_X_X&pmak_in_query=PMAK-6717875c69335700017b1c46",
 				},
 				Host: "example.com",
@@ -678,7 +678,7 @@ func TestObfuscationConfigs(t *testing.T) {
 						Meta: &pb.MethodMeta_Http{
 							Http: &pb.HTTPMethodMeta{
 								Method:       "POST",
-								PathTemplate: "/v1/doggos",
+								PathTemplate: "/v1/doggos/REDACTED/api-key/REDACTED",
 								Host:         "example.com",
 								Obfuscation:  pb.HTTPMethodMeta_NONE,
 							},

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -531,7 +531,12 @@ func TestObfuscationConfigs(t *testing.T) {
 				"x-access-token": {"XX__X_X_X_X"},
 				"pmak_in_header": {"PMAK-6717875c69335700017b1c46"},
 			},
-			Body: memview.New([]byte(`{"name": "error", "number": 202410081550, "pmakInBody": "PMAK-6717875c69335700017b1c46"}`)),
+			Body: memview.New([]byte(`{
+				"name": "error",
+				"number": 202410081550,
+				"pmakInBody": "PMAK-6717875c69335700017b1c46",
+				"api_key": "XX__X_X_X_X"
+			}`)),
 		},
 	}
 
@@ -550,7 +555,21 @@ func TestObfuscationConfigs(t *testing.T) {
 					Value: "Random-Cookie-Value",
 				},
 			},
-			Body: memview.New([]byte(`{"homes": ["error", "happened", "here"], "pmakInResponseBody": "PMAK-6717875c69335700017b1c46"}`)),
+			Body: memview.New([]byte(`{
+				"homes": ["error", "happened", "here"],
+				"structList": [
+					{
+						"encryption_key": "XX__X_X_X_1",
+						"index": 0
+					},
+					{
+						"encryption_key": "XX__X_X_X_2",
+						"index": 1
+					}
+				],
+				"pmakInResponseBody": "PMAK-6717875c69335700017b1c46",
+				"encryption_key": [1,2,3,4,5]
+			}`)),
 		},
 	}
 
@@ -572,22 +591,36 @@ func TestObfuscationConfigs(t *testing.T) {
 					"9NijbeQiJAg=": newTestQueryParamSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), "sso_jwt_key", 0),
 					"b5t-IaNo7Ug=": newTestQueryParamSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), "pmak_in_query", 0),
 					"k5p4y9tXMAk=": newTestAuthSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), 0),
-					"bxitt4RTL5k=": newTestBodySpecFromStruct(0, pb.HTTPBody_JSON, "application/json", map[string]*pb.Data{
+					"Ee95MCpMH0c=": newTestBodySpecFromStruct(0, pb.HTTPBody_JSON, "application/json", map[string]*pb.Data{
 						"name":       dataFromPrimitive(spec_util.NewPrimitiveString("error")),
 						"number":     dataFromPrimitive(spec_util.NewPrimitiveInt64(202410081550)),
 						"pmakInBody": dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")),
+						"api_key":    dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")),
 					}),
 				},
 				Responses: map[string]*pb.Data{
 					"hAjVb_ouhwQ=": newTestCookieSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), "Random-Cookie", 404),
 					"rZob7SB3qd0=": newTestHeaderSpec(dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")), "postman_sid", 404),
-					"cBn6EHKhiAA=": newTestBodySpecFromStruct(404, pb.HTTPBody_JSON, "application/json", map[string]*pb.Data{
+					"PeIWlWWGoSE=": newTestBodySpecFromStruct(404, pb.HTTPBody_JSON, "application/json", map[string]*pb.Data{
 						"homes": dataFromList(
 							dataFromPrimitive(spec_util.NewPrimitiveString("error")),
 							dataFromPrimitive(spec_util.NewPrimitiveString("happened")),
 							dataFromPrimitive(spec_util.NewPrimitiveString("here")),
 						),
+						"structList": dataFromList(
+							dataFromStruct(map[string]*pb.Data{
+								"encryption_key": dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")),
+								"index":          dataFromPrimitive(spec_util.NewPrimitiveInt64(0)),
+							}),
+							dataFromStruct(map[string]*pb.Data{
+								"encryption_key": dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")),
+								"index":          dataFromPrimitive(spec_util.NewPrimitiveInt64(1)),
+							}),
+						),
 						"pmakInResponseBody": dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")),
+						"encryption_key": dataFromList(
+							dataFromPrimitive(spec_util.NewPrimitiveString("REDACTED")),
+						),
 					}),
 				},
 				Meta: &pb.MethodMeta{

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -1,6 +1,8 @@
 package trace
 
 import (
+	"regexp"
+
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 	"github.com/akitasoftware/akita-libs/spec_util"
 	. "github.com/akitasoftware/akita-libs/visitors"
@@ -8,12 +10,51 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/printer"
 )
 
-func obfuscate(m *pb.Method) {
-	var ov obfuscationVisitor
-	vis.Apply(&ov, m)
+type Obfuscator struct {
+	SensitiveDataKeys          []string
+	SensitiveDataValuePatterns []*regexp.Regexp
+}
 
-	// Mark the method as obfuscated.
-	m.GetMeta().GetHttp().Obfuscation = pb.HTTPMethodMeta_ZERO_VALUE
+func NewObfuscator() *Obfuscator {
+	config, err := configFromFile("obfuscation_config.yaml")
+	if err != nil {
+		printer.Errorf("failed to load obfuscation config: %v\n", err)
+		return nil
+	}
+
+	sensitiveDataRegex := make([]*regexp.Regexp, len(config.SensitiveValueRegexes))
+
+	// Compile regex patterns.
+	for i, pattern := range config.SensitiveValueRegexes {
+		regex, err := regexp.Compile(pattern)
+		if err != nil {
+			printer.Errorf("failed to compile regex pattern %s: %v\n", pattern, err)
+			return nil
+		}
+		sensitiveDataRegex[i] = regex
+	}
+
+	return &Obfuscator{
+		SensitiveDataKeys:          config.SensitiveKeys,
+		SensitiveDataValuePatterns: sensitiveDataRegex,
+	}
+}
+
+func (o *Obfuscator) obfuscate(m *pb.Method, obfuscateWholePayload bool) {
+	if obfuscateWholePayload {
+		var ov obfuscationVisitor
+		vis.Apply(&ov, m)
+
+		// Mark the method as obfuscated.
+		m.GetMeta().GetHttp().Obfuscation = pb.HTTPMethodMeta_ZERO_VALUE
+		return
+	}
+
+	pov := partialObfuscationVisitor{
+		obfuscationOptions: o,
+	}
+	vis.Apply(&pov, m)
+	return
 }
 
 type obfuscationVisitor struct {
@@ -23,6 +64,65 @@ type obfuscationVisitor struct {
 var _ vis.DefaultSpecVisitor = (*obfuscationVisitor)(nil)
 
 func (*obfuscationVisitor) EnterData(self interface{}, ctx vis.SpecVisitorContext, d *pb.Data) Cont {
+	return ObfuscateWithZeroValue(d)
+}
+
+type partialObfuscationVisitor struct {
+	vis.DefaultSpecVisitorImpl
+	obfuscationOptions *Obfuscator
+}
+
+var _ vis.DefaultSpecVisitor = (*partialObfuscationVisitor)(nil)
+
+func (pov *partialObfuscationVisitor) EnterData(self interface{}, ctx vis.SpecVisitorContext, d *pb.Data) Cont {
+	authorization := spec_util.HTTPAuthFromData(d)
+	if authorization != nil {
+		return ObfuscateWithZeroValue(d)
+	}
+
+	var key string
+
+	header := spec_util.HTTPHeaderFromData(d)
+	if header != nil {
+		key = header.Key
+	}
+	queryParam := spec_util.HTTPQueryFromData(d)
+	if queryParam != nil {
+		key = queryParam.Key
+	}
+	pathParam := spec_util.HTTPPathFromData(d)
+	if pathParam != nil {
+		key = pathParam.Key
+	}
+
+	// Check if the key is in the list of keys to obfuscate.
+	for _, k := range pov.obfuscationOptions.SensitiveDataKeys {
+		if k == key {
+			return ObfuscateWithZeroValue(d)
+		}
+	}
+
+	dp, isPrimitive := d.GetValue().(*pb.Data_Primitive)
+	if !isPrimitive {
+		return Continue
+	}
+
+	stringValue := dp.Primitive.GetStringValue()
+	if stringValue == nil {
+		// Not a string, regex will be applied to string values only.
+		return Continue
+	}
+
+	for _, pattern := range pov.obfuscationOptions.SensitiveDataValuePatterns {
+		if pattern.MatchString(stringValue.Value) {
+			return ObfuscateWithZeroValue(d)
+		}
+	}
+
+	return Continue
+}
+
+func ObfuscateWithZeroValue(d *pb.Data) Cont {
 	dp, isPrimitive := d.GetValue().(*pb.Data_Primitive)
 	if !isPrimitive {
 		return Continue

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -16,6 +16,7 @@ type Obfuscator struct {
 }
 
 func NewObfuscator() *Obfuscator {
+	// Load obfuscation config using relative path to load the config file.
 	config, err := configFromFile("obfuscation_config.yaml")
 	if err != nil {
 		printer.Errorf("failed to load obfuscation config: %v\n", err)
@@ -63,6 +64,7 @@ type obfuscationVisitor struct {
 
 var _ vis.DefaultSpecVisitor = (*obfuscationVisitor)(nil)
 
+// EnterData processes the given data and obfuscates all the primitive values with zero values, regardless of it's meta data.
 func (*obfuscationVisitor) EnterData(self interface{}, ctx vis.SpecVisitorContext, d *pb.Data) Cont {
 	return ObfuscateWithZeroValue(d)
 }
@@ -74,41 +76,42 @@ type partialObfuscationVisitor struct {
 
 var _ vis.DefaultSpecVisitor = (*partialObfuscationVisitor)(nil)
 
+// EnterData processes the given data and obfuscates sensitive information based on the provided obfuscation options.
+// It does 3 checks to determine if the data contains sensitive information:
+// 1. It checks if spec is an HTTP Authroization or Cookie data and obfuscates the value.
+// 2. It cheks if spec is an HTTP Header or Query Param data and obfuscates the value if the key is in the list of sensitive keys.
+// 3. It applies regex patterns to all obfuscate sensitive primitive string values.
 func (pov *partialObfuscationVisitor) EnterData(self interface{}, ctx vis.SpecVisitorContext, d *pb.Data) Cont {
-	authorization := spec_util.HTTPAuthFromData(d)
-	if authorization != nil {
-		return ObfuscateWithZeroValue(d)
-	}
-
-	cookie := spec_util.HTTPCookieFromData(d)
-	if cookie != nil {
-		return ObfuscateWithZeroValue(d)
-	}
-
-	var key string
-
-	header := spec_util.HTTPHeaderFromData(d)
-	if header != nil {
-		key = header.Key
-	}
-	queryParam := spec_util.HTTPQueryFromData(d)
-	if queryParam != nil {
-		key = queryParam.Key
-	}
-
-	// Check if the key is in the list of keys to obfuscate.
-	for _, k := range pov.obfuscationOptions.SensitiveDataKeys {
-		if k == key {
+	dataMeta, ok := d.GetMeta().GetMeta().(*pb.DataMeta_Http)
+	if ok {
+		var key string
+		switch dataMeta.Http.Location.(type) {
+		case *pb.HTTPMeta_Auth:
 			return ObfuscateWithZeroValue(d)
+		case *pb.HTTPMeta_Cookie:
+			return ObfuscateWithZeroValue(d)
+		case *pb.HTTPMeta_Header:
+			header := dataMeta.Http.GetHeader()
+			key = header.Key
+		case *pb.HTTPMeta_Query:
+			queryParam := dataMeta.Http.GetQuery()
+			key = queryParam.Key
+		}
+		// Check if the key is in the list of keys to obfuscate.
+		for _, k := range pov.obfuscationOptions.SensitiveDataKeys {
+			if k == key {
+				return ObfuscateWithZeroValue(d)
+			}
 		}
 	}
 
-	dp, isPrimitive := d.GetValue().(*pb.Data_Primitive)
-	if !isPrimitive {
+	primitive := d.GetPrimitive()
+	if primitive == nil {
+		// Not a primitive, regex will be applied to primitive string values only.
 		return Continue
 	}
 
-	stringValue := dp.Primitive.GetStringValue()
+	stringValue := primitive.GetStringValue()
 	if stringValue == nil {
 		// Not a string, regex will be applied to string values only.
 		return Continue

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -160,6 +160,23 @@ func (s *redactSensitiveInfoVisitor) EnterHTTPMultipart(self interface{}, ctx vi
 	return Continue
 }
 
+func (s *redactSensitiveInfoVisitor) EnterHTTPMethodMeta(self interface{}, ctx vis.SpecVisitorContext, meta *pb.HTTPMethodMeta) Cont {
+	pathSegments := strings.Split(meta.PathTemplate, "/")
+
+	for i, segment := range pathSegments {
+		// Check if the path segment contains sensitive information.
+		for _, pattern := range s.obfuscationOptions.SensitiveDataValuePatterns {
+			if pattern.MatchString(segment) {
+				pathSegments[i] = "REDACTED"
+				break
+			}
+		}
+	}
+
+	meta.PathTemplate = strings.Join(pathSegments, "/")
+	return Continue
+}
+
 // Traverses the protobuf data and redacts sensitive information based on the sensitive keys.
 // The function has 2 parameters:
 //  1. data: The current node in the recursive tree traversal of the protobuf data.

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -177,6 +177,10 @@ func (s *redactSensitiveInfoVisitor) traverseAndRedactSensitiveInfo(data *pb.Dat
 				s.traverseAndRedactSensitiveInfo(itemData, redactData)
 			}
 		}
+	default:
+		// Unknown data type, mark as REDACTED string.
+		printer.Errorf("Unknown data type (OneOf or Optional) found, marking as REDACTED string\n")
+		ObfuscatePrimitiveWithRedactedString(data)
 	}
 }
 
@@ -188,8 +192,8 @@ func ObfuscatePrimitiveWithRedactedString(d *pb.Data) Cont {
 	if dp := d.GetPrimitive(); dp != nil {
 		dp.Value = redactedPrimitiveString.Value
 	} else {
-		// Unknown data type captured, though this should not happen.
-		// Mark the data as REDACTED string.
+		// Unknown data type captured, though this should not happen,except in case of OneOf and Optionals which should also not be present.
+		// Mark the data as REDACTED  string.
 		printer.Debugf("Unknown data type found, marking as REDACTED string\n")
 		d.Value = &pb.Data_Primitive{Primitive: redactedPrimitiveString}
 	}

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -1,6 +1,7 @@
 package trace
 
 import (
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -53,7 +54,7 @@ func (o *Obfuscator) Obfuscate(m *pb.Method, obfuscateWholePayload bool) {
 		return
 	}
 
-	pov := partialObfuscationVisitor{
+	pov := redactSensitiveInfoVisitor{
 		obfuscationOptions: o,
 	}
 	vis.Apply(&pov, m)
@@ -84,26 +85,26 @@ func (*obfuscationVisitor) EnterData(self interface{}, ctx vis.SpecVisitorContex
 	return Continue
 }
 
-type partialObfuscationVisitor struct {
+type redactSensitiveInfoVisitor struct {
 	vis.DefaultSpecVisitorImpl
 	obfuscationOptions *Obfuscator
 }
 
-var _ vis.DefaultSpecVisitor = (*partialObfuscationVisitor)(nil)
+var _ vis.DefaultSpecVisitor = (*redactSensitiveInfoVisitor)(nil)
 
 // EnterData processes the given data and obfuscates sensitive information based on the provided obfuscation options.
 // It does 3 checks to determine if the data contains sensitive information:
 // 1. It checks if spec is an HTTP Authroization or Cookie data and obfuscates the value.
 // 2. It cheks if spec is an HTTP Header or Query Param data and obfuscates the value if the key is in the list of sensitive keys.
 // 3. It applies regex patterns to all obfuscate sensitive primitive string values.
-func (pov *partialObfuscationVisitor) EnterData(self interface{}, ctx vis.SpecVisitorContext, d *pb.Data) Cont {
+func (s *redactSensitiveInfoVisitor) EnterData(self interface{}, ctx vis.SpecVisitorContext, d *pb.Data) Cont {
 	if httpMeta := d.GetMeta().GetHttp(); httpMeta != nil {
 		var key string
 		switch httpMeta.Location.(type) {
 		case *pb.HTTPMeta_Auth:
-			return ObfuscateWithRedactedString(d)
+			return ObfuscatePrimitiveWithRedactedString(d)
 		case *pb.HTTPMeta_Cookie:
-			return ObfuscateWithRedactedString(d)
+			return ObfuscatePrimitiveWithRedactedString(d)
 		case *pb.HTTPMeta_Header:
 			header := httpMeta.GetHeader()
 			key = header.Key
@@ -112,8 +113,8 @@ func (pov *partialObfuscationVisitor) EnterData(self interface{}, ctx vis.SpecVi
 			key = queryParam.Key
 		}
 		// Check if the key is in the list of keys to obfuscate.
-		if pov.obfuscationOptions.SensitiveDataKeys.Contains(strings.ToLower(key)) {
-			return ObfuscateWithRedactedString(d)
+		if s.obfuscationOptions.SensitiveDataKeys.Contains(strings.ToLower(key)) {
+			return ObfuscatePrimitiveWithRedactedString(d)
 		}
 	}
 
@@ -129,21 +130,76 @@ func (pov *partialObfuscationVisitor) EnterData(self interface{}, ctx vis.SpecVi
 		return Continue
 	}
 
-	for pattern, _ := range pov.obfuscationOptions.SensitiveDataValuePatterns {
+	for pattern, _ := range s.obfuscationOptions.SensitiveDataValuePatterns {
 		if pattern.MatchString(stringValue.Value) {
-			return ObfuscateWithRedactedString(d)
+			return ObfuscatePrimitiveWithRedactedString(d)
 		}
 	}
 
 	return Continue
 }
 
-func ObfuscateWithRedactedString(d *pb.Data) Cont {
-	dp := d.GetPrimitive()
-	if dp == nil {
+func (s *redactSensitiveInfoVisitor) EnterHTTPBody(self interface{}, ctx vis.SpecVisitorContext, b *pb.HTTPBody) Cont {
+	node, _ := ctx.GetInnermostNode(reflect.TypeOf((*pb.Data)(nil)))
+	data := node.(*pb.Data)
+	if data == nil {
 		return Continue
 	}
 
-	dp.Value = spec_util.NewPrimitiveString("REDACTED").Value
+	// Traverse the data node and redact sensitive information.
+	s.traverseAndRedactSensitiveInfo(ctx, data)
+
+	return Continue
+}
+
+func (s *redactSensitiveInfoVisitor) traverseAndRedactSensitiveInfo(ctx vis.SpecVisitorContext, data *pb.Data) {
+	switch val := data.Value.(type) {
+	case *pb.Data_Struct:
+		// Traverse the struct's fields and redact sensitive information based on key.
+		structData := val.Struct
+		for fieldName, fieldData := range structData.GetFields() {
+			// If field Data is primitive or primitiveList, then check it's key and redact if needed
+			if spec_util.IsPrimitive(fieldData) || spec_util.IsPrimitiveList(fieldData) {
+				if s.obfuscationOptions.SensitiveDataKeys.Contains(strings.ToLower(fieldName)) {
+					ObfuscatePrimitiveWithRedactedString(fieldData)
+				}
+			} else {
+				// Recursively traverse the struct's fields.
+				childCtx := ctx.EnterStruct(structData, fieldName).(vis.SpecVisitorContext)
+				s.traverseAndRedactSensitiveInfo(childCtx, fieldData)
+			}
+		}
+	case *pb.Data_List:
+		listData := val.List
+		if items := listData.GetElems(); items != nil {
+			for i, itemData := range items {
+				// Step through each item in the list and traverse the data node.
+				// This list will never be primitive list, as primitive list is handled above.
+				childCtx := ctx.EnterArray(listData, i).(vis.SpecVisitorContext)
+				s.traverseAndRedactSensitiveInfo(childCtx, itemData)
+			}
+		}
+	}
+}
+
+// Obfuscate the given primitive data with REDACTED string.
+// In case of a primitive value repalce with REDACTED string and in case of a primitive list replace
+// with a new list having single element, i.e., REDACTED string, to maintain the list structure.
+func ObfuscatePrimitiveWithRedactedString(d *pb.Data) Cont {
+	if spec_util.IsPrimitive(d) {
+		dv := d.GetPrimitive()
+		dv.Value = spec_util.NewPrimitiveString("REDACTED").Value
+	}
+
+	if spec_util.IsPrimitiveList(d) {
+		dl := d.GetList()
+		dl.Elems = make([]*pb.Data, 0)
+		dl.Elems = append(dl.Elems, &pb.Data{
+			Value: &pb.Data_Primitive{
+				Primitive: spec_util.NewPrimitiveString("REDACTED"),
+			},
+		})
+	}
+
 	return Continue
 }

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -80,6 +80,11 @@ func (pov *partialObfuscationVisitor) EnterData(self interface{}, ctx vis.SpecVi
 		return ObfuscateWithZeroValue(d)
 	}
 
+	cookie := spec_util.HTTPCookieFromData(d)
+	if cookie != nil {
+		return ObfuscateWithZeroValue(d)
+	}
+
 	var key string
 
 	header := spec_util.HTTPHeaderFromData(d)
@@ -89,10 +94,6 @@ func (pov *partialObfuscationVisitor) EnterData(self interface{}, ctx vis.SpecVi
 	queryParam := spec_util.HTTPQueryFromData(d)
 	if queryParam != nil {
 		key = queryParam.Key
-	}
-	pathParam := spec_util.HTTPPathFromData(d)
-	if pathParam != nil {
-		key = pathParam.Key
 	}
 
 	// Check if the key is in the list of keys to obfuscate.

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -15,12 +15,12 @@ import (
 
 type Obfuscator struct {
 	SensitiveDataKeys          sets.Set[string]
-	SensitiveDataValuePatterns sets.Set[*regexp.Regexp]
+	SensitiveDataValuePatterns []*regexp.Regexp
 }
 
 func NewObfuscator() *Obfuscator {
 	// Load obfuscation config using relative path to load the config file.
-	config, err := configFromFile("obfuscation_config.yaml")
+	config, err := loadConfigFromFile()
 	if err != nil {
 		printer.Errorf("failed to load obfuscation config: %v\n", err)
 		return nil
@@ -30,21 +30,17 @@ func NewObfuscator() *Obfuscator {
 
 	// Compile regex patterns.
 	for i, pattern := range config.SensitiveValueRegexes {
-		regex, err := regexp.Compile(pattern)
-		if err != nil {
-			printer.Errorf("failed to compile regex pattern %s: %v\n", pattern, err)
-			return nil
-		}
-		sensitiveDataRegex[i] = regex
+		// Panic if any pattern in invalid. Since the list is not user driven and is part of the agent, this is acceptable.
+		sensitiveDataRegex[i] = regexp.MustCompile(pattern)
 	}
 
 	return &Obfuscator{
 		SensitiveDataKeys:          sets.NewSet(config.SensitiveKeys...),
-		SensitiveDataValuePatterns: sets.NewSet(sensitiveDataRegex...),
+		SensitiveDataValuePatterns: sensitiveDataRegex,
 	}
 }
 
-func (o *Obfuscator) ObfuscateData(m *pb.Method) {
+func (o *Obfuscator) ObfuscateDataWithZeroValue(m *pb.Method) {
 	var ov obfuscationVisitor
 	vis.Apply(&ov, m)
 
@@ -53,10 +49,14 @@ func (o *Obfuscator) ObfuscateData(m *pb.Method) {
 	return
 }
 
+type obfuscationVisitor struct {
+	vis.DefaultSpecVisitorImpl
+}
+
 var _ vis.DefaultSpecVisitor = (*obfuscationVisitor)(nil)
 
 // EnterData processes the given data and obfuscates all the primitive values with zero values, regardless of it's meta data.
-func (*obfuscationVisitor) EnterData(self interface{}, ctx vis.SpecVisitorContext, d *pb.Data) Cont {
+func (*obfuscationVisitor) EnterData(self interface{}, _ vis.SpecVisitorContext, d *pb.Data) Cont {
 	dp := d.GetPrimitive()
 	if dp == nil {
 		return Continue
@@ -80,10 +80,6 @@ func (o *Obfuscator) RedactData(m *pb.Method) {
 	vis.Apply(&pov, m)
 }
 
-type obfuscationVisitor struct {
-	vis.DefaultSpecVisitorImpl
-}
-
 type redactSensitiveInfoVisitor struct {
 	vis.DefaultSpecVisitorImpl
 	obfuscationOptions *Obfuscator
@@ -93,10 +89,10 @@ var _ vis.DefaultSpecVisitor = (*redactSensitiveInfoVisitor)(nil)
 
 // EnterData processes the given data and obfuscates sensitive information based on the provided obfuscation options.
 // It does 3 checks to determine if the data contains sensitive information:
-// 1. It checks if spec is an HTTP Authroization or Cookie data and obfuscates the value.
-// 2. It cheks if spec is an HTTP Header or Query Param data and obfuscates the value if the key is in the list of sensitive keys.
+// 1. It checks if spec is an HTTP Authorization or Cookie data and obfuscates the value.
+// 2. It checks if spec is an HTTP Header or Query Param data and obfuscates the value if the key is in the list of sensitive keys.
 // 3. It applies regex patterns to all obfuscate sensitive primitive string values.
-func (s *redactSensitiveInfoVisitor) EnterData(self interface{}, ctx vis.SpecVisitorContext, d *pb.Data) Cont {
+func (s *redactSensitiveInfoVisitor) EnterData(self interface{}, _ vis.SpecVisitorContext, d *pb.Data) Cont {
 	if httpMeta := d.GetMeta().GetHttp(); httpMeta != nil {
 		var key string
 		switch httpMeta.Location.(type) {
@@ -129,7 +125,7 @@ func (s *redactSensitiveInfoVisitor) EnterData(self interface{}, ctx vis.SpecVis
 		return Continue
 	}
 
-	for pattern, _ := range s.obfuscationOptions.SensitiveDataValuePatterns {
+	for _, pattern := range s.obfuscationOptions.SensitiveDataValuePatterns {
 		if pattern.MatchString(stringValue.Value) {
 			return ObfuscatePrimitiveWithRedactedString(d)
 		}
@@ -146,58 +142,56 @@ func (s *redactSensitiveInfoVisitor) EnterHTTPBody(self interface{}, ctx vis.Spe
 	}
 
 	// Traverse the data node and redact sensitive information.
-	s.traverseAndRedactSensitiveInfo(ctx, data)
+	s.traverseAndRedactSensitiveInfo(data, false)
 
 	return Continue
 }
 
-func (s *redactSensitiveInfoVisitor) traverseAndRedactSensitiveInfo(ctx vis.SpecVisitorContext, data *pb.Data) {
+// Traverses the protobuf data and redacts sensitive information based on the sensitive keys.
+// The function has 2 parameters:
+//  1. data: The current node in the recursive tree traversal of the protobuf data.
+//  2. redactData: A boolean flag to indicate if the data should be redacted irrespective of it's key and value.
+//     This will be true when the parent node is a sensitive key.
+//
+// The function checks if the data fields are primitive and redacts them if their keys are sensitive.
+// For non-primitive fields, it recursively traverses it's child nodes with the redactData flag set to true if the parent node is sensitive.
+func (s *redactSensitiveInfoVisitor) traverseAndRedactSensitiveInfo(data *pb.Data, redactData bool) {
 	switch val := data.Value.(type) {
+	case *pb.Data_Primitive:
+		if redactData {
+			ObfuscatePrimitiveWithRedactedString(data)
+		}
 	case *pb.Data_Struct:
 		// Traverse the struct's fields and redact sensitive information based on key.
 		structData := val.Struct
 		for fieldName, fieldData := range structData.GetFields() {
-			// If field Data is primitive or primitiveList, then check it's key and redact if needed
-			if spec_util.IsPrimitive(fieldData) || spec_util.IsPrimitiveList(fieldData) {
-				if s.obfuscationOptions.SensitiveDataKeys.Contains(strings.ToLower(fieldName)) {
-					ObfuscatePrimitiveWithRedactedString(fieldData)
-				}
-			} else {
-				// Recursively traverse the struct's fields.
-				childCtx := ctx.EnterStruct(structData, fieldName).(vis.SpecVisitorContext)
-				s.traverseAndRedactSensitiveInfo(childCtx, fieldData)
-			}
+			// Check if the key is sensitive. If it is, redact the child data.
+			redactData := redactData || s.obfuscationOptions.SensitiveDataKeys.Contains(strings.ToLower(fieldName))
+			s.traverseAndRedactSensitiveInfo(fieldData, redactData)
 		}
 	case *pb.Data_List:
 		listData := val.List
 		if items := listData.GetElems(); items != nil {
-			for i, itemData := range items {
+			for _, itemData := range items {
 				// Step through each item in the list and traverse the data node.
-				// This list will never be primitive list, as primitive list is handled above.
-				childCtx := ctx.EnterArray(listData, i).(vis.SpecVisitorContext)
-				s.traverseAndRedactSensitiveInfo(childCtx, itemData)
+				s.traverseAndRedactSensitiveInfo(itemData, redactData)
 			}
 		}
 	}
 }
 
 // Obfuscate the given primitive data with REDACTED string.
-// In case of a primitive value repalce with REDACTED string and in case of a primitive list replace
-// with a new list having single element, i.e., REDACTED string, to maintain the list structure.
+// In case data is not primitive type, it will also be marked as REDACTED string.
 func ObfuscatePrimitiveWithRedactedString(d *pb.Data) Cont {
-	if spec_util.IsPrimitive(d) {
-		dv := d.GetPrimitive()
-		dv.Value = spec_util.NewPrimitiveString("REDACTED").Value
-	}
+	redactedPrimitiveString := spec_util.NewPrimitiveString("REDACTED")
 
-	if spec_util.IsPrimitiveList(d) {
-		dl := d.GetList()
-		dl.Elems = make([]*pb.Data, 0)
-		dl.Elems = append(dl.Elems, &pb.Data{
-			Value: &pb.Data_Primitive{
-				Primitive: spec_util.NewPrimitiveString("REDACTED"),
-			},
-		})
+	if dp := d.GetPrimitive(); dp != nil {
+		dp.Value = redactedPrimitiveString.Value
+	} else {
+		// Unknown data type captured, though this should not happen.
+		// Mark the data as REDACTED string.
+		printer.Debugf("Unknown data type found, marking as REDACTED string\n")
+		d.Value = &pb.Data_Primitive{Primitive: redactedPrimitiveString}
 	}
 
 	return Continue

--- a/trace/obfuscation_config.go
+++ b/trace/obfuscation_config.go
@@ -1,0 +1,45 @@
+package trace
+
+import (
+	"os"
+	"strings"
+
+	"github.com/akitasoftware/go-utils/sets"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+type obfuscationConfig struct {
+	SensitiveKeys         []string `yaml:"sensitive_keys"`
+	SensitiveValueRegexes []string `yaml:"sensitive_value_regexes"`
+}
+
+func (c *obfuscationConfig) sanitizeConfigData() bool {
+
+	// Convert all the keys to lower case and remove duplicates
+	keys := sets.NewSet[string]()
+	for _, key := range c.SensitiveKeys {
+		keys.Insert(strings.ToLower(key))
+	}
+	c.SensitiveKeys = keys.AsSlice()
+
+	return false
+}
+
+func configFromFile(n string) (*obfuscationConfig, error) {
+	f, err := os.Open(n)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open config file")
+	}
+	defer f.Close()
+
+	var c obfuscationConfig
+	dec := yaml.NewDecoder(f)
+	if err := dec.Decode(&c); err != nil {
+		return nil, errors.Wrap(err, "failed to parse YAML")
+	}
+
+	c.sanitizeConfigData()
+
+	return &c, nil
+}

--- a/trace/obfuscation_config.yaml
+++ b/trace/obfuscation_config.yaml
@@ -1,6 +1,4 @@
 sensitive_keys:
-  - authorization
-  - cookies
   - x-access-token
   - encryption_key
   - sso_jwt_key

--- a/trace/obfuscation_config.yaml
+++ b/trace/obfuscation_config.yaml
@@ -1,0 +1,11 @@
+sensitive_keys:
+  - authorization
+  - cookies
+  - x-access-token
+  - encryption_key
+  - sso_jwt_key
+  - postman_sid
+  - api_key
+
+sensitive_value_regexes:
+  - \bPMAK-[a-f0-9]{24}\b

--- a/trace/report_buffer.go
+++ b/trace/report_buffer.go
@@ -84,7 +84,7 @@ func (buf *reportBuffer) addWitness(w *witnessWithInfo) {
 			// The witness exceeds our per-witness storage limit. Obfuscate it to
 			// reduce its size while retaining its typing information.
 			printer.Debugf("Obfuscating oversized witness (%d MB) captured on interface %s\n", len(witnessReport.WitnessProto)/1_000_000, w.netInterface)
-			obfuscate(w.witness.GetMethod())
+			buf.collector.obfuscator.obfuscate(w.witness.GetMethod(), true)
 			witnessReport, err = w.toReport()
 			if err != nil {
 				printer.Warningf("Failed to convert obfuscated witness to report: %v\n", err)

--- a/trace/report_buffer.go
+++ b/trace/report_buffer.go
@@ -84,7 +84,7 @@ func (buf *reportBuffer) addWitness(w *witnessWithInfo) {
 			// The witness exceeds our per-witness storage limit. Obfuscate it to
 			// reduce its size while retaining its typing information.
 			printer.Debugf("Obfuscating oversized witness (%d MB) captured on interface %s\n", len(witnessReport.WitnessProto)/1_000_000, w.netInterface)
-			buf.collector.obfuscator.ObfuscateData(w.witness.GetMethod())
+			buf.collector.obfuscator.ObfuscateDataWithZeroValue(w.witness.GetMethod())
 			witnessReport, err = w.toReport()
 			if err != nil {
 				printer.Warningf("Failed to convert obfuscated witness to report: %v\n", err)

--- a/trace/report_buffer.go
+++ b/trace/report_buffer.go
@@ -84,7 +84,7 @@ func (buf *reportBuffer) addWitness(w *witnessWithInfo) {
 			// The witness exceeds our per-witness storage limit. Obfuscate it to
 			// reduce its size while retaining its typing information.
 			printer.Debugf("Obfuscating oversized witness (%d MB) captured on interface %s\n", len(witnessReport.WitnessProto)/1_000_000, w.netInterface)
-			buf.collector.obfuscator.Obfuscate(w.witness.GetMethod(), true)
+			buf.collector.obfuscator.ObfuscateData(w.witness.GetMethod())
 			witnessReport, err = w.toReport()
 			if err != nil {
 				printer.Warningf("Failed to convert obfuscated witness to report: %v\n", err)

--- a/trace/report_buffer.go
+++ b/trace/report_buffer.go
@@ -84,7 +84,7 @@ func (buf *reportBuffer) addWitness(w *witnessWithInfo) {
 			// The witness exceeds our per-witness storage limit. Obfuscate it to
 			// reduce its size while retaining its typing information.
 			printer.Debugf("Obfuscating oversized witness (%d MB) captured on interface %s\n", len(witnessReport.WitnessProto)/1_000_000, w.netInterface)
-			buf.collector.obfuscator.obfuscate(w.witness.GetMethod(), true)
+			buf.collector.obfuscator.Obfuscate(w.witness.GetMethod(), true)
 			witnessReport, err = w.toReport()
 			if err != nil {
 				printer.Warningf("Failed to convert obfuscated witness to report: %v\n", err)


### PR DESCRIPTION
* In this PR, we are adding support for scrubbing sensitive data as an option for `obfuscation` struct
* Added a new `obfuscation_config.go` and `obfusaction_config.yaml` which contains 2 configs:
  * `sensitive_keys`: Will be doing an exact match with the header, query_param
  * `sensitive_value_regexes`: Will be doing regex match with all the `primitive string` type values
  * Authorization and Cookies will be obfuscated always
  * We are using relative path for fetching config file