### PR TITLE
[POA-2141] Accept project ID via environment flag

### DIFF
--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -122,11 +122,11 @@ func apidumpRunInternal(cmd *cobra.Command, _ []string) error {
 	}
 
 	// override the project id if the environment variable is set
-	if envProjectID := os.Getenv("POSTMAN_AGENT_PROJECT_ID"); envProjectID != "" {
+	if envProjectID := os.Getenv("POSTMAN_INSIGHTS_PROJECT_ID"); envProjectID != "" {
 		projectID = envProjectID
 	}
 
-	// Check that exactly one of --project or --collection is specified, or POSTMAN_AGENT_PROJECT_ID was set.
+	// Check that exactly one of --project or --collection is specified, or POSTMAN_INSIGHTS_PROJECT_ID was set.
 	// If not, we wll loop indefinitely to avoid boot loops.
 	if projectID == "" && postmanCollectionID == "" {
 		printer.Stdout.Infof("This process will not exit, to avoid boot loops. Please correct the command line flags or environment and retry.\n")

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -121,9 +121,14 @@ func apidumpRunInternal(cmd *cobra.Command, _ []string) error {
 		return errors.Wrap(err, "failed to load plugins")
 	}
 
+	// override the project id if the environment variable is set
+	if envProjectID := os.Getenv("POSTMAN_AGENT_PROJECT_ID"); envProjectID != "" {
+		projectID = envProjectID
+	}
+
 	// Check that exactly one of --project or --collection is specified.
 	if projectID == "" && postmanCollectionID == "" {
-		return errors.New("exactly one of --project or --collection must be specified")
+		return errors.New("exactly one of --project or --collection must be specified, or set the POSTMAN_AGENT_PROJECT_ID environment variable")
 	}
 
 	// If --project was given, convert projectID to serviceID.

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -127,11 +127,8 @@ func apidumpRunInternal(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Check that exactly one of --project or --collection is specified, or POSTMAN_INSIGHTS_PROJECT_ID was set.
-	// If not, we wll loop indefinitely to avoid boot loops.
 	if projectID == "" && postmanCollectionID == "" {
-		printer.Stdout.Infof("Please specify a project ID with the --project flag or the POSTMAN_INSIGHTS_PROJECT_ID environment variable.\n")
-		printer.Stdout.Infof("This process will not exit, to avoid boot loops. Please correct the command line flags or environment and retry.\n")
-		select {}
+		return errors.New("Exactly one of --project or --collection must be specified, or POSTMAN_INSIGHTS_PROJECT_ID must be set.")
 	}
 
 	// If --project was given, convert projectID to serviceID.

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -129,6 +129,7 @@ func apidumpRunInternal(cmd *cobra.Command, _ []string) error {
 	// Check that exactly one of --project or --collection is specified, or POSTMAN_INSIGHTS_PROJECT_ID was set.
 	// If not, we wll loop indefinitely to avoid boot loops.
 	if projectID == "" && postmanCollectionID == "" {
+		printer.Stdout.Infof("Please specify a project ID with the --project flag or the POSTMAN_INSIGHTS_PROJECT_ID environment variable.\n")
 		printer.Stdout.Infof("This process will not exit, to avoid boot loops. Please correct the command line flags or environment and retry.\n")
 		select {}
 	}

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -126,9 +126,11 @@ func apidumpRunInternal(cmd *cobra.Command, _ []string) error {
 		projectID = envProjectID
 	}
 
-	// Check that exactly one of --project or --collection is specified.
+	// Check that exactly one of --project or --collection is specified, or POSTMAN_AGENT_PROJECT_ID was set.
+	// If not, we wll loop indefinitely to avoid boot loops.
 	if projectID == "" && postmanCollectionID == "" {
-		return errors.New("exactly one of --project or --collection must be specified, or set the POSTMAN_AGENT_PROJECT_ID environment variable")
+		printer.Stdout.Infof("This process will not exit, to avoid boot loops. Please correct the command line flags or environment and retry.\n")
+		select {}
 	}
 
 	// If --project was given, convert projectID to serviceID.


### PR DESCRIPTION
With this PR, we can now set/override the project ID using an environment variable called `POSTMAN_AGENT_PROJECT_ID`