### PR TITLE
[POA-2928] Cover corner case of pod not coming up at all

### DIFF
--- a/cmd/internal/kube/daemonset/telemetry.go
+++ b/cmd/internal/kube/daemonset/telemetry.go
@@ -27,7 +27,7 @@ func (d *Daemonset) sendTelemetry() {
 // dumpPodsApiDumpProcessState logs the current state of active pods.
 // It prints a formatted table with the pod name, project ID, and current state for each pod.
 func (d *Daemonset) dumpPodsApiDumpProcessState() {
-	logf := printer.Debugf
+	logf := printer.Infof
 
 	const hrBr = "================================================================================" +
 		"===========================================================================================\n"


### PR DESCRIPTION
I observed some corner cases in the beta environment, where some services are directly moving to the final state before going to the running state.
This could happen if there are some config issues like `CreateContainerConfigError`.

For example, here we got a Pod Delete event where the pod's status is still Pending.
```
[31m[ERROR] [0mPod status is in unknown state, pod name: cronjob-scheduled-work-29008098-8mgxh, status: Pending
[31m[ERROR] [0mFailed to change pod state, pod name: cronjob-scheduled-work-29008098-8mgxh, from: PodPending to: PodTerminated, error: Invalid current state for pod cronjob-scheduled-work-29008098-8mgxh: PodPending
```

For such corner cases, I have added an if condition, i.e., if a pod doesn't exist anymore, then move its state to `PodTerminated` irrespective of the previous state. This will then stop the apidump process (if it is still active) and remove it from map. This will remove the unnecessary garbage data in maps.