### PR TITLE
[POA-2766] Send accurate duration in initial and success telemetry

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -214,7 +214,7 @@ func (a *apidump) SendInitialTelemetry() {
 	req := kgxapi.PostInitialClientTelemetryRequest{
 		ClientID:                  a.ClientID,
 		ObservedStartingAt:        a.startTime,
-		ObservedDurationInSeconds: a.TelemetryInterval,
+		ObservedDurationInSeconds: 0,
 		SendsWitnessPayloads:      a.ReproMode,
 		CLIVersion:                version.ReleaseVersion().String(),
 		CLITargetArch:             architecture.GetCanonicalArch(),
@@ -438,7 +438,8 @@ func (a *apidump) TelemetryWorker(done <-chan struct{}) {
 				subsequentTelemetrySent = true
 			case <-a.successTelemetry.Channel:
 				if !subsequentTelemetrySent {
-					a.SendPacketTelemetry(a.TelemetryInterval)
+					duration := int(time.Since(a.startTime) / time.Second)
+					a.SendPacketTelemetry(duration)
 				}
 			}
 		}


### PR DESCRIPTION
A follow-up PR from https://github.com/postmanlabs/postman-insights-agent/pull/65#discussion_r1938541053

NOTE: Do not merge before https://github.com/postman-eng/observability-superstar-service/pull/2256 is released all the way through to PRODUCTION