### PR TITLE
[POA-2516] Parse and persist invalid JSON and YAML bodies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
-	github.com/akitasoftware/akita-ir v0.0.0-20241212105914-68c47ec34a0a
-	github.com/akitasoftware/akita-libs v0.0.0-20241212114105-28b291366b0a
+	github.com/akitasoftware/akita-ir v0.0.0-20241213050034-057d7b6097e8
+	github.com/akitasoftware/akita-libs v0.0.0-20241213051250-7fac08ba3594
 	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
-	github.com/akitasoftware/akita-ir v0.0.0-20241210134130-1db037ecc549
-	github.com/akitasoftware/akita-libs v0.0.0-20241210150553-bc063b60bd85
+	github.com/akitasoftware/akita-ir v0.0.0-20241212105914-68c47ec34a0a
+	github.com/akitasoftware/akita-libs v0.0.0-20241212114105-28b291366b0a
 	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
-	github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4
-	github.com/akitasoftware/akita-libs v0.0.0-20241115053127-0af65b813d9c
+	github.com/akitasoftware/akita-ir v0.0.0-20241210134130-1db037ecc549
+	github.com/akitasoftware/akita-libs v0.0.0-20241210150553-bc063b60bd85
 	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,12 @@ github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tj
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4 h1:jbsA7E68G4dkK+ldQKQNPFIaRojFCn+cEB3gEEUSEU4=
 github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
+github.com/akitasoftware/akita-ir v0.0.0-20241210134130-1db037ecc549 h1:r5EbkpsLDonkIEQWdUqNwI1FaI0/kThShk0zD0KC08E=
+github.com/akitasoftware/akita-ir v0.0.0-20241210134130-1db037ecc549/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20241115053127-0af65b813d9c h1:EFEyv9FTVqSbCKfiSlXEAcNJQoJwMpIGjHuc4uR1Bgk=
 github.com/akitasoftware/akita-libs v0.0.0-20241115053127-0af65b813d9c/go.mod h1:5rzkpaJI1sA9CtGELYZpf15oczAVopcyda2WsYG5xno=
+github.com/akitasoftware/akita-libs v0.0.0-20241210150553-bc063b60bd85 h1:uox18K4ZFvxzzNlyXL7Tzlk3FBE54Vd3auDYFzDHxvc=
+github.com/akitasoftware/akita-libs v0.0.0-20241210150553-bc063b60bd85/go.mod h1:mvXnUbqFuKt/PsZ4rhpBrKx0sjFhIkwIQLwmj9F4Zbc=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20240820200020-7289ae956f70 h1:VnU7QLDBwRujpQoHwShs5yu0Ahv1fSalNJa4UijwlmY=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ github.com/akitasoftware/akita-ir v0.0.0-20241210134130-1db037ecc549 h1:r5EbkpsL
 github.com/akitasoftware/akita-ir v0.0.0-20241210134130-1db037ecc549/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-ir v0.0.0-20241212105914-68c47ec34a0a h1:7qu19Mmi+I9AwDZqrbGUPYmsyXu/UbwRFnlnvjyuboQ=
 github.com/akitasoftware/akita-ir v0.0.0-20241212105914-68c47ec34a0a/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
+github.com/akitasoftware/akita-ir v0.0.0-20241213050034-057d7b6097e8/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20241115053127-0af65b813d9c h1:EFEyv9FTVqSbCKfiSlXEAcNJQoJwMpIGjHuc4uR1Bgk=
 github.com/akitasoftware/akita-libs v0.0.0-20241115053127-0af65b813d9c/go.mod h1:5rzkpaJI1sA9CtGELYZpf15oczAVopcyda2WsYG5xno=
 github.com/akitasoftware/akita-libs v0.0.0-20241210150553-bc063b60bd85 h1:uox18K4ZFvxzzNlyXL7Tzlk3FBE54Vd3auDYFzDHxvc=
@@ -40,6 +41,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20241212110122-6626e5bb189c h1:UqBlV2
 github.com/akitasoftware/akita-libs v0.0.0-20241212110122-6626e5bb189c/go.mod h1:RTaDmDZR5Ytg7i+2qcvzCJByhCDY9cIkdPfy7eV30/M=
 github.com/akitasoftware/akita-libs v0.0.0-20241212114105-28b291366b0a h1:BecrRvaXJIbgFD3qh5v8OVSI/yVUQb9ohYRW7BWHXrA=
 github.com/akitasoftware/akita-libs v0.0.0-20241212114105-28b291366b0a/go.mod h1:RTaDmDZR5Ytg7i+2qcvzCJByhCDY9cIkdPfy7eV30/M=
+github.com/akitasoftware/akita-libs v0.0.0-20241213051250-7fac08ba3594 h1:OLA8tSW2p8ECSP8w8ldZkBVI769hUa1/E48cfM6+s7w=
+github.com/akitasoftware/akita-libs v0.0.0-20241213051250-7fac08ba3594/go.mod h1:Fg14kX6+N7we3KdP1c11W/SzbKsgapV1hP5d4Z/Hqwc=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20240820200020-7289ae956f70 h1:VnU7QLDBwRujpQoHwShs5yu0Ahv1fSalNJa4UijwlmY=

--- a/go.sum
+++ b/go.sum
@@ -30,10 +30,16 @@ github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4 h1:jbsA7E68
 github.com/akitasoftware/akita-ir v0.0.0-20241008173748-ca8e2e3d5db4/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-ir v0.0.0-20241210134130-1db037ecc549 h1:r5EbkpsLDonkIEQWdUqNwI1FaI0/kThShk0zD0KC08E=
 github.com/akitasoftware/akita-ir v0.0.0-20241210134130-1db037ecc549/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
+github.com/akitasoftware/akita-ir v0.0.0-20241212105914-68c47ec34a0a h1:7qu19Mmi+I9AwDZqrbGUPYmsyXu/UbwRFnlnvjyuboQ=
+github.com/akitasoftware/akita-ir v0.0.0-20241212105914-68c47ec34a0a/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20241115053127-0af65b813d9c h1:EFEyv9FTVqSbCKfiSlXEAcNJQoJwMpIGjHuc4uR1Bgk=
 github.com/akitasoftware/akita-libs v0.0.0-20241115053127-0af65b813d9c/go.mod h1:5rzkpaJI1sA9CtGELYZpf15oczAVopcyda2WsYG5xno=
 github.com/akitasoftware/akita-libs v0.0.0-20241210150553-bc063b60bd85 h1:uox18K4ZFvxzzNlyXL7Tzlk3FBE54Vd3auDYFzDHxvc=
 github.com/akitasoftware/akita-libs v0.0.0-20241210150553-bc063b60bd85/go.mod h1:mvXnUbqFuKt/PsZ4rhpBrKx0sjFhIkwIQLwmj9F4Zbc=
+github.com/akitasoftware/akita-libs v0.0.0-20241212110122-6626e5bb189c h1:UqBlV2CPdorbKE/xlrcnrHxzOYq562gEiv3mlHZ+2uA=
+github.com/akitasoftware/akita-libs v0.0.0-20241212110122-6626e5bb189c/go.mod h1:RTaDmDZR5Ytg7i+2qcvzCJByhCDY9cIkdPfy7eV30/M=
+github.com/akitasoftware/akita-libs v0.0.0-20241212114105-28b291366b0a h1:BecrRvaXJIbgFD3qh5v8OVSI/yVUQb9ohYRW7BWHXrA=
+github.com/akitasoftware/akita-libs v0.0.0-20241212114105-28b291366b0a/go.mod h1:RTaDmDZR5Ytg7i+2qcvzCJByhCDY9cIkdPfy7eV30/M=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20240820200020-7289ae956f70 h1:VnU7QLDBwRujpQoHwShs5yu0Ahv1fSalNJa4UijwlmY=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ github.com/akitasoftware/akita-ir v0.0.0-20241210134130-1db037ecc549 h1:r5EbkpsL
 github.com/akitasoftware/akita-ir v0.0.0-20241210134130-1db037ecc549/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-ir v0.0.0-20241212105914-68c47ec34a0a h1:7qu19Mmi+I9AwDZqrbGUPYmsyXu/UbwRFnlnvjyuboQ=
 github.com/akitasoftware/akita-ir v0.0.0-20241212105914-68c47ec34a0a/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
+github.com/akitasoftware/akita-ir v0.0.0-20241213050034-057d7b6097e8 h1:sf2aaOG8o+tAIMxuk7peMkKrHPp9l3/r+JmiQ3dwJ5U=
 github.com/akitasoftware/akita-ir v0.0.0-20241213050034-057d7b6097e8/go.mod h1:WEWPzhZtxlJnov3MxcqSDiZaHHf00vs3aJwCdt3OwzA=
 github.com/akitasoftware/akita-libs v0.0.0-20241115053127-0af65b813d9c h1:EFEyv9FTVqSbCKfiSlXEAcNJQoJwMpIGjHuc4uR1Bgk=
 github.com/akitasoftware/akita-libs v0.0.0-20241115053127-0af65b813d9c/go.mod h1:5rzkpaJI1sA9CtGELYZpf15oczAVopcyda2WsYG5xno=

--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -129,6 +129,7 @@ func ParseHTTP(elem akinet.ParsedNetworkContent) (*PartialWitness, error) {
 			return nil, errors.Wrap(err, "failed to decode body")
 		}
 
+		// saving a copy to use for capturing the raw stringified body in case of parsing error
 		origReader, fallbackReader, err := createMultiReader(decodeStream)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create multi reader")
@@ -144,7 +145,9 @@ func ParseHTTP(elem akinet.ParsedNetworkContent) (*PartialWitness, error) {
 			printer.Debugf("Failed to parse body, attempting common decompressions: %v\n", err)
 			decompressedReader, decompressErr := attemptDecompress(rawBody)
 			if decompressErr == nil {
-				bodyData, err = parseBody(contentType, decompressedReader, statusCode)
+				// saving a copy to use for capturing the raw stringified body in case of parsing error
+				origReader, fallbackReader, _ = createMultiReader(decompressedReader)
+				bodyData, err = parseBody(contentType, origReader, statusCode)
 			}
 		}
 

--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -147,6 +147,8 @@ func ParseHTTP(elem akinet.ParsedNetworkContent) (*PartialWitness, error) {
 			// When the body is unparsable even after attempting fallback decompressions,
 			// we will try to capture the body as a string and indicate parsing error in the body meta
 			bodyStream := rawBody.CreateReader()
+			// we are ignoring the error from decodeBody here
+			// if the decodeStream is nil, we will capture a placeholder bodyData that would say we received an unparsable body
 			decodeStream, _ := decodeBody(headers, bodyStream, bodyDecompressed)
 			bodyData = captureUnparsableBody(decodeStream, contentType, statusCode)
 		}
@@ -433,6 +435,10 @@ func captureUnparsableBody(bodyStream io.Reader, contentType string, statusCode 
 			},
 			ResponseCode: int32(statusCode),
 		}),
+	}
+
+	if bodyStream == nil {
+		return bodyData
 	}
 
 	// Categorize the body as a string.

--- a/learn/parse_http.go
+++ b/learn/parse_http.go
@@ -132,7 +132,8 @@ func ParseHTTP(elem akinet.ParsedNetworkContent) (*PartialWitness, error) {
 		// saving a copy to use for capturing the raw stringified body in case of parsing error
 		origReader, fallbackReader, err := createMultiReader(decodeStream)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create multi reader")
+			origReader = decodeStream
+			fallbackReader = decodeStream
 		}
 
 		contentType := headers.Get("Content-Type")
@@ -146,7 +147,12 @@ func ParseHTTP(elem akinet.ParsedNetworkContent) (*PartialWitness, error) {
 			decompressedReader, decompressErr := attemptDecompress(rawBody)
 			if decompressErr == nil {
 				// saving a copy to use for capturing the raw stringified body in case of parsing error
-				origReader, fallbackReader, _ = createMultiReader(decompressedReader)
+				origReader, fallbackReader, err = createMultiReader(decompressedReader)
+				if err != nil {
+					origReader = decompressedReader
+					fallbackReader = decompressedReader
+				}
+
 				bodyData, err = parseBody(contentType, origReader, statusCode)
 			}
 		}

--- a/learn/parse_http_test.go
+++ b/learn/parse_http_test.go
@@ -10,6 +10,7 @@ import (
 	as "github.com/akitasoftware/akita-ir/go/api_spec"
 	"github.com/akitasoftware/akita-libs/akinet"
 	"github.com/akitasoftware/akita-libs/spec_util"
+	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 	"github.com/spf13/viper"
 )
@@ -84,7 +85,7 @@ func newTestBodySpecContentType(contentType string, statusCode int) *as.Data {
 }
 
 func newTestBodySpecFromStruct(statusCode int, contentType as.HTTPBody_ContentType, originalContentType string, s map[string]*as.Data) *as.Data {
-	return newTestBodySpecFromData(statusCode, contentType, originalContentType, dataFromStruct(s), nil)
+	return newTestBodySpecFromData(statusCode, contentType, originalContentType, dataFromStruct(s), optionals.None[as.HTTPBody_Errors]())
 }
 
 func newTestBodySpecFromData(
@@ -92,7 +93,7 @@ func newTestBodySpecFromData(
 	contentType as.HTTPBody_ContentType,
 	originalContentType string,
 	d *as.Data,
-	bodyError *as.HTTPBody_Errors,
+	bodyError optionals.Optional[as.HTTPBody_Errors],
 ) *as.Data {
 	d.Meta = newBodyDataMeta(statusCode, contentType, originalContentType, bodyError)
 	return d
@@ -105,7 +106,7 @@ func newTestMultipartFormData(statusCode int) *as.Data {
 		Value: &as.Data_Struct{
 			Struct: &as.Struct{
 				Fields: map[string]*as.Data{
-					"field1": newTestBodySpecFromData(statusCode, as.HTTPBody_TEXT_PLAIN, "text/plain", f1, nil),
+					"field1": newTestBodySpecFromData(statusCode, as.HTTPBody_TEXT_PLAIN, "text/plain", f1, optionals.None[as.HTTPBody_Errors]()),
 					"field2": newTestBodySpecFromStruct(statusCode, as.HTTPBody_JSON, "application/json", map[string]*as.Data{
 						"foo": dataFromPrimitive(spec_util.NewPrimitiveString("bar")),
 						"baz": dataFromPrimitive(spec_util.NewPrimitiveInt64(123)),
@@ -362,7 +363,7 @@ func TestParseHTTPRequest(t *testing.T) {
 						as.HTTPBody_OCTET_STREAM,
 						"application/octet-stream",
 						dataFromPrimitive(spec_util.NewPrimitiveBytes([]byte("prince is a good boy"))),
-						nil,
+						optionals.None[as.HTTPBody_Errors](),
 					),
 				},
 				UnknownHTTPMethodMeta(),
@@ -495,7 +496,7 @@ prince:
 						as.HTTPBody_JSON,
 						"application/json",
 						dataFromPrimitive(spec_util.NewPrimitiveString("I am not JSON")),
-						as.HTTPBody_PARSING_ERROR.Enum(),
+						optionals.Some(as.HTTPBody_PARSING_ERROR),
 					),
 				},
 				UnknownHTTPMethodMeta(),

--- a/learn/parse_http_test.go
+++ b/learn/parse_http_test.go
@@ -373,10 +373,10 @@ func TestParseHTTPRequest(t *testing.T) {
 			testContent: newTestHTTPResponse(
 				200,
 				[]byte(`
-		prince:
-		  - bread
-		  - eat
-		`),
+prince:
+  - bread
+  - eat
+`),
 				"application/x-yaml",
 				map[string][]string{},
 				[]*http.Cookie{},

--- a/learn/util_test.go
+++ b/learn/util_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/akitasoftware/akita-libs/memview"
 	"github.com/akitasoftware/akita-libs/pbhash"
 	"github.com/akitasoftware/akita-libs/spec_util"
+	"github.com/akitasoftware/go-utils/optionals"
 )
 
 const (
@@ -195,7 +196,7 @@ func newBodyDataMeta(
 	responseCode int,
 	contentType pb.HTTPBody_ContentType,
 	originalContentType string,
-	bodyError *as.HTTPBody_Errors,
+	bodyErrorOpt optionals.Optional[pb.HTTPBody_Errors],
 ) *pb.DataMeta {
 	dataMeta := newDataMeta(&pb.HTTPMeta{
 		Location: &pb.HTTPMeta_Body{
@@ -207,8 +208,8 @@ func newBodyDataMeta(
 		ResponseCode: int32(responseCode),
 	})
 
-	if bodyError != nil {
-		dataMeta.GetHttp().GetBody().Errors = *bodyError
+	if bodyError, exists := bodyErrorOpt.Get(); exists {
+		dataMeta.GetHttp().GetBody().Errors = bodyError
 	}
 
 	return dataMeta

--- a/learn/util_test.go
+++ b/learn/util_test.go
@@ -191,8 +191,13 @@ func dataFromPrimitive(p *pb.Primitive) *pb.Data {
 	return &pb.Data{Value: &pb.Data_Primitive{Primitive: p}}
 }
 
-func newBodyDataMeta(responseCode int, contentType pb.HTTPBody_ContentType, originalContentType string) *pb.DataMeta {
-	return newDataMeta(&pb.HTTPMeta{
+func newBodyDataMeta(
+	responseCode int,
+	contentType pb.HTTPBody_ContentType,
+	originalContentType string,
+	bodyError *as.HTTPBody_Errors,
+) *pb.DataMeta {
+	dataMeta := newDataMeta(&pb.HTTPMeta{
 		Location: &pb.HTTPMeta_Body{
 			Body: &pb.HTTPBody{
 				ContentType: contentType,
@@ -201,6 +206,12 @@ func newBodyDataMeta(responseCode int, contentType pb.HTTPBody_ContentType, orig
 		},
 		ResponseCode: int32(responseCode),
 	})
+
+	if bodyError != nil {
+		dataMeta.GetHttp().GetBody().Errors = *bodyError
+	}
+
+	return dataMeta
 }
 
 func annotateIfSensitiveForTest(sensitive bool, prim *pb.Primitive) *pb.Primitive {


### PR DESCRIPTION
- Added support for capturing unparsable bodies as raw string
- Also indicates the same using the new Errors field added with the body meta. 