### PR TITLE
POA-2294 Fix redaction for null values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4
-	github.com/akitasoftware/akita-libs v0.0.0-20241008174225-3b01e02d3430
+	github.com/akitasoftware/akita-libs v0.0.0-20241112234915-e21d522a70ed
 	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4
-	github.com/akitasoftware/akita-libs v0.0.0-20241112234915-e21d522a70ed
+	github.com/akitasoftware/akita-libs v0.0.0-20241113221948-cf2298b3c0fd
 	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tj
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4 h1:jbsA7E68G4dkK+ldQKQNPFIaRojFCn+cEB3gEEUSEU4=
 github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
-github.com/akitasoftware/akita-libs v0.0.0-20241112234915-e21d522a70ed h1:CJC018RVxs1oztfwpu50piG+U/6Vtk2OjaXGYYI5YBE=
-github.com/akitasoftware/akita-libs v0.0.0-20241112234915-e21d522a70ed/go.mod h1:5rzkpaJI1sA9CtGELYZpf15oczAVopcyda2WsYG5xno=
+github.com/akitasoftware/akita-libs v0.0.0-20241113221948-cf2298b3c0fd h1:ZzV9VguF9u915Alo9p5pWBe/m5R4Pfjq1l/y0Xncrm4=
+github.com/akitasoftware/akita-libs v0.0.0-20241113221948-cf2298b3c0fd/go.mod h1:5rzkpaJI1sA9CtGELYZpf15oczAVopcyda2WsYG5xno=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20240820200020-7289ae956f70 h1:VnU7QLDBwRujpQoHwShs5yu0Ahv1fSalNJa4UijwlmY=

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tj
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4 h1:jbsA7E68G4dkK+ldQKQNPFIaRojFCn+cEB3gEEUSEU4=
 github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
