### PR TITLE
[POA-2064] Add resource request and limit to K8S sidecar

### DIFF
--- a/cmd/internal/kube/util.go
+++ b/cmd/internal/kube/util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // The image to use for the Postman Insights Agent sidecar
@@ -109,11 +110,24 @@ func createPostmanSidecar(insightsProjectID string, addAPIKeyAsSecret bool) v1.C
 		})
 	}
 
+	cpu := resource.MustParse("200m")
+	memory := resource.MustParse("500Mi")
+
 	sidecar := v1.Container{
 		Name:  "postman-insights-agent",
 		Image: akitaImage,
 		Env:   envs,
 		Args:  args,
+		Resources: v1.ResourceRequirements{
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    cpu,
+				v1.ResourceMemory: memory,
+			},
+			Requests: v1.ResourceList{
+				v1.ResourceCPU:    cpu,
+				v1.ResourceMemory: memory,
+			},
+		},
 		SecurityContext: &v1.SecurityContext{
 			Capabilities: &v1.Capabilities{Add: []v1.Capability{"NET_RAW"}},
 		},


### PR DESCRIPTION
Adds CPU and memory limits to the injected Kubernetes sidecar.

Tested with a sample deployment file, container looks like:

```
      - args:
        - apidump
        - --project
        - svc_0oC1bEWcE2h615Ri01Pp9w
        env:
        - name: POSTMAN_API_KEY
          valueFrom:
            secretKeyRef:
              key: postman-api-key
              name: postman-agent-secrets
        - name: POSTMAN_ENV
          value: BETA
        image: public.ecr.aws/postman/postman-insights-agent:latest
        name: postman-insights-agent
        resources:
          limits:
            cpu: 200m
            memory: 500Mi
          requests:
            cpu: 200m
            memory: 500Mi
        securityContext:
          capabilities:
            add:
            - NET_RAW
```