### PR TITLE
[POA-2129] Separate out common `apidump` flags

### DIFF
--- a/cmd/internal/apidump/common_flags.go
+++ b/cmd/internal/apidump/common_flags.go
@@ -1,0 +1,130 @@
+package apidump
+
+import (
+	"strconv"
+
+	"github.com/postmanlabs/postman-insights-agent/apispec"
+	"github.com/spf13/cobra"
+)
+
+type CommonApidumpFlags struct {
+	Filter              string
+	HostAllowlist       []string
+	HostExclusions      []string
+	Interfaces          []string
+	PathAllowlist       []string
+	PathExclusions      []string
+	RandomizedStart     int
+	RateLimit           float64
+	SendWitnessPayloads bool
+}
+
+func AddCommonApiDumpFlags(cmd *cobra.Command) (flags CommonApidumpFlags) {
+	cmd.Flags().StringVar(
+		&flags.Filter,
+		"filter",
+		"",
+		"Used to match packets going to and coming from your API service.",
+	)
+
+	cmd.Flags().StringSliceVar(
+		&flags.HostAllowlist,
+		"host-allow",
+		nil,
+		"Allows only HTTP hosts matching regular expressions.",
+	)
+
+	cmd.Flags().StringSliceVar(
+		&flags.HostExclusions,
+		"host-exclusions",
+		nil,
+		"Removes HTTP hosts matching regular expressions.",
+	)
+
+	cmd.Flags().StringSliceVar(
+		&flags.Interfaces,
+		"interfaces",
+		nil,
+		"List of network interfaces to listen on. Defaults to all interfaces on host.",
+	)
+
+	cmd.Flags().StringSliceVar(
+		&flags.PathAllowlist,
+		"path-allow",
+		nil,
+		"Allows only HTTP paths matching regular expressions.",
+	)
+
+	cmd.Flags().StringSliceVar(
+		&flags.PathExclusions,
+		"path-exclusions",
+		nil,
+		"Removes HTTP paths matching regular expressions.",
+	)
+
+	cmd.Flags().IntVar(
+		&flags.RandomizedStart,
+		"randomized-start",
+		100,
+		"Probability that the apidump command will start intercepting traffic.",
+	)
+	_ = cmd.Flags().MarkHidden("randomized-start")
+
+	cmd.Flags().Float64Var(
+		&flags.RateLimit,
+		"rate-limit",
+		apispec.DefaultRateLimit,
+		"Number of requests per minute to capture.",
+	)
+
+	cmd.Flags().BoolVar(
+		&flags.SendWitnessPayloads,
+		"send-witness-payloads",
+		false,
+		"Send request and response payloads to Postman",
+	)
+	_ = cmd.Flags().MarkHidden("send-witness-payloads")
+
+	return flags
+}
+
+func ConvertCommonApiDumpFlagsToArgs(flags CommonApidumpFlags) []string {
+	commonApidumpArgs := []string{}
+
+	if flags.Filter != "" {
+		commonApidumpArgs = append(commonApidumpArgs, "--filter", flags.Filter)
+	}
+
+	if flags.RandomizedStart != 100 {
+		commonApidumpArgs = append(commonApidumpArgs, "--randomized-start", strconv.Itoa(flags.RandomizedStart))
+	}
+
+	if flags.RateLimit != apispec.DefaultRateLimit {
+		commonApidumpArgs = append(commonApidumpArgs, "--rate-limit", strconv.FormatFloat(flags.RateLimit, 'f', -1, 64))
+	}
+
+	if flags.SendWitnessPayloads {
+		commonApidumpArgs = append(commonApidumpArgs, "--send-witness-payloads")
+	}
+
+	// Add slice type flags to the entry point.
+	// Flags: --host-allow, --host-exclusions, --interfaces, --path-allow, --path-exclusions
+	// Added them separately instead of joining with comma(,) to avoid any regex parsing issues.
+	for _, host := range flags.HostAllowlist {
+		commonApidumpArgs = append(commonApidumpArgs, "--host-allow", host)
+	}
+	for _, host := range flags.HostExclusions {
+		commonApidumpArgs = append(commonApidumpArgs, "--host-exclusions", host)
+	}
+	for _, interfaceFlag := range flags.Interfaces {
+		commonApidumpArgs = append(commonApidumpArgs, "--interfaces", interfaceFlag)
+	}
+	for _, path := range flags.PathAllowlist {
+		commonApidumpArgs = append(commonApidumpArgs, "--path-allow", path)
+	}
+	for _, path := range flags.PathExclusions {
+		commonApidumpArgs = append(commonApidumpArgs, "--path-exclusions", path)
+	}
+
+	return commonApidumpArgs
+}

--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/pkg/errors"
 	"github.com/postmanlabs/postman-insights-agent/cfg"
+	"github.com/postmanlabs/postman-insights-agent/cmd/internal/apidump"
 	"github.com/postmanlabs/postman-insights-agent/consts"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
@@ -61,7 +62,7 @@ var (
 
 // Helper function for reporting telemetry
 func reportStep(stepName string) {
-	telemetry.WorkflowStep("Starting systemd conguration", stepName)
+	telemetry.WorkflowStep("Starting systemd configuration", stepName)
 }
 
 func setupAgentForServer(projectID string) error {
@@ -228,10 +229,18 @@ func configureSystemdFiles(projectID string) error {
 		return err
 	}
 
+	// Get the common apidump args
+	apidumpArgs := apidump.ConvertCommonApiDumpFlagsToArgs(apidumpFlags)
+
+	// Join the extra apidump args to a single string
+	apidumpArgsStr := strings.Join(apidumpArgs, " ")
+
 	serviceFileData := struct {
 		AgentInstallPath string
+		ExtraApidumpArgs string
 	}{
 		AgentInstallPath: agentInstallPath,
+		ExtraApidumpArgs: apidumpArgsStr,
 	}
 
 	// Generate and write the service file, with permissions 0600 (read/write for owner only)

--- a/cmd/internal/ec2/ec2.go
+++ b/cmd/internal/ec2/ec2.go
@@ -3,13 +3,15 @@ package ec2
 import (
 	"fmt"
 
+	"github.com/postmanlabs/postman-insights-agent/cmd/internal/apidump"
 	"github.com/postmanlabs/postman-insights-agent/cmd/internal/cmderr"
 	"github.com/spf13/cobra"
 )
 
 var (
 	// Postman Insights project id
-	projectID string
+	projectID    string
+	apidumpFlags apidump.CommonApidumpFlags
 )
 
 var Cmd = &cobra.Command{
@@ -43,6 +45,9 @@ var RemoveFromEC2Cmd = &cobra.Command{
 func init() {
 	Cmd.PersistentFlags().StringVar(&projectID, "project", "", "Your Insights Project ID")
 	Cmd.MarkPersistentFlagRequired("project")
+
+	// initialize common apidump flags as flags for the ecs add command
+	apidumpFlags = apidump.AddCommonApiDumpFlags(Cmd)
 
 	Cmd.AddCommand(SetupInEC2Cmd)
 	Cmd.AddCommand(RemoveFromEC2Cmd)

--- a/cmd/internal/ec2/postman-insights-agent.service.tmpl
+++ b/cmd/internal/ec2/postman-insights-agent.service.tmpl
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/default/postman-insights-agent
 # DO NOT CHANGE
 # "${FOO}" uses the arguement as is, while "$FOO" splits the string on white space 
 # Reference: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Command%20lines
-ExecStart={{.AgentInstallPath}} apidump --project "${PROJECT_ID}" --interfaces "${INTERFACES}" --filter "${FILTER}" "$EXTRA_APIDUMP_ARGS"
+ExecStart={{.AgentInstallPath}} apidump --project "${PROJECT_ID}" --interfaces "${INTERFACES}" --filter "${FILTER}" {{.ExtraApidumpArgs}} "${EXTRA_APIDUMP_ARGS}"
 
 [Install]
 WantedBy=multi-user.target

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -7,9 +7,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/pkg/errors"
-	"github.com/postmanlabs/postman-insights-agent/apispec"
 	ecs_cloudformation_utils "github.com/postmanlabs/postman-insights-agent/aws_utils/cloudformation/ecs"
 	ecs_console_utils "github.com/postmanlabs/postman-insights-agent/aws_utils/console/ecs"
+	"github.com/postmanlabs/postman-insights-agent/cmd/internal/apidump"
 	"github.com/postmanlabs/postman-insights-agent/cmd/internal/cmderr"
 	"github.com/spf13/cobra"
 )
@@ -38,13 +38,7 @@ var (
 
 	// apidump flags
 	// These flags will be passed to apidump command in task definition file
-	filterFlag         string
-	hostAllowlistFlag  []string
-	hostExclusionsFlag []string
-	interfacesFlag     []string
-	pathAllowlistFlag  []string
-	pathExclusionsFlag []string
-	rateLimitFlag      float64
+	apidumpFlags apidump.CommonApidumpFlags
 )
 
 var Cmd = &cobra.Command{
@@ -123,13 +117,7 @@ func init() {
 	Cmd.PersistentFlags().MarkHidden("aws-credentials")
 
 	// initialize apidump flags as flags for the ecs add command
-	AddToECSCmd.Flags().StringVar(&filterFlag, "filter", "", "Used to match packets going to and coming from your API service.")
-	AddToECSCmd.Flags().StringSliceVar(&hostAllowlistFlag, "host-allow", nil, "Allows only HTTP hosts matching regular expressions.")
-	AddToECSCmd.Flags().StringSliceVar(&hostExclusionsFlag, "host-exclusions", nil, "Removes HTTP hosts matching regular expressions.")
-	AddToECSCmd.Flags().StringSliceVar(&interfacesFlag, "interfaces", nil, "List of network interfaces to listen on. Defaults to all interfaces on host.")
-	AddToECSCmd.Flags().StringSliceVar(&pathAllowlistFlag, "path-allow", nil, "Allows only HTTP paths matching regular expressions.")
-	AddToECSCmd.Flags().StringSliceVar(&pathExclusionsFlag, "path-exclusions", nil, "Removes HTTP paths matching regular expressions.")
-	AddToECSCmd.Flags().Float64Var(&rateLimitFlag, "rate-limit", apispec.DefaultRateLimit, "Number of requests per minute to capture.")
+	apidumpFlags = apidump.AddCommonApiDumpFlags(Cmd)
 
 	Cmd.AddCommand(AddToECSCmd)
 	Cmd.AddCommand(PrintCloudFormationFragmentCmd)


### PR DESCRIPTION
* In this PR, we have moved out common `apidump` flags from `apidump.go` to `common_flags.go`.
* `common_flags.go` have two functions:
  * `AddCommonApiDumpFlags()`: Add the flags to cobra.Command object. It returns the objects to which flag values will be assigned.
  * `ConvertCommonApiDumpFlagsToArgs()`: Returns an array of strings (like `--flag value`). It is added to the apidump command in different platform installation configurations.
* The `ecs` and `ec2` commands will read these values and then convert them to flags for `apidump` commands and add them to the definition file (`ecs`) or systems service file (`ec2`)
* The `apidump` command will use these flag values to set the main `apidump` package variables.