### PR TITLE
[POA-1907] Update permissions of ec2 systemd files

### DIFF
--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -216,7 +216,8 @@ func configureSystemdFiles(projectID string) error {
 		envFiledata.PostmanEnv = env
 	}
 
-	err = util.GenerateAndWriteTemplateFile(envFileFS, envFileTemplateName, envFileBasePath, envFileName, envFiledata)
+	// Generate and write the env file, with permissions 0600 (read/write for owner only)
+	err = util.GenerateAndWriteTemplateFile(envFileFS, envFileTemplateName, envFileBasePath, envFileName, 0600, envFiledata)
 	if err != nil {
 		return err
 	}
@@ -233,7 +234,8 @@ func configureSystemdFiles(projectID string) error {
 		AgentInstallPath: agentInstallPath,
 	}
 
-	err = util.GenerateAndWriteTemplateFile(serviceFileFS, serviceFileTemplateName, serviceFileBasePath, serviceFileName, serviceFileData)
+	// Generate and write the service file, with permissions 0600 (read/write for owner only)
+	err = util.GenerateAndWriteTemplateFile(serviceFileFS, serviceFileTemplateName, serviceFileBasePath, serviceFileName, 0600, serviceFileData)
 	if err != nil {
 		return err
 	}

--- a/util/templateUtils.go
+++ b/util/templateUtils.go
@@ -14,6 +14,7 @@ func GenerateAndWriteTemplateFile(
 	templateName string,
 	fileDirectory string,
 	fileName string,
+	filePermissions os.FileMode,
 	data interface{},
 ) error {
 	// Parse the template file
@@ -29,10 +30,10 @@ func GenerateAndWriteTemplateFile(
 		return errors.Wrapf(err, "Failed to create %s directory\n", fileDirectory)
 	}
 
-	// Create the file
-	file, err := os.Create(fileDirectory + fileName)
+	// Create the file with the given permissions
+	file, err := os.OpenFile(fileDirectory+fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, filePermissions)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to create %s file in %s directory\n", fileName, fileDirectory)
+		return errors.Wrapf(err, "Failed to create %s file in %s directory with permissions %d\n", fileName, fileDirectory, filePermissions)
 	}
 
 	// Write the data to the file
@@ -41,12 +42,5 @@ func GenerateAndWriteTemplateFile(
 		return errors.Wrapf(err, "Failed to write values to %s file\n", fileName)
 	}
 
-	// Change file permissions to 600.
-	// This is to ensure that the file is only readable and writable by the owner.
-	// As it might contain some sensitive information.
-	err = os.Chmod(fileDirectory+fileName, 0600)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to change %s file permissions\n", fileName)
-	}
 	return nil
 }

--- a/util/templateUtils.go
+++ b/util/templateUtils.go
@@ -35,6 +35,7 @@ func GenerateAndWriteTemplateFile(
 	if err != nil {
 		return errors.Wrapf(err, "Failed to create %s file in %s directory with permissions %d\n", fileName, fileDirectory, filePermissions)
 	}
+	defer file.Close()
 
 	// Write the data to the file
 	err = tmpl.Execute(file, data)

--- a/util/templateUtils.go
+++ b/util/templateUtils.go
@@ -40,5 +40,13 @@ func GenerateAndWriteTemplateFile(
 	if err != nil {
 		return errors.Wrapf(err, "Failed to write values to %s file\n", fileName)
 	}
+
+	// Change file permissions to 600.
+	// This is to ensure that the file is only readable and writable by the owner.
+	// As it might contain some sensitive information.
+	err = os.Chmod(fileDirectory+fileName, 0600)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to change %s file permissions\n", fileName)
+	}
 	return nil
 }


### PR DESCRIPTION
* Added a new step in the file creation process to change the permission of files to 600, i.e., the file is only readable and writable to owners
* This is to avoid exposure of sensitive data to other users.
* Added the step in `templateUtils.go` instead of making it EC2-specific.