### PR TITLE
[POA-2780] Refactor rest client to handle multiple auth ways

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -142,7 +142,7 @@ type Args struct {
 	// Args for running apidump as daemonset in Kubernetes
 	TargetNetworkNamespaceOpt optionals.Optional[string]
 	StopChan                  <-chan error
-	PodName                   string
+	PodName                   optionals.Optional[string]
 }
 
 // TODO: either remove write-to-local-HAR-file completely,
@@ -183,8 +183,8 @@ func (a *apidump) LookupService() error {
 		return nil
 	}
 	var frontClient rest.FrontClient
-	if a.PodName != "" {
-		frontClient = rest.NewFrontClientForDaemonset(a.Domain, a.ClientID, a.PodName)
+	if podName, exists := a.PodName.Get(); exists {
+		frontClient = rest.NewFrontClientForDaemonset(a.Domain, a.ClientID, podName)
 	} else {
 		frontClient = rest.NewFrontClient(a.Domain, a.ClientID)
 	}
@@ -207,11 +207,9 @@ func (a *apidump) LookupService() error {
 		a.backendSvcName = serviceName
 	}
 
-	if a.PodName != "" {
-		frontClient = rest.NewFrontClientForDaemonset(a.Domain, a.ClientID, a.PodName)
-		a.learnClient = rest.NewLearnClientForDaemonset(a.Domain, a.ClientID, a.backendSvc, a.PodName)
+	if podName, exists := a.PodName.Get(); exists {
+		a.learnClient = rest.NewLearnClientForDaemonset(a.Domain, a.ClientID, a.backendSvc, podName)
 	} else {
-		frontClient = rest.NewFrontClient(a.Domain, a.ClientID)
 		a.learnClient = rest.NewLearnClient(a.Domain, a.ClientID, a.backendSvc)
 	}
 	return nil

--- a/cfg/credentials.go
+++ b/cfg/credentials.go
@@ -146,3 +146,28 @@ func DistinctIDFromCredentials() string {
 func GetPostmanInsightsVerificationToken() string {
 	return creds.GetString("default.postman_insights_verification_token")
 }
+
+// Sets Postman API Key and environment in the config
+// with pod name as profile
+func SetPodPostmanAPIKeyAndEnvironment(podName, postmanAPIKey, postmanEnv string) error {
+	if postmanAPIKey == "" {
+		return errors.New("Postman API key is empty")
+	} else {
+		creds.Set(podName+".postman_api_key", postmanAPIKey)
+	}
+
+	if postmanEnv != "" {
+		creds.Set(podName+".postman_env", postmanEnv)
+	}
+	return nil
+}
+
+// Get Postman API Key and environment from config for given pod name
+func GetPodPostmanAPIKeyAndEnvironment(podName string) (string, string) {
+	return creds.GetString(podName + ".postman_api_key"), creds.GetString(podName + ".postman_env")
+}
+
+func UnsetPodPostmanAPIKeyAndEnvironment(podName string) {
+	creds.Set(podName+".postman_api_key", nil)
+	creds.Set(podName+".postman_env", nil)
+}

--- a/cfg/credentials.go
+++ b/cfg/credentials.go
@@ -71,8 +71,6 @@ func initCreds() {
 	creds.BindEnv("default.postman_api_key", "POSTMAN_API_KEY")
 	creds.BindEnv("default.postman_env", "POSTMAN_ENV")
 
-	creds.BindEnv("default.postman_insights_verification_token", "POSTMAN_INSIGHTS_VERIFICATION_TOKEN")
-
 	if err := creds.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			// Ignore config file not found error since the config may be set by
@@ -140,34 +138,4 @@ func CredentialsPresent() bool {
 func DistinctIDFromCredentials() string {
 	key, _ := GetAPIKeyAndSecret()
 	return key
-}
-
-// Get Postman team verification token from config
-func GetPostmanInsightsVerificationToken() string {
-	return creds.GetString("default.postman_insights_verification_token")
-}
-
-// Sets Postman API Key and environment in the config
-// with pod name as profile
-func SetPodPostmanAPIKeyAndEnvironment(podName, postmanAPIKey, postmanEnv string) error {
-	if postmanAPIKey == "" {
-		return errors.New("Postman API key is empty")
-	} else {
-		creds.Set(podName+".postman_api_key", postmanAPIKey)
-	}
-
-	if postmanEnv != "" {
-		creds.Set(podName+".postman_env", postmanEnv)
-	}
-	return nil
-}
-
-// Get Postman API Key and environment from config for given pod name
-func GetPodPostmanAPIKeyAndEnvironment(podName string) (string, string) {
-	return creds.GetString(podName + ".postman_api_key"), creds.GetString(podName + ".postman_env")
-}
-
-func UnsetPodPostmanAPIKeyAndEnvironment(podName string) {
-	creds.Set(podName+".postman_api_key", nil)
-	creds.Set(podName+".postman_env", nil)
 }

--- a/cmd/internal/cmderr/checks.go
+++ b/cmd/internal/cmderr/checks.go
@@ -42,7 +42,7 @@ func CheckAPIKeyAndInsightsProjectID(projectID string) error {
 		return errors.New("project ID is missing, it must be specified")
 	}
 
-	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID())
+	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID(), nil)
 	var serviceID akid.ServiceID
 	err = akid.ParseIDAs(projectID, &serviceID)
 	if err != nil {

--- a/cmd/internal/kube/daemonset/daemonset.go
+++ b/cmd/internal/kube/daemonset/daemonset.go
@@ -160,7 +160,7 @@ func (d *Daemonset) StartApiDumpProcess(podArgs PodArgs, podCreds PodCreds) erro
 		TargetNetworkNamespaceOpt: optionals.Some(networkNamespace),
 		ReproMode:                 podArgs.InsightsReproModeEnabled,
 		StopChan:                  stopChan,
-		PodName:                   podArgs.PodName,
+		PodName:                   optionals.Some(podArgs.PodName),
 	}
 
 	// Put the process stop channel map and start the process in separate go routine

--- a/cmd/internal/kube/daemonset/daemonset.go
+++ b/cmd/internal/kube/daemonset/daemonset.go
@@ -166,7 +166,7 @@ func (d *Daemonset) checkPodsHealth() {
 		if podStatus == string(coreV1.PodSucceeded) || podStatus == string(coreV1.PodFailed) {
 			printer.Infof("pod %s has stopped running", podStatus)
 			d.StopApiDumpProcess(
-				podStatus,
+				podName,
 				fmt.Errorf("pod %s has stopped running, status: %s", podName, podStatus),
 			)
 		}
@@ -193,7 +193,8 @@ func (d *Daemonset) PodsHealthWorker(done <-chan struct{}) {
 func (d *Daemonset) StartApiDumpProcess(podArgs PodArgs, podCreds PodCreds) error {
 	networkNamespace, err := d.CRIClient.GetNetworkNamespace(podArgs.ContainerUUID)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get network namespace for pod/containerUUID: %s/%s", podArgs.PodName, podArgs.ContainerUUID)
+		return errors.Wrapf(err, "failed to get network namespace for pod/containerUUID: %s/%s",
+			podArgs.PodName, podArgs.ContainerUUID)
 	}
 
 	// Channel to stop the API dump process

--- a/cmd/internal/kube/daemonset/daemonset.go
+++ b/cmd/internal/kube/daemonset/daemonset.go
@@ -248,7 +248,10 @@ func (d *Daemonset) checkPodsHealth() {
 			}
 
 			isSameStage, err := podArgs.validatePodTrafficMonitorStage(PodTerminated, TrafficMonitoringStarted)
-			if isSameStage || err != nil {
+			if err != nil {
+				printer.Errorf("pod %s is in invalid state %d", podName, podArgs.PodTrafficMonitorStage)
+			}
+			if isSameStage {
 				printer.Errorf("pod %s is already in state %d", podName, podArgs.PodTrafficMonitorStage)
 			}
 

--- a/cmd/internal/kube/inject.go
+++ b/cmd/internal/kube/inject.go
@@ -184,7 +184,7 @@ func lookupService(insightsProjectID string) error {
 		return fmt.Errorf("Can't parse %q as project ID.", insightsProjectID)
 	}
 
-	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID())
+	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID(), nil)
 
 	_, err = util.GetServiceNameByServiceID(frontClient, serviceID)
 	return err

--- a/cmd/internal/legacy/specs.go
+++ b/cmd/internal/legacy/specs.go
@@ -117,7 +117,7 @@ func runGetSpec(specIdentifier string) error {
 
 	clientID := akid.GenerateClientID()
 
-	frontClient := rest.NewFrontClient(rest.Domain, clientID)
+	frontClient := rest.NewFrontClient(rest.Domain, clientID, nil)
 
 	// Convert service name to service ID.
 	serviceID, err := getServiceIDByName(frontClient, getSpecServiceFlag)
@@ -125,7 +125,7 @@ func runGetSpec(specIdentifier string) error {
 		return err
 	}
 
-	learnClient := rest.NewLearnClient(rest.Domain, clientID, serviceID)
+	learnClient := rest.NewLearnClient(rest.Domain, clientID, serviceID, nil)
 
 	// Check to see if the user specified an AkID or a version name.
 	var specID akid.APISpecID

--- a/integrations/nginx/backend.go
+++ b/integrations/nginx/backend.go
@@ -159,13 +159,13 @@ func NewNginxBackend(args *Args) (*NginxBackend, error) {
 		startTime:  time.Now(),
 	}
 
-	frontClient := rest.NewFrontClient(args.Domain, args.ClientID)
+	frontClient := rest.NewFrontClient(args.Domain, args.ClientID, nil)
 	backendSvc, err := util.GetServiceIDByName(frontClient, args.ServiceName)
 	if err != nil {
 		return nil, err
 	}
 	b.backendSvc = backendSvc
-	b.learnClient = rest.NewLearnClient(args.Domain, args.ClientID, backendSvc)
+	b.learnClient = rest.NewLearnClient(args.Domain, args.ClientID, backendSvc, nil)
 
 	traceTags := map[tags.Key]string{
 		tags.XAkitaSource: "nginx",

--- a/rest/auth_handlers.go
+++ b/rest/auth_handlers.go
@@ -9,7 +9,6 @@ import (
 
 func baseAuthHandler(req *http.Request) error {
 	postmanAPIKey, postmanEnv := cfg.GetPostmanAPIKeyAndEnvironment()
-	postmanInsightsVerificationToken := cfg.GetPostmanInsightsVerificationToken()
 
 	if postmanAPIKey != "" {
 		// Set postman API key as header
@@ -19,9 +18,6 @@ func baseAuthHandler(req *http.Request) error {
 		if postmanEnv != "" {
 			req.Header.Set("x-postman-env", postmanEnv)
 		}
-	} else if postmanInsightsVerificationToken != "" {
-		// Set postman team verification token as header
-		req.Header.Set("postman-insights-verification-token ", postmanInsightsVerificationToken)
 	} else {
 		// XXX Integration tests still use Akita API keys.
 		apiKeyID, apiKeySecret := cfg.GetAPIKeyAndSecret()
@@ -40,9 +36,7 @@ func baseAuthHandler(req *http.Request) error {
 	return nil
 }
 
-func daemonsetAuthHandler(podName string) func(*http.Request) error {
-	postmanAPIKey, postmanEnv := cfg.GetPodPostmanAPIKeyAndEnvironment(podName)
-
+func ApiDumpDaemonsetAuthHandler(postmanAPIKey string, postmanEnv string) func(*http.Request) error {
 	return func(req *http.Request) error {
 		if postmanAPIKey == "" {
 			return errors.New("Postman API key is empty")
@@ -52,6 +46,16 @@ func daemonsetAuthHandler(podName string) func(*http.Request) error {
 		if postmanEnv != "" {
 			req.Header.Set("x-postman-env", postmanEnv)
 		}
+		return nil
+	}
+}
+
+func DaemonsetAuthHandler(postmanInsightsVerificationToken string) func(*http.Request) error {
+	return func(req *http.Request) error {
+		if postmanInsightsVerificationToken == "" {
+			return errors.New("Postman Insights verification token is empty")
+		}
+		req.Header.Set("postman-insights-verification-token", postmanInsightsVerificationToken)
 		return nil
 	}
 }

--- a/rest/auth_handlers.go
+++ b/rest/auth_handlers.go
@@ -1,0 +1,57 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/cfg"
+)
+
+func baseAuthHandler(req *http.Request) error {
+	postmanAPIKey, postmanEnv := cfg.GetPostmanAPIKeyAndEnvironment()
+	postmanInsightsVerificationToken := cfg.GetPostmanInsightsVerificationToken()
+
+	if postmanAPIKey != "" {
+		// Set postman API key as header
+		req.Header.Set("x-api-key", postmanAPIKey)
+
+		// Set postman env header if it exists
+		if postmanEnv != "" {
+			req.Header.Set("x-postman-env", postmanEnv)
+		}
+	} else if postmanInsightsVerificationToken != "" {
+		// Set postman team verification token as header
+		req.Header.Set("postman-insights-verification-token ", postmanInsightsVerificationToken)
+	} else {
+		// XXX Integration tests still use Akita API keys.
+		apiKeyID, apiKeySecret := cfg.GetAPIKeyAndSecret()
+
+		if apiKeyID == "" {
+			return errors.New(`Missing or incomplete credentials. Ensure the POSTMAN_API_KEY environment variable has a valid API key for Postman.`)
+		}
+
+		if apiKeySecret == "" {
+			return errors.New(`Akita API key secret not found, run "login" or use AKITA_API_KEY_SECRET environment variable. If using with Postman, ensure the POSTMAN_API_KEY environment variable has a valid API key for Postman.`)
+		}
+
+		req.SetBasicAuth(apiKeyID, apiKeySecret)
+	}
+
+	return nil
+}
+
+func daemonsetAuthHandler(podName string) func(*http.Request) error {
+	postmanAPIKey, postmanEnv := cfg.GetPodPostmanAPIKeyAndEnvironment(podName)
+
+	return func(req *http.Request) error {
+		if postmanAPIKey == "" {
+			return errors.New("Postman API key is empty")
+		}
+		req.Header.Set("x-api-key", postmanAPIKey)
+
+		if postmanEnv != "" {
+			req.Header.Set("x-postman-env", postmanEnv)
+		}
+		return nil
+	}
+}

--- a/rest/auth_handlers.go
+++ b/rest/auth_handlers.go
@@ -7,6 +7,9 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/cfg"
 )
 
+// baseAuthHandler is the default auth handler for all requests.
+// It uses PostmanAPIKey from the config to authenticate the request,
+// and fallbacks to the Akita API key if PostmanAPIKey is not set.
 func baseAuthHandler(req *http.Request) error {
 	postmanAPIKey, postmanEnv := cfg.GetPostmanAPIKeyAndEnvironment()
 
@@ -36,6 +39,9 @@ func baseAuthHandler(req *http.Request) error {
 	return nil
 }
 
+// ApiDumpDaemonsetAuthandler is used by the apidump functions if it is started
+// by the kube daemonSet process. It excepts the postmanAPIKey and postmanEnv
+// as arguments instead of reading it from the config.
 func ApiDumpDaemonsetAuthHandler(postmanAPIKey string, postmanEnv string) func(*http.Request) error {
 	return func(req *http.Request) error {
 		if postmanAPIKey == "" {
@@ -50,6 +56,8 @@ func ApiDumpDaemonsetAuthHandler(postmanAPIKey string, postmanEnv string) func(*
 	}
 }
 
+// DaemonsetAuthHandler is used by the daemonset process to authenticate the telemetry requests.
+// it uses the postmanInsightsVerificationToken to authenticate the request.
 func DaemonsetAuthHandler(postmanInsightsVerificationToken string) func(*http.Request) error {
 	return func(req *http.Request) error {
 		if postmanInsightsVerificationToken == "" {

--- a/rest/front_client.go
+++ b/rest/front_client.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"context"
+	"net/http"
 	"path"
 
 	"github.com/akitasoftware/akita-libs/akid"
@@ -13,17 +14,11 @@ type frontClientImpl struct {
 	BaseClient
 }
 
-func NewFrontClientForDaemonset(host string, cli akid.ClientID, podName string) *frontClientImpl {
-	return &frontClientImpl{
-		BaseClient: NewBaseClient(host, cli, daemonsetAuthHandler(podName)),
-	}
-}
-
 var _ FrontClient = (*frontClientImpl)(nil)
 
-func NewFrontClient(host string, cli akid.ClientID) *frontClientImpl {
+func NewFrontClient(host string, cli akid.ClientID, authHandler func(*http.Request) error) *frontClientImpl {
 	return &frontClientImpl{
-		BaseClient: NewBaseClient(host, cli, nil),
+		BaseClient: NewBaseClient(host, cli, authHandler),
 	}
 }
 

--- a/rest/front_client.go
+++ b/rest/front_client.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"context"
+	"net/http"
 	"path"
 
 	"github.com/akitasoftware/akita-libs/akid"
@@ -12,9 +13,22 @@ type frontClientImpl struct {
 	BaseClient
 }
 
+func NewFrontClientForDaemonset(host string, cli akid.ClientID, podName string) *frontClientImpl {
+	var authHandler func(*http.Request) error
+	if podName != "" {
+		authHandler = daemonsetAuthHandler(podName)
+	}
+
+	return &frontClientImpl{
+		BaseClient: NewBaseClient(host, cli, authHandler),
+	}
+}
+
+var _ FrontClient = (*frontClientImpl)(nil)
+
 func NewFrontClient(host string, cli akid.ClientID) *frontClientImpl {
 	return &frontClientImpl{
-		BaseClient: NewBaseClient(host, cli),
+		BaseClient: NewBaseClient(host, cli, nil),
 	}
 }
 

--- a/rest/front_client.go
+++ b/rest/front_client.go
@@ -2,7 +2,6 @@ package rest
 
 import (
 	"context"
-	"net/http"
 	"path"
 
 	"github.com/akitasoftware/akita-libs/akid"
@@ -15,13 +14,8 @@ type frontClientImpl struct {
 }
 
 func NewFrontClientForDaemonset(host string, cli akid.ClientID, podName string) *frontClientImpl {
-	var authHandler func(*http.Request) error
-	if podName != "" {
-		authHandler = daemonsetAuthHandler(podName)
-	}
-
 	return &frontClientImpl{
-		BaseClient: NewBaseClient(host, cli, authHandler),
+		BaseClient: NewBaseClient(host, cli, daemonsetAuthHandler(podName)),
 	}
 }
 

--- a/rest/http.go
+++ b/rest/http.go
@@ -13,7 +13,6 @@ import (
 	"github.com/akitasoftware/akita-libs/spec_util"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
-	"github.com/postmanlabs/postman-insights-agent/cfg"
 	"github.com/postmanlabs/postman-insights-agent/consts"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/postmanlabs/postman-insights-agent/version"
@@ -108,7 +107,7 @@ func initHTTPClient() {
 	HTTPClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
 }
 
-func sendRequest(ctx context.Context, req *http.Request) ([]byte, error) {
+func sendRequest(ctx context.Context, req *http.Request, authHandler func(*http.Request) error) ([]byte, error) {
 	initHTTPClientOnce.Do(initHTTPClient)
 
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
@@ -117,33 +116,10 @@ func sendRequest(ctx context.Context, req *http.Request) ([]byte, error) {
 		ctx = c
 	}
 
-	postmanAPIKey, postmanEnv := cfg.GetPostmanAPIKeyAndEnvironment()
-	postmanInsightsVerificationToken := cfg.GetPostmanInsightsVerificationToken()
-
-	if postmanAPIKey != "" {
-		// Set postman API key as header
-		req.Header.Set("x-api-key", postmanAPIKey)
-
-		// Set postman env header if it exists
-		if postmanEnv != "" {
-			req.Header.Set("x-postman-env", postmanEnv)
-		}
-	} else if postmanInsightsVerificationToken != "" {
-		// Set postman team verification token as header
-		req.Header.Set("postman-insights-verification-token ", postmanInsightsVerificationToken)
-	} else {
-		// XXX Integration tests still use Akita API keys.
-		apiKeyID, apiKeySecret := cfg.GetAPIKeyAndSecret()
-
-		if apiKeyID == "" {
-			return nil, errors.New(`Missing or incomplete credentials. Ensure the POSTMAN_API_KEY environment variable has a valid API key for Postman.`)
-		}
-
-		if apiKeySecret == "" {
-			return nil, errors.New(`Akita API key secret not found, run "login" or use AKITA_API_KEY_SECRET environment variable. If using with Postman, ensure the POSTMAN_API_KEY environment variable has a valid API key for Postman.`)
-		}
-
-		req.SetBasicAuth(apiKeyID, apiKeySecret)
+	// Apply authentication headers.
+	err := authHandler(req)
+	if err != nil {
+		return nil, err
 	}
 
 	req.Header.Set("user-agent", GetUserAgent())

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"path"
 	"strconv"
@@ -22,16 +23,9 @@ type learnClientImpl struct {
 
 var _ LearnClient = (*learnClientImpl)(nil)
 
-func NewLearnClientForDaemonset(host string, cli akid.ClientID, svc akid.ServiceID, podName string) *learnClientImpl {
+func NewLearnClient(host string, cli akid.ClientID, svc akid.ServiceID, authHandler func(*http.Request) error) *learnClientImpl {
 	return &learnClientImpl{
-		BaseClient: NewBaseClient(host, cli, daemonsetAuthHandler(podName)),
-		serviceID:  svc,
-	}
-}
-
-func NewLearnClient(host string, cli akid.ClientID, svc akid.ServiceID) *learnClientImpl {
-	return &learnClientImpl{
-		BaseClient: NewBaseClient(host, cli, nil),
+		BaseClient: NewBaseClient(host, cli, authHandler),
 		serviceID:  svc,
 	}
 }

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"path"
 	"strconv"
@@ -28,9 +29,21 @@ type learnClientImpl struct {
 
 var _ LearnClient = (*learnClientImpl)(nil)
 
+func NewLearnClientForDaemonset(host string, cli akid.ClientID, svc akid.ServiceID, podName string) *learnClientImpl {
+	var authHandler func(*http.Request) error
+	if podName != "" {
+		authHandler = daemonsetAuthHandler(podName)
+	}
+
+	return &learnClientImpl{
+		BaseClient: NewBaseClient(host, cli, authHandler),
+		serviceID:  svc,
+	}
+}
+
 func NewLearnClient(host string, cli akid.ClientID, svc akid.ServiceID) *learnClientImpl {
 	return &learnClientImpl{
-		BaseClient: NewBaseClient(host, cli),
+		BaseClient: NewBaseClient(host, cli, nil),
 		serviceID:  svc,
 	}
 }

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -3,22 +3,15 @@ package rest
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 	"path"
 	"strconv"
 	"time"
 
 	"github.com/akitasoftware/akita-libs/akid"
-	"github.com/akitasoftware/akita-libs/api_schema"
 	kgxapi "github.com/akitasoftware/akita-libs/api_schema"
 	"github.com/akitasoftware/akita-libs/path_trie"
 	"github.com/akitasoftware/akita-libs/tags"
-)
-
-var (
-	// Value that will be marshalled into an empty JSON object.
-	emptyObject = map[string]interface{}{}
 )
 
 type learnClientImpl struct {
@@ -30,13 +23,8 @@ type learnClientImpl struct {
 var _ LearnClient = (*learnClientImpl)(nil)
 
 func NewLearnClientForDaemonset(host string, cli akid.ClientID, svc akid.ServiceID, podName string) *learnClientImpl {
-	var authHandler func(*http.Request) error
-	if podName != "" {
-		authHandler = daemonsetAuthHandler(podName)
-	}
-
 	return &learnClientImpl{
-		BaseClient: NewBaseClient(host, cli, authHandler),
+		BaseClient: NewBaseClient(host, cli, daemonsetAuthHandler(podName)),
 		serviceID:  svc,
 	}
 }
@@ -268,7 +256,7 @@ func (c *learnClientImpl) GetTimeline(ctx context.Context, serviceID akid.Servic
 	q.Add("key", "method")
 	q.Add("key", "path")
 	q.Add("key", "code")
-	q.Add("aggregate", string(api_schema.Aggr_99p))
+	q.Add("aggregate", string(kgxapi.Aggr_99p))
 
 	var resp kgxapi.TimelineResponse
 	err := c.GetWithQuery(ctx, path, q, &resp)

--- a/setversion/run.go
+++ b/setversion/run.go
@@ -10,7 +10,7 @@ import (
 
 func Run(args Args) error {
 	// Resolve service ID.
-	frontClient := rest.NewFrontClient(args.Domain, args.ClientID)
+	frontClient := rest.NewFrontClient(args.Domain, args.ClientID, nil)
 	serviceName := args.ModelURI.ServiceName
 	serviceID, err := util.GetServiceIDByName(frontClient, serviceName)
 	if err != nil {
@@ -18,7 +18,7 @@ func Run(args Args) error {
 	}
 
 	// Resolve API model ID.
-	learnClient := rest.NewLearnClient(args.Domain, args.ClientID, serviceID)
+	learnClient := rest.NewLearnClient(args.Domain, args.ClientID, serviceID, nil)
 	modelID, err := util.ResolveSpecURI(learnClient, args.ModelURI)
 	if err != nil {
 		return err

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -165,7 +165,7 @@ func getUserIdentity() (string, string, error) {
 		// API key.
 		ctx, cancel := context.WithTimeout(context.Background(), userAPITimeout)
 		defer cancel()
-		frontClient := rest.NewFrontClient(rest.Domain, GetClientID())
+		frontClient := rest.NewFrontClient(rest.Domain, GetClientID(), nil)
 		userResponse, err := frontClient.GetUser(ctx)
 		if err == nil {
 			return fmt.Sprint(userResponse.ID), fmt.Sprint(userResponse.TeamID), nil

--- a/util/util.go
+++ b/util/util.go
@@ -42,7 +42,7 @@ var (
 )
 
 func NewLearnSession(domain string, clientID akid.ClientID, svc akid.ServiceID, sessionName string, tags map[tags.Key]string, baseSpecRef *kgxapi.APISpecReference) (akid.LearnSessionID, error) {
-	learnClient := rest.NewLearnClient(domain, clientID, svc)
+	learnClient := rest.NewLearnClient(domain, clientID, svc, nil)
 
 	// Create a new learn session.
 	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
@@ -314,13 +314,13 @@ func GetTraceURIByTags(domain string, clientID akid.ClientID, serviceName string
 
 	// Resolve ServiceID
 	// TODO: find a better way to overlap this with commands that already do the lookup
-	frontClient := rest.NewFrontClient(domain, clientID)
+	frontClient := rest.NewFrontClient(domain, clientID, nil)
 	serviceID, err := GetServiceIDByName(frontClient, serviceName)
 	if err != nil {
 		return akiuri.URI{}, errors.Wrapf(err, "failed to resolve project name %q", serviceName)
 	}
 
-	learnClient := rest.NewLearnClient(domain, clientID, serviceID)
+	learnClient := rest.NewLearnClient(domain, clientID, serviceID, nil)
 	learnSession, err := GetLearnSessionByTags(learnClient, serviceID, tags)
 	if err != nil {
 		return akiuri.URI{}, errors.Wrapf(err, "failed to list traces for %q", serviceName)


### PR DESCRIPTION
In this PR, we have done changes in the auth handling method of rest client and also handle API Keys for separate pods apidump process

* We will be storing the API keys in the viper config and use pod name as profile
* Refactored the rest client to receive the auth handler as the interface parameter
* Created 2 separate auth handlers. 1) for default flow 2) For new pod process flow
* In stopapidump process unset the required configs.