### PR TITLE
[POA-2503] Add --force flag in ec2 setup to overwrite files

### DIFF
--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -198,9 +198,12 @@ func configureSystemdFiles(projectID string) error {
 	printer.Infof(message + "\n")
 	reportStep(message)
 
-	err := checkReconfiguration()
-	if err != nil {
-		return err
+	// Prompt user if --force flag is not set
+	if !forceOverwrite {
+		err := checkReconfiguration()
+		if err != nil {
+			return err
+		}
 	}
 
 	// -------- Write env file --------
@@ -218,7 +221,7 @@ func configureSystemdFiles(projectID string) error {
 	}
 
 	// Generate and write the env file, with permissions 0600 (read/write for owner only)
-	err = util.GenerateAndWriteTemplateFile(envFileFS, envFileTemplateName, envFileBasePath, envFileName, 0600, envFiledata)
+	err := util.GenerateAndWriteTemplateFile(envFileFS, envFileTemplateName, envFileBasePath, envFileName, 0600, envFiledata)
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -101,6 +101,12 @@ func askToReconfigure() error {
 		"Check systemd service file: cat %s\n",
 		envFilePath, serviceFilePath)
 
+	// Don't prompt user if forceOverwrite is true, print the message and return
+	if forceOverwrite {
+		printer.Infof("--force flag is set, overwriting old API key and Project ID values in systemd configuration file with current values\n")
+		return nil
+	}
+
 	err := survey.AskOne(
 		&survey.Confirm{
 			Message: "Overwrite old API key and Project ID values in systemd configuration file with current values?",
@@ -198,12 +204,9 @@ func configureSystemdFiles(projectID string) error {
 	printer.Infof(message + "\n")
 	reportStep(message)
 
-	// Prompt user if --force flag is not set
-	if !forceOverwrite {
-		err := checkReconfiguration()
-		if err != nil {
-			return err
-		}
+	err := checkReconfiguration()
+	if err != nil {
+		return err
 	}
 
 	// -------- Write env file --------
@@ -221,7 +224,7 @@ func configureSystemdFiles(projectID string) error {
 	}
 
 	// Generate and write the env file, with permissions 0600 (read/write for owner only)
-	err := util.GenerateAndWriteTemplateFile(envFileFS, envFileTemplateName, envFileBasePath, envFileName, 0600, envFiledata)
+	err = util.GenerateAndWriteTemplateFile(envFileFS, envFileTemplateName, envFileBasePath, envFileName, 0600, envFiledata)
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/ec2/ec2.go
+++ b/cmd/internal/ec2/ec2.go
@@ -52,7 +52,7 @@ func init() {
 	// initialize common apidump flags as flags for the ecs add command
 	apidumpFlags = apidump.AddCommonApiDumpFlags(Cmd)
 
-	SetupInEC2Cmd.PersistentFlags().BoolVarP(&forceOverwrite, "force", "f", false, "If the service files already exists, overwrite them and don't prompt the user")
+	SetupInEC2Cmd.PersistentFlags().BoolVarP(&forceOverwrite, "force", "f", false, "If the service files already exist, overwrite them without asking for confirmation")
 
 	Cmd.AddCommand(SetupInEC2Cmd)
 	Cmd.AddCommand(RemoveFromEC2Cmd)

--- a/cmd/internal/ec2/ec2.go
+++ b/cmd/internal/ec2/ec2.go
@@ -12,6 +12,9 @@ var (
 	// Postman Insights project id
 	projectID    string
 	apidumpFlags apidump.CommonApidumpFlags
+
+	// Overwrite the existing service file and don't prompt the user
+	forceOverwrite bool
 )
 
 var Cmd = &cobra.Command{
@@ -48,6 +51,8 @@ func init() {
 
 	// initialize common apidump flags as flags for the ecs add command
 	apidumpFlags = apidump.AddCommonApiDumpFlags(Cmd)
+
+	SetupInEC2Cmd.PersistentFlags().BoolVarP(&forceOverwrite, "force", "f", false, "If the service files already exists, overwrite them and don't prompt the user")
 
 	Cmd.AddCommand(SetupInEC2Cmd)
 	Cmd.AddCommand(RemoveFromEC2Cmd)


### PR DESCRIPTION
With this PR, we are adding a new `--force` flag to `ec2 setup` command which will overwrite existing service files (if any) instead of asking user.
This will be useful in running the command in non-interactive shells, which is used while installing the agent in beanstalk services.