-github.com/akitasoftware/akita-libs v0.0.0-20241008174225-3b01e02d3430 h1:rmeFo57G8voBffbLNBGsqpBtmc7+awRHcWSSk7XdBd4=
-github.com/akitasoftware/akita-libs v0.0.0-20241008174225-3b01e02d3430/go.mod h1:5rzkpaJI1sA9CtGELYZpf15oczAVopcyda2WsYG5xno=
+github.com/akitasoftware/akita-libs v0.0.0-20241112234915-e21d522a70ed h1:CJC018RVxs1oztfwpu50piG+U/6Vtk2OjaXGYYI5YBE=
+github.com/akitasoftware/akita-libs v0.0.0-20241112234915-e21d522a70ed/go.mod h1:5rzkpaJI1sA9CtGELYZpf15oczAVopcyda2WsYG5xno=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20240820200020-7289ae956f70 h1:VnU7QLDBwRujpQoHwShs5yu0Ahv1fSalNJa4UijwlmY=

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -295,7 +295,7 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 	if !c.sendWitnessPayloads || !hasOnlyErrorResponses(w.witness.GetMethod()) {
 		// Obfuscate the original value so type inference engine can use it on the
 		// backend without revealing the actual value.
-		c.obfuscator.ObfuscateDataWithZeroValue(w.witness.GetMethod())
+		c.obfuscator.ZeroAllPrimitivesInMethod(w.witness.GetMethod())
 	} else {
 		c.obfuscator.RedactData(w.witness.GetMethod())
 	}

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -297,7 +297,7 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 		// backend without revealing the actual value.
 		c.obfuscator.ZeroAllPrimitivesInMethod(w.witness.GetMethod())
 	} else {
-		c.obfuscator.RedactData(w.witness.GetMethod())
+		c.obfuscator.RedactSensitiveData(w.witness.GetMethod())
 	}
 
 	c.uploadReportBatch.Add(rawReport{

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -519,14 +519,12 @@ func TestObfuscationConfigs(t *testing.T) {
 	// Prepare a test cases
 	streamID := uuid.New()
 	type testCase struct {
-		name              string
 		request           akinet.HTTPRequest
 		response          akinet.HTTPResponse
 		expectedWitnesses *api_spec.Witness
 	}
-	testCases := []testCase{
-		{
-			name: "no sensitive data",
+	testCases := map[string]testCase{
+		"no sensitive data": {
 			request: akinet.HTTPRequest{
 				StreamID: streamID,
 				Seq:      1204,
@@ -589,8 +587,7 @@ func TestObfuscationConfigs(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "sensitive data in header, query param, cookie and URL path",
+		"sensitive data in header, query param, cookie and URL path": {
 			request: akinet.HTTPRequest{
 				StreamID: streamID,
 				Seq:      1204,
@@ -687,8 +684,7 @@ func TestObfuscationConfigs(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "sensitive data in body",
+		"sensitive data in body": {
 			request: akinet.HTTPRequest{
 				StreamID: streamID,
 				Seq:      1204,
@@ -763,8 +759,7 @@ func TestObfuscationConfigs(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "struct with sensitive keys and values",
+		"struct with sensitive keys and values": {
 			request: akinet.HTTPRequest{
 				StreamID: streamID,
 				Seq:      1204,
@@ -869,8 +864,7 @@ func TestObfuscationConfigs(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "list with sensitive keys and values",
+		"list with sensitive keys and values": {
 			request: akinet.HTTPRequest{
 				StreamID: streamID,
 				Seq:      1204,
@@ -986,8 +980,7 @@ func TestObfuscationConfigs(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "multipart data, no sensitive data",
+		"multipart data, no sensitive data": {
 			request: akinet.HTTPRequest{
 				StreamID: streamID,
 				Seq:      1204,
@@ -1062,8 +1055,7 @@ func TestObfuscationConfigs(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "multipart data, with sensitive data",
+		"multipart data, with sensitive data": {
 			request: akinet.HTTPRequest{
 				StreamID: streamID,
 				Seq:      1204,
@@ -1167,8 +1159,10 @@ func TestObfuscationConfigs(t *testing.T) {
 		AnyTimes().
 		Return(nil)
 
-	for i, testCase := range testCases {
-		fmt.Println("Running test case: ", testCase.name)
+	i := -1
+	for name, testCase := range testCases {
+		i++
+		fmt.Println("Running test case: ", name)
 
 		req := akinet.ParsedNetworkTraffic{Content: testCase.request}
 		resp := akinet.ParsedNetworkTraffic{Content: testCase.response}

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -1144,6 +1144,75 @@ func TestObfuscationConfigs(t *testing.T) {
 				},
 			},
 		},
+		"null value": {
+			request: akinet.HTTPRequest{
+				StreamID: streamID,
+				Seq:      1204,
+				Method:   "POST",
+				URL: &url.URL{
+					Path: "/",
+				},
+				Host: "example.com",
+				Header: map[string][]string{
+					"Content-Type": {"application/json"},
+				},
+				Body: memview.New([]byte(`
+					{
+						"null": null
+					}
+				`)),
+			},
+			response: akinet.HTTPResponse{
+				StreamID:   streamID,
+				Seq:        1204,
+				StatusCode: 404,
+				Header: map[string][]string{
+					"Content-Type": {"application/json"},
+				},
+				Body: memview.New([]byte(`
+				  {
+						"null": null
+				  }
+				`)),
+			},
+			expectedWitnesses: &pb.Witness{
+				Method: &pb.Method{
+					Id: &pb.MethodID{
+						ApiType: pb.ApiType_HTTP_REST,
+					},
+					Args: map[string]*pb.Data{
+						"sLSDNjJ5umQ=": newTestBodySpecFromStruct(
+							0,
+							pb.HTTPBody_JSON,
+							"application/json",
+							map[string]*pb.Data{
+								"null": spec_util.NoneData,
+							},
+						),
+					},
+					Responses: map[string]*pb.Data{
+						"2drZdoQw74E=": newTestBodySpecFromStruct(
+							404,
+							pb.HTTPBody_JSON,
+							"application/json",
+							map[string]*pb.Data{
+								"null": spec_util.NoneData,
+							},
+						),
+					},
+					Meta: &pb.MethodMeta{
+						Meta: &pb.MethodMeta_Http{
+							Http: &pb.HTTPMethodMeta{
+								Method:       "POST",
+								PathTemplate: "/",
+								Host:         "example.com",
+								Obfuscation:  api_spec.HTTPMethodMeta_NONE,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	// Setup for running tests

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -1,7 +1,6 @@
 package trace
 
 import (
-	"reflect"
 	"regexp"
 	"strings"
 
@@ -90,75 +89,47 @@ type redactSensitiveInfoVisitor struct {
 
 var _ vis.DefaultSpecVisitor = (*redactSensitiveInfoVisitor)(nil)
 
-// EnterData processes the given data and obfuscates sensitive information based on the provided obfuscation options.
-// It does 3 checks to determine if the data contains sensitive information:
-// 1. It checks if spec is an HTTP Authorization or Cookie data and obfuscates the value.
-// 2. It checks if spec is an HTTP Header or Query Param data and obfuscates the value if the key is in the list of sensitive keys.
-// 3. It applies regex patterns to all obfuscate sensitive primitive string values.
-func (s *redactSensitiveInfoVisitor) EnterData(self interface{}, _ vis.SpecVisitorContext, d *pb.Data) Cont {
-	if httpMeta := d.GetMeta().GetHttp(); httpMeta != nil {
-		var key string
-		switch httpMeta.Location.(type) {
-		case *pb.HTTPMeta_Auth:
-			return ObfuscatePrimitiveWithRedactedString(d)
-		case *pb.HTTPMeta_Cookie:
-			return ObfuscatePrimitiveWithRedactedString(d)
-		case *pb.HTTPMeta_Header:
-			header := httpMeta.GetHeader()
-			key = header.Key
-		case *pb.HTTPMeta_Query:
-			queryParam := httpMeta.GetQuery()
-			key = queryParam.Key
-		}
-		// Check if the key is in the list of keys to obfuscate.
-		if s.obfuscationOptions.SensitiveDataKeys.Contains(strings.ToLower(key)) {
-			return ObfuscatePrimitiveWithRedactedString(d)
-		}
+// EnterData processes the given data and obfuscates sensitive information based
+// on the provided obfuscation options. It does 3 checks to determine if the
+// data contains sensitive information:
+//
+// 1. It checks if spec is an HTTP Authorization or Cookie data and obfuscates
+// the value.
+//
+// 2. It checks if spec is an HTTP Header or Query Param data and obfuscates the
+// value if the key is in the list of sensitive keys.
+//
+// 3. It applies regex patterns to all obfuscate sensitive primitive string
+// values.
+func (s *redactSensitiveInfoVisitor) EnterData(self interface{}, ctx vis.SpecVisitorContext, d *pb.Data) Cont {
+	// Redact cookies and authorization headers.
+	switch ctx.GetValueType() {
+	case vis.AUTH, vis.COOKIE:
+		redactPrimitivesInIR(d)
+		return SkipChildren
 	}
 
-	primitive := d.GetPrimitive()
-	if primitive == nil {
-		// Not a primitive, regex will be applied to primitive string values only.
-		return Continue
-	}
-
-	stringValue := primitive.GetStringValue()
-	if stringValue == nil {
-		// Not a string, regex will be applied to string values only.
-		return Continue
-	}
-
-	for _, pattern := range s.obfuscationOptions.SensitiveDataValuePatterns {
-		if pattern.MatchString(stringValue.Value) {
-			return ObfuscatePrimitiveWithRedactedString(d)
+	if p := d.GetPrimitive(); p != nil {
+		// We have a primitive value. Redact if the value is sensitive. Otherwise,
+		// fall through and redact based on the field name.
+		if s.primitiveHasSensitiveValue(p) {
+			redactPrimitive(p)
+			return SkipChildren
 		}
 	}
 
-	return Continue
-}
-
-func (s *redactSensitiveInfoVisitor) EnterHTTPBody(self interface{}, ctx vis.SpecVisitorContext, b *pb.HTTPBody) Cont {
-	node, _ := ctx.GetInnermostNode(reflect.TypeOf((*pb.Data)(nil)))
-	data := node.(*pb.Data)
-	if data == nil {
-		return Continue
+	// If a field name indicates that it is sensitive, redact its value.
+	fieldPath := ctx.GetFieldPath()
+	if len(fieldPath) > 0 {
+		innermostFieldPathElt := fieldPath[len(fieldPath)-1]
+		if innermostFieldPathElt.IsFieldName() {
+			fieldName := innermostFieldPathElt.String()
+			if s.obfuscationOptions.SensitiveDataKeys.Contains(strings.ToLower(fieldName)) {
+				redactPrimitivesInIR(d)
+				return SkipChildren
+			}
+		}
 	}
-
-	// Traverse the data node and redact sensitive information.
-	s.traverseAndRedactSensitiveInfo(data, false)
-
-	return Continue
-}
-
-func (s *redactSensitiveInfoVisitor) EnterHTTPMultipart(self interface{}, ctx vis.SpecVisitorContext, mp *pb.HTTPMultipart) Cont {
-	node, _ := ctx.GetInnermostNode(reflect.TypeOf((*pb.Data)(nil)))
-	data := node.(*pb.Data)
-	if data == nil {
-		return Continue
-	}
-
-	// Traverse the data node and redact sensitive information.
-	s.traverseAndRedactSensitiveInfo(data, false)
 
 	return Continue
 }
@@ -168,68 +139,60 @@ func (s *redactSensitiveInfoVisitor) EnterHTTPMethodMeta(self interface{}, ctx v
 
 	for i, segment := range pathSegments {
 		// Check if the path segment contains sensitive information.
-		for _, pattern := range s.obfuscationOptions.SensitiveDataValuePatterns {
-			if pattern.MatchString(segment) {
-				pathSegments[i] = redactionString
-				break
-			}
+		if s.isSensitiveString(segment) {
+			pathSegments[i] = redactionString
 		}
 	}
 
 	meta.PathTemplate = strings.Join(pathSegments, "/")
-	return Continue
+	return SkipChildren
 }
 
-// Traverses the protobuf data and redacts sensitive information based on the sensitive keys.
-// The function has 2 parameters:
-//  1. data: The current node in the recursive tree traversal of the protobuf data.
-//  2. redactData: A boolean flag to indicate if the data should be redacted irrespective of it's key and value.
-//     This will be true when the parent node is a sensitive key.
-//
-// The function checks if the data fields are primitive and redacts them if their keys are sensitive.
-// For non-primitive fields, it recursively traverses it's child nodes with the redactData flag set to true if the parent node is sensitive.
-func (s *redactSensitiveInfoVisitor) traverseAndRedactSensitiveInfo(data *pb.Data, redactData bool) {
-	switch val := data.Value.(type) {
-	case *pb.Data_Primitive:
-		if redactData {
-			ObfuscatePrimitiveWithRedactedString(data)
+// Determines whether the given string is a sensitive value.
+func (s *redactSensitiveInfoVisitor) isSensitiveString(v string) bool {
+	for _, pattern := range s.obfuscationOptions.SensitiveDataValuePatterns {
+		if pattern.MatchString(v) {
+			return true
 		}
-	case *pb.Data_Struct:
-		// Traverse the struct's fields and redact sensitive information based on key.
-		structData := val.Struct
-		for fieldName, fieldData := range structData.GetFields() {
-			// Check if the key is sensitive. If it is, redact the child data.
-			redactData := redactData || s.obfuscationOptions.SensitiveDataKeys.Contains(strings.ToLower(fieldName))
-			s.traverseAndRedactSensitiveInfo(fieldData, redactData)
-		}
-	case *pb.Data_List:
-		listData := val.List
-		if items := listData.GetElems(); items != nil {
-			for _, itemData := range items {
-				// Step through each item in the list and traverse the data node.
-				s.traverseAndRedactSensitiveInfo(itemData, redactData)
-			}
-		}
-	default:
-		// Unknown data type, mark as REDACTED string.
-		printer.Errorf("Unknown data type '%v' found, marking as REDACTED string\n", reflect.TypeOf(data.Value).String())
-		ObfuscatePrimitiveWithRedactedString(data)
 	}
+	return false
 }
 
-// Obfuscate the given primitive data with REDACTED string.
-// In case data is not primitive type, it will also be marked as REDACTED string.
-func ObfuscatePrimitiveWithRedactedString(d *pb.Data) Cont {
-	redactedPrimitiveString := spec_util.NewPrimitiveString(redactionString)
-
-	if dp := d.GetPrimitive(); dp != nil {
-		dp.Value = redactedPrimitiveString.Value
-	} else {
-		// Unknown data type captured, though this should not happen,except in case of OneOf and Optionals which should also not be present.
-		// Mark the data as REDACTED  string.
-		printer.Debugf("Unknown data type found, marking as REDACTED string\n")
-		d.Value = &pb.Data_Primitive{Primitive: redactedPrimitiveString}
+// Determines whether the given Primitive has a sensitive value.
+func (s *redactSensitiveInfoVisitor) primitiveHasSensitiveValue(p *pb.Primitive) bool {
+	sv := p.GetStringValue()
+	if sv == nil {
+		// Only strings can be sensitive.
+		return false
 	}
 
-	return Continue
+	return s.isSensitiveString(sv.Value)
+}
+
+func redactPrimitivesInIR[nodeT any](node nodeT) {
+	var v redactPrimitivesVisitor
+	vis.Apply(&v, node)
+}
+
+type redactPrimitivesVisitor struct {
+	vis.DefaultSpecVisitorImpl
+}
+
+var _ vis.DefaultSpecVisitor = (*redactPrimitivesVisitor)(nil)
+
+// If the Data being visited is a Primitive, it is replaced with the redaction
+// string.
+func (*redactPrimitivesVisitor) EnterData(self interface{}, _ vis.SpecVisitorContext, d *pb.Data) Cont {
+	dp := d.GetPrimitive()
+	if dp == nil {
+		return Continue
+	}
+
+	redactPrimitive(dp)
+	return SkipChildren
+}
+
+// Replaces the value in the given Primitive with the redaction string.
+func redactPrimitive(p *pb.Primitive) {
+	p.Value = spec_util.NewPrimitiveString(redactionString).Value
 }

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -44,21 +44,22 @@ func NewObfuscator() *Obfuscator {
 
 // Replaces all primitive values in the given method with zero values.
 func (o *Obfuscator) ZeroAllPrimitivesInMethod(m *pb.Method) {
-	var ov obfuscationVisitor
+	var ov zeroPrimitivesVisitor
 	vis.Apply(&ov, m)
 
 	// Mark the method as obfuscated.
 	m.GetMeta().GetHttp().Obfuscation = pb.HTTPMethodMeta_ZERO_VALUE
 }
 
-type obfuscationVisitor struct {
+type zeroPrimitivesVisitor struct {
 	vis.DefaultSpecVisitorImpl
 }
 
-var _ vis.DefaultSpecVisitor = (*obfuscationVisitor)(nil)
+var _ vis.DefaultSpecVisitor = (*zeroPrimitivesVisitor)(nil)
 
-// EnterData processes the given data and obfuscates all the primitive values with zero values, regardless of it's meta data.
-func (*obfuscationVisitor) EnterData(self interface{}, _ vis.SpecVisitorContext, d *pb.Data) Cont {
+// EnterData processes the given data and replaces all the primitive values
+// with zero values, regardless of its metadata.
+func (*zeroPrimitivesVisitor) EnterData(self interface{}, _ vis.SpecVisitorContext, d *pb.Data) Cont {
 	dp := d.GetPrimitive()
 	if dp == nil {
 		return Continue
@@ -66,7 +67,7 @@ func (*obfuscationVisitor) EnterData(self interface{}, _ vis.SpecVisitorContext,
 
 	pv, err := spec_util.PrimitiveValueFromProto(dp)
 	if err != nil {
-		printer.Warningf("failed to obfuscate raw value, dropping\n")
+		printer.Warningf("failed to zero out raw value, dropping\n")
 		d.Value = nil
 		return Continue
 	}

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -42,13 +42,13 @@ func NewObfuscator() *Obfuscator {
 	}
 }
 
-func (o *Obfuscator) ObfuscateDataWithZeroValue(m *pb.Method) {
+// Replaces all primitive values in the given method with zero values.
+func (o *Obfuscator) ZeroAllPrimitivesInMethod(m *pb.Method) {
 	var ov obfuscationVisitor
 	vis.Apply(&ov, m)
 
 	// Mark the method as obfuscated.
 	m.GetMeta().GetHttp().Obfuscation = pb.HTTPMethodMeta_ZERO_VALUE
-	return
 }
 
 type obfuscationVisitor struct {

--- a/trace/obfuscate.go
+++ b/trace/obfuscate.go
@@ -75,7 +75,7 @@ func (*obfuscationVisitor) EnterData(self interface{}, _ vis.SpecVisitorContext,
 	return Continue
 }
 
-func (o *Obfuscator) RedactData(m *pb.Method) {
+func (o *Obfuscator) RedactSensitiveData(m *pb.Method) {
 	pov := redactSensitiveInfoVisitor{
 		obfuscationOptions: o,
 	}

--- a/trace/obfuscate_test.go
+++ b/trace/obfuscate_test.go
@@ -93,6 +93,6 @@ func BenchmarkObfuscation(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		o.ObfuscateDataWithZeroValue(testWitness.Method)
+		o.ZeroAllPrimitivesInMethod(testWitness.Method)
 	}
 }

--- a/trace/obfuscate_test.go
+++ b/trace/obfuscate_test.go
@@ -71,7 +71,7 @@ func TestRedaction16CharacterIdentifier(t *testing.T) {
 		},
 	}
 
-	o.RedactData(witness.Method)
+	o.RedactSensitiveData(witness.Method)
 
 	assert.Equal(t, origVal1, witness.Method.Args["1"].GetPrimitive().GetStringValue().Value)
 	assert.Equal(t, origVal2, witness.Method.Args["2"].GetPrimitive().GetStringValue().Value)
@@ -83,7 +83,7 @@ func BenchmarkRedaction(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		o.RedactData(testWitness.Method)
+		o.RedactSensitiveData(testWitness.Method)
 	}
 }
 

--- a/trace/report_buffer.go
+++ b/trace/report_buffer.go
@@ -84,7 +84,7 @@ func (buf *reportBuffer) addWitness(w *witnessWithInfo) {
 			// The witness exceeds our per-witness storage limit. Obfuscate it to
 			// reduce its size while retaining its typing information.
 			printer.Debugf("Obfuscating oversized witness (%d MB) captured on interface %s\n", len(witnessReport.WitnessProto)/1_000_000, w.netInterface)
-			buf.collector.obfuscator.ObfuscateDataWithZeroValue(w.witness.GetMethod())
+			buf.collector.obfuscator.ZeroAllPrimitivesInMethod(w.witness.GetMethod())
 			witnessReport, err = w.toReport()
 			if err != nil {
 				printer.Warningf("Failed to convert obfuscated witness to report: %v\n", err)


### PR DESCRIPTION
As part of this, redaction has been reworked to better use visitors.

Tested locally as well. See the `null` field below.
```
$ ./witness_dump --env local org_295oDMFK8b1yS5dwlSTdgP svc_6NiejyYEVpWfziUXJgovV6 lrn_1H3eLS92zSmgyuiwqkGvB5
method: <
  id: <
    api_type: HTTP_REST
  >
  responses: <
    key: "q2ovkcc4jNQ="
    value: <
      struct: <
        fields: <
          key: "api-key"
          value: <
            primitive: <
              string_value: <
                value: "*REDACTED*"
              >
            >
          >
        >
        fields: <
          key: "empty"
          value: <
            list: <
            >
          >
        >
        fields: <
          key: "null"
          value: <
            optional: <
              none: <
              >
            >
          >
        >
        fields: <
          key: "secret"
          value: <
            primitive: <
              string_value: <
                value: "*REDACTED*"
              >
            >
          >
        >
      >
      meta: <
        http: <
          body: <
            content_type: JSON
            other_type: "application/json"
          >
          response_code: 404
        >
      >
    >
  >
  meta: <
    http: <
      method: "GET"
      path_template: "/"
      processing_latency: 4.242
      obfuscation: NONE
    >
  >
>
```