### PR TITLE
[POA-1908][POA-1912] Add warning message for experimental flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,6 +95,8 @@ func preRun(cmd *cobra.Command, args []string) {
 	telemetry.CommandLine(cmd.Name(), os.Args)
 
 	startProfiling(cmd, args)
+
+	printFlagsWarning()
 }
 
 func startProfiling(cmd *cobra.Command, args []string) {
@@ -138,6 +140,22 @@ func stopProfiling(cmd *cobra.Command, args []string) {
 	if cpuProfileOut != nil {
 		pprof.StopCPUProfile()
 		cpuProfileOut.Close()
+	}
+}
+
+func printFlagsWarning() {
+	testingFlags := make(map[string]string)
+
+	if testOnlyUseHTTPSFlag {
+		testingFlags["test_only_disable_https"] = "This is only for debugging and testing in local environment."
+	}
+
+	if liveProfileAddress != "" {
+		testingFlags["live-profile"] = "The profiler server can run on an unsecured HTTP port without authentication, which could expose sensitive process information to unauthorized users."
+	}
+
+	if len(testingFlags) > 0 {
+		util.PrintFlagsWarning(testingFlags)
 	}
 }
 

--- a/util/printWarningMsg.go
+++ b/util/printWarningMsg.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/postmanlabs/postman-insights-agent/printer"
+)
+
+const warningMessage = `
+██     ██  █████  ██████  ███    ██ ██ ███    ██  ██████  
+██     ██ ██   ██ ██   ██ ████   ██ ██ ████   ██ ██       
+██  █  ██ ███████ ██████  ██ ██  ██ ██ ██ ██  ██ ██   ███ 
+██ ███ ██ ██   ██ ██   ██ ██  ██ ██ ██ ██  ██ ██ ██    ██ 
+ ███ ███  ██   ██ ██   ██ ██   ████ ██ ██   ████  ██████  
+                                                          
+ ______   ______   ______   ______   ______   ______ 
+/_____/  /_____/  /_____/  /_____/  /_____/  /_____/ 
+																										
+YOU ARE USING UNDOCUMENTED FLAGS ONLY FOR DEBUGGING AND
+TESTING. THESE FLAGS ARE NOT MEANT TO BY USED BY END USERS
+UNLESS THEY ARE DIRECTED TO DO SO BY POSTMAN SUPPORT!!!
+ ______   ______   ______   ______   ______   ______ 
+/_____/  /_____/  /_____/  /_____/  /_____/  /_____/ 
+																										
+See below for flags and their warning:`
+
+func PrintFlagsWarning(warningFlags map[string]string) {
+	// Print banner
+	printer.Warningf("%s\n", warningMessage)
+
+	// Print flags and their warnings
+	for flag, warning := range warningFlags {
+		fmt.Printf("Flag: %s\tWarning: %s\n", flag, warning)
+	}
+
+	// Print new line
+	fmt.Printf("\n")
+}


### PR DESCRIPTION
* Add a new `PrintFlagsWarning()` util function to print **BIG** warning message for experimental flags
* Used this function in `root.go` as a preRun task
* For now we have added only 2 flags.