### PR TITLE
[POA-2701] Add --repro-mode flag

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -139,8 +139,8 @@ type Args struct {
 	// The port to be used by the Docker Extension for health checks
 	HealthCheckPort int
 
-	// Whether to include request/response payloads when uploading witnesses.
-	SendWitnessPayloads bool
+	// Whether to enable repro mode and include request/response payloads when uploading witnesses.
+	ReproMode bool
 }
 
 // TODO: either remove write-to-local-HAR-file completely,
@@ -689,7 +689,7 @@ func (a *apidump) Run() error {
 			} else {
 				var backendCollector trace.Collector
 				if args.Out.AkitaURI != nil {
-					backendCollector = trace.NewBackendCollector(a.backendSvc, backendLrn, a.learnClient, optionals.Some(a.MaxWitnessSize_bytes), summary, args.SendWitnessPayloads, args.Plugins)
+					backendCollector = trace.NewBackendCollector(a.backendSvc, backendLrn, a.learnClient, optionals.Some(a.MaxWitnessSize_bytes), summary, args.ReproMode, args.Plugins)
 					collector = backendCollector
 				} else {
 					return errors.Errorf("invalid output location")

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -220,7 +220,9 @@ func apidumpRunInternal(cmd *cobra.Command, _ []string) error {
 		MaxWitnessSize_bytes:    maxWitnessSize_bytes,
 		DockerExtensionMode:     dockerExtensionMode,
 		HealthCheckPort:         healthCheckPort,
-		SendWitnessPayloads:     commonApidumpFlags.SendWitnessPayloads,
+
+		// TODO: remove the SendWitnessPayloads flag once all existing users are migrated to new flag.
+		ReproMode: commonApidumpFlags.EnableReproMode || commonApidumpFlags.SendWitnessPayloads,
 	}
 	if err := apidump.Run(args); err != nil {
 		return cmderr.AkitaErr{Err: err}

--- a/cmd/internal/apidump/common_flags.go
+++ b/cmd/internal/apidump/common_flags.go
@@ -92,7 +92,7 @@ func AddCommonApiDumpFlags(cmd *cobra.Command) *CommonApidumpFlags {
 		&flags.EnableReproMode,
 		"repro-mode",
 		false,
-		"Enable repro mode to send request and response payloads to Postman",
+		"Enable repro mode to send request and response payloads to Postman.",
 	)
 
 	return flags

--- a/cmd/internal/apidump/common_flags.go
+++ b/cmd/internal/apidump/common_flags.go
@@ -94,6 +94,7 @@ func AddCommonApiDumpFlags(cmd *cobra.Command) *CommonApidumpFlags {
 		false,
 		"Enable repro mode to send request and response payloads to Postman.",
 	)
+	_ = cmd.PersistentFlags().MarkHidden("repro-mode")
 
 	return flags
 }

--- a/cmd/internal/apidump/common_flags.go
+++ b/cmd/internal/apidump/common_flags.go
@@ -17,6 +17,7 @@ type CommonApidumpFlags struct {
 	RandomizedStart     int
 	RateLimit           float64
 	SendWitnessPayloads bool
+	EnableReproMode     bool
 }
 
 func AddCommonApiDumpFlags(cmd *cobra.Command) *CommonApidumpFlags {
@@ -87,6 +88,13 @@ func AddCommonApiDumpFlags(cmd *cobra.Command) *CommonApidumpFlags {
 	)
 	_ = cmd.PersistentFlags().MarkHidden("send-witness-payloads")
 
+	cmd.PersistentFlags().BoolVar(
+		&flags.EnableReproMode,
+		"repro-mode",
+		false,
+		"Enable repro mode to send request and response payloads to Postman",
+	)
+
 	return flags
 }
 
@@ -107,6 +115,10 @@ func ConvertCommonApiDumpFlagsToArgs(flags *CommonApidumpFlags) []string {
 
 	if flags.SendWitnessPayloads {
 		commonApidumpArgs = append(commonApidumpArgs, "--send-witness-payloads")
+	}
+
+	if flags.EnableReproMode {
+		commonApidumpArgs = append(commonApidumpArgs, "--repro-mode")
 	}
 
 	// Add slice type flags to the entry point.


### PR DESCRIPTION
* Added a new flag, `--repro-mode`, which is the equivalent to `--send-witness-payload` flag.
* The `--send-witness-payload` flag will be removed in the future.
* Renamed variables wherever possible. However, the variable name was not changed in `backend_collection.go` because `sendWitnessPayloads` is more appropriate there, as it better reflects its functionality.