### PR TITLE
[POA-2904] Recover from closed channel panic in redactor

### DIFF
--- a/data_masks/redactor.go
+++ b/data_masks/redactor.go
@@ -111,6 +111,14 @@ func NewRedactor(
 }
 
 func (o *Redactor) StopPeriodicUpdates() {
+	// Handle the panic state when closing the already closed channel
+	// This will happen when apidump process is listening to multiple interfaces,
+	// since we are using same redactor instance for all the interfaces's collectors.
+	defer func() {
+		if err := recover(); err != nil {
+			printer.Debugf("Recovered from panic while closing redactor exit channel: %v\n", err)
+		}
+	}()
 	close(o.exitChannel)
 }
 


### PR DESCRIPTION
In this PR, we have fixed the bug which is causing the panic in the agent's apidump process while shutting down.

**Reason:** We are using the same redactor objects ([[1]](https://github.com/postmanlabs/postman-insights-agent/blob/main/apidump/apidump.go#L643-L646), [[2]](https://github.com/postmanlabs/postman-insights-agent/blob/main/apidump/apidump.go#L684-L693)) for multiple collectors of different network interfaces. Hence, while shutting down the collectors, we are calling `close()` for the same redactor multiple times, which is causing panic.

**Fix:** I have added a defer function in `StopPeriodicUpdates()` to catch the panic, log it and continue the normal flow.

**Other Options:**
1. Create separate redactor objects for each collector object
2. Use the `sync.Mutex()` and `closed` bool to close the channel in a sync manner.

Let me know if we have to go with other options, instead of catching the panic option.