### PR TITLE
[POA-2713] Implement Run function

### DIFF
--- a/cmd/internal/kube/daemonset/apidump_process.go
+++ b/cmd/internal/kube/daemonset/apidump_process.go
@@ -1,0 +1,104 @@
+package daemonset
+
+import (
+	"runtime/debug"
+
+	"github.com/akitasoftware/go-utils/optionals"
+	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/apidump"
+	"github.com/postmanlabs/postman-insights-agent/printer"
+	"github.com/postmanlabs/postman-insights-agent/rest"
+	"github.com/postmanlabs/postman-insights-agent/telemetry"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (d *Daemonset) StartApiDumpProcess(podUID types.UID) error {
+	podArgs, err := d.getPodArgsFromMap(podUID)
+	if err != nil {
+		return err
+	}
+
+	err = podArgs.changePodTrafficMonitorState(TrafficMonitoringStarted, PodDetected, PodInitialized)
+	if err != nil {
+		return errors.Wrapf(err, "failed to change pod state, pod name: %s, from: %d to: %d",
+			podArgs.PodName, podArgs.PodTrafficMonitorState, TrafficMonitoringStopped)
+	}
+
+	go func() (funcErr error) {
+		// defer function handle the error (if any) in the apidump process and change the pod state accordingly
+		defer func() {
+			nextState := TrafficMonitoringEnded
+
+			if err := recover(); err != nil {
+				printer.Errorf("Panic occurred in apidump process for pod %s, err: %v\n%v\n",
+					podArgs.PodName, err, string(debug.Stack()))
+				nextState = TrafficMonitoringFailed
+			} else if funcErr != nil {
+				printer.Errorf("Error occurred in apidump process for pod %s, err: %v", podArgs.PodName, funcErr)
+				nextState = TrafficMonitoringFailed
+			} else {
+				printer.Infof("Apidump process ended for pod %s", podArgs.PodName)
+			}
+
+			err = podArgs.changePodTrafficMonitorState(nextState, TrafficMonitoringStarted)
+			if err != nil {
+				printer.Errorf("Failed to change pod state, pod name: %s, from: %d to: %d, error: %v",
+					podArgs.PodName, podArgs.PodTrafficMonitorState, nextState, err)
+				return
+			}
+
+			// It is possible that the apidump process is already stopped and the stopChannel is of no use
+			// This is just a safety check
+			err := d.StopApiDumpProcess(podUID, err)
+			if err != nil {
+				printer.Errorf("Failed to stop api dump process, pod name: %s, error: %v", podArgs.PodName, err)
+			}
+		}()
+
+		networkNamespace, err := d.CRIClient.GetNetworkNamespace(podArgs.ContainerUUID)
+		if err != nil {
+			funcErr = errors.Errorf("Failed to get network namespace for pod/containerUUID: %s/%s, err: %v",
+				podArgs.PodName, podArgs.ContainerUUID, err)
+			return
+		}
+
+		apidumpArgs := apidump.Args{
+			ClientID:  telemetry.GetClientID(),
+			Domain:    rest.Domain,
+			ServiceID: podArgs.InsightsProjectID,
+			ReproMode: d.InsightsReproModeEnabled,
+			DaemonsetArgs: optionals.Some(apidump.DaemonsetArgs{
+				TargetNetworkNamespaceOpt: networkNamespace,
+				StopChan:                  podArgs.StopChan,
+				APIKey:                    podArgs.PodCreds.InsightsAPIKey,
+				Environment:               podArgs.PodCreds.InsightsEnvironment,
+			}),
+		}
+
+		if err := apidump.Run(apidumpArgs); err != nil {
+			funcErr = errors.Wrapf(err, "Failed to run apidump process for pod %s", podArgs.PodName)
+		}
+		return
+	}()
+
+	return nil
+}
+
+func (d *Daemonset) StopApiDumpProcess(podUID types.UID, stopErr error) error {
+	podArgs, err := d.getPodArgsFromMap(podUID)
+	if err != nil {
+		return err
+	}
+
+	err = podArgs.changePodTrafficMonitorState(TrafficMonitoringStopped,
+		PodTerminated, TrafficMonitoringFailed, TrafficMonitoringEnded)
+	if err != nil {
+		return errors.Wrapf(err, "failed to change pod state, pod name: %s, from: %d to: %d",
+			podArgs.PodName, podArgs.PodTrafficMonitorState, TrafficMonitoringStopped)
+	}
+
+	printer.Infof("Stopping API dump process for pod %s", podArgs.PodName)
+	podArgs.StopChan <- stopErr
+
+	return nil
+}

--- a/cmd/internal/kube/daemonset/apidump_process.go
+++ b/cmd/internal/kube/daemonset/apidump_process.go
@@ -91,7 +91,7 @@ func (d *Daemonset) StopApiDumpProcess(podUID types.UID, stopErr error) error {
 	}
 
 	err = podArgs.changePodTrafficMonitorState(TrafficMonitoringStopped,
-		PodTerminated, TrafficMonitoringFailed, TrafficMonitoringEnded)
+		PodTerminated, DaemonSetShutdown, TrafficMonitoringFailed, TrafficMonitoringEnded)
 	if err != nil {
 		return errors.Wrapf(err, "failed to change pod state, pod name: %s, from: %d to: %d",
 			podArgs.PodName, podArgs.PodTrafficMonitorState, TrafficMonitoringStopped)

--- a/cmd/internal/kube/daemonset/pods_healthcheck_worker.go
+++ b/cmd/internal/kube/daemonset/pods_healthcheck_worker.go
@@ -1,0 +1,50 @@
+package daemonset
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/printer"
+	coreV1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (d *Daemonset) checkPodsHealth() {
+	printer.Debugf("Checking pods health, time: %s", time.Now().UTC())
+
+	var podUIDs []types.UID
+	d.PodArgsByNameMap.Range(func(k, _ interface{}) bool {
+		podUIDs = append(podUIDs, k.(types.UID))
+		return true
+	})
+
+	podStatuses, err := d.KubeClient.GetPodsStatusByUIDs(podUIDs)
+	if err != nil {
+		printer.Errorf("Failed to get pods status: %v", err)
+		return
+	}
+
+	for podUID, podStatus := range podStatuses {
+		if podStatus == coreV1.PodSucceeded || podStatus == coreV1.PodFailed {
+			printer.Infof("Pod %s has stopped running", podStatus)
+
+			podArgs, err := d.getPodArgsFromMap(podUID)
+			if err != nil {
+				printer.Errorf("Failed to get podArgs for podUID %s: %v", podUID, err)
+				continue
+			}
+
+			err = podArgs.changePodTrafficMonitorState(PodTerminated, TrafficMonitoringStarted)
+			if err != nil {
+				printer.Errorf("Failed to change pod state, pod name: %s, from: %d to: %d, error: %v",
+					podArgs.PodName, podArgs.PodTrafficMonitorState, PodTerminated, err)
+				continue
+			}
+
+			err = d.StopApiDumpProcess(podUID, errors.Errorf("pod %s has stopped running, status: %s", podArgs.PodName, podStatus))
+			if err != nil {
+				printer.Errorf("Failed to stop api dump process, pod name: %s, error: %v", podArgs.PodName, err)
+			}
+		}
+	}
+}

--- a/cmd/internal/kube/daemonset/telemetry.go
+++ b/cmd/internal/kube/daemonset/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/postmanlabs/postman-insights-agent/printer"
+	"github.com/spf13/viper"
 )
 
 func (d *Daemonset) sendTelemetry() {
@@ -17,4 +18,23 @@ func (d *Daemonset) sendTelemetry() {
 	if err != nil {
 		printer.Errorf("Failed to send telemetry: %v\n", err)
 	}
+}
+
+func (d *Daemonset) dumpPodsApiDumpProcessState() {
+	if !viper.GetBool("debug") {
+		return
+	}
+	logf := printer.Debugf
+
+	logf("========================================================\n")
+	logf("Pods active and their states:\n")
+	logf("%15v %15v %25v\n", "podName", "projectID", "currentState")
+	logf("========================================================\n")
+
+	d.PodArgsByNameMap.Range(func(_, v interface{}) bool {
+		podArgs := v.(*PodArgs)
+		logf("%15v %15v %25v\n", podArgs.PodName, podArgs.InsightsProjectID, podArgs.PodTrafficMonitorState)
+		return true
+	})
+	logf("========================================================\n")
 }

--- a/cmd/internal/kube/daemonset/telemetry.go
+++ b/cmd/internal/kube/daemonset/telemetry.go
@@ -1,0 +1,20 @@
+package daemonset
+
+import (
+	"context"
+	"time"
+
+	"github.com/postmanlabs/postman-insights-agent/printer"
+)
+
+func (d *Daemonset) sendTelemetry() {
+	printer.Debugf("Sending telemetry, time: %s", time.Now().UTC())
+
+	ctx, cancel := context.WithTimeout(context.Background(), apiContextTimeout)
+	defer cancel()
+
+	err := d.FrontClient.PostDaemonsetAgentTelemetry(ctx, d.ClusterName)
+	if err != nil {
+		printer.Errorf("Failed to send telemetry: %v\n", err)
+	}
+}


### PR DESCRIPTION
In this PR, we have implemented the main run function which will start all the workers.

* Start all the required workers
* Call the `StartProcessInExistingPods` function to check for existing pods
* Start listening to the interrupt signal to stop the process
* On interrupt signal workers to stop
* Stop running apidump processes
* Added 2 new functions
  * Dump the pod states on regular intervals if debug mode enabled
  * prune stopped processes from map
* Also moved some functions to their separate files