### PR TITLE
[POA-2570] Remove quotes around EXTRA_APIDUMP_ARGS

### DIFF
--- a/cmd/internal/ec2/postman-insights-agent.service.tmpl
+++ b/cmd/internal/ec2/postman-insights-agent.service.tmpl
@@ -6,9 +6,9 @@ After=network-online.target NetworkManager.service systemd-resolved.service
 [Service]
 EnvironmentFile=/etc/default/postman-insights-agent
 # DO NOT CHANGE
-# "${FOO}" uses the arguement as is, while "$FOO" splits the string on white space 
+# "${FOO}" uses the argument as is, while "$FOO" splits the string on white space 
 # Reference: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Command%20lines
-ExecStart={{.AgentInstallPath}} apidump --project "${PROJECT_ID}" --interfaces "${INTERFACES}" --filter "${FILTER}" {{.ExtraApidumpArgs}} "${EXTRA_APIDUMP_ARGS}"
+ExecStart={{.AgentInstallPath}} apidump --project "${PROJECT_ID}" --interfaces "${INTERFACES}" --filter "${FILTER}" {{.ExtraApidumpArgs}} ${EXTRA_APIDUMP_ARGS}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
`ExecStart={{.AgentInstallPath}} apidump --project "${PROJECT_ID}" --interfaces "${INTERFACES}" --filter "${FILTER}" {{.ExtraApidumpArgs}} "${EXTRA_APIDUMP_ARGS}"`

In the above command, if `EXTRA_APIDUMP_ARGS` env var is empty, then apidump will interpret it as quotes (`""`), which will error out with message `[ERROR] accepts 0 arg(s), received 1`.

Remove the quotes surrounding the environment command.