### PR TITLE
POA-2390 Exclude certain Cloud API endpoints from Repro Mode

### DIFF
--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -3,6 +3,7 @@ package trace
 import (
 	"encoding/base64"
 	"net"
+	"regexp"
 	"sync"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/akitasoftware/akita-libs/akinet"
 	kgxapi "github.com/akitasoftware/akita-libs/api_schema"
 	"github.com/akitasoftware/akita-libs/batcher"
+	"github.com/akitasoftware/akita-libs/http_rest_methods"
 	"github.com/akitasoftware/akita-libs/spec_util"
 	"github.com/akitasoftware/akita-libs/spec_util/ir_hash"
 	"github.com/akitasoftware/go-utils/optionals"
@@ -280,6 +282,45 @@ func (c *BackendCollector) processTLSHandshake(tls akinet.TLSHandshakeMetadata) 
 	return nil
 }
 
+var cloudAPIEnvironmentsPathRE = regexp.MustCompile(`^/environments/[^/]+$`)
+
+// Returns true if the witness should be excluded from Repro Mode.
+//
+// XXX This is a stop-gap hack to exclude certain endpoints for Cloud API from
+// Repro Mode.
+func excludeWitnessFromReproMode(w *pb.Witness) bool {
+
+	httpMeta := w.GetMethod().GetMeta().GetHttp()
+	if httpMeta == nil {
+		return false
+	}
+
+	switch httpMeta.Host {
+	case "api.getpostman-stage.com", "api.getpostman.com":
+		switch httpMeta.Method {
+		case http_rest_methods.GET.String():
+			// Exclude GET /environments/{environment}.
+			if cloudAPIEnvironmentsPathRE.MatchString(httpMeta.PathTemplate) {
+				return true
+			}
+
+		case http_rest_methods.POST.String():
+			// Exclude POST /environments.
+			if httpMeta.PathTemplate == "/environments" {
+				return true
+			}
+
+		case http_rest_methods.PUT.String():
+			// Exclude PUT /environments/{environment}.
+			// Exclude GET /environments/{environment}.
+			if cloudAPIEnvironmentsPathRE.MatchString(httpMeta.PathTemplate) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 	// Mark the method as not obfuscated.
 	w.witness.GetMethod().GetMeta().GetHttp().Obfuscation = pb.HTTPMethodMeta_NONE
@@ -292,7 +333,9 @@ func (c *BackendCollector) queueUpload(w *witnessWithInfo) {
 		}
 	}
 
-	if !c.sendWitnessPayloads || !hasOnlyErrorResponses(w.witness.GetMethod()) {
+	if !c.sendWitnessPayloads ||
+		!hasOnlyErrorResponses(w.witness.GetMethod()) ||
+		excludeWitnessFromReproMode(w.witness) {
 		// Obfuscate the original value so type inference engine can use it on the
 		// backend without revealing the actual value.
 		c.obfuscator.ZeroAllPrimitivesInMethod(w.witness.GetMethod())


### PR DESCRIPTION
Tested locally:
```
 has_payload | response_code | method |        host_port         |        path  
-------------+---------------+--------+--------------------------+--------------------
 f           |           200 | GET    | api.getpostman-stage.com | /aoeu
 f           |           200 | POST   | api.getpostman-stage.com | /environments
 f           |           200 | GET    | api.getpostman-stage.com | /environments/aoeu
 f           |           200 | PUT    | api.getpostman-stage.com | /environments/aoeu
 f           |           200 | GET    | api.getpostman.com       | /aoeu
 f           |           200 | POST   | api.getpostman.com       | /environments
 f           |           200 | GET    | api.getpostman.com       | /environments/aoeu
 f           |           200 | PUT    | api.getpostman.com       | /environments/aoeu
 f           |           200 | GET    | localhost                | /aoeu
 f           |           200 | POST   | localhost                | /environments
 f           |           200 | GET    | localhost                | /environments/aoeu
 f           |           200 | PUT    | localhost                | /environments/aoeu
 f           |           404 | POST   | api.getpostman-stage.com | /environments
 f           |           404 | GET    | api.getpostman-stage.com | /environments/aoeu
 f           |           404 | PUT    | api.getpostman-stage.com | /environments/aoeu
 f           |           404 | POST   | api.getpostman.com       | /environments
 f           |           404 | GET    | api.getpostman.com       | /environments/aoeu
 f           |           404 | PUT    | api.getpostman.com       | /environments/aoeu
 t           |           404 | GET    | api.getpostman-stage.com | /aoeu
 t           |           404 | GET    | api.getpostman.com       | /aoeu
 t           |           404 | GET    | localhost                | /aoeu
 t           |           404 | POST   | localhost                | /environments
 t           |           404 | GET    | localhost                | /environments/aoeu
 t           |           404 | PUT    | localhost                | /environments/aoeu
(24 rows)
```