### PR TITLE
POA-2485: add primarySecret and secondSecret to field list

### DIFF
--- a/trace/obfuscation_config.yaml
+++ b/trace/obfuscation_config.yaml
@@ -11,7 +11,9 @@ sensitive_keys:
 - encryption_key
 - password
 - postman_sid
+- primarySecret
 - proxy-authorization
+- secondarySecret
 - secretKey
 - sessionToken
 - set-cookie


### PR DESCRIPTION
These appear in the /v1/changelog/consumer endpoint in the Version Control service.