### PR TITLE
[POA-3041] Check all containers for env vars

### DIFF
--- a/cmd/internal/kube/daemonset/daemonset.go
+++ b/cmd/internal/kube/daemonset/daemonset.go
@@ -253,8 +253,6 @@ func (d *Daemonset) StartProcessInExistingPods() error {
 		err := d.inspectPodForEnvVars(pod, args)
 		if err != nil {
 			switch err {
-			case allRequiredEnvVarsAbsentErr:
-				printer.Debugf("None of the required env vars present, skipping pod: %s\n", pod.Name)
 			case requiredEnvVarMissingErr:
 				printer.Errorf("Required env var missing, skipping pod: %s\n", pod.Name)
 			default:

--- a/cmd/internal/kube/daemonset/daemonset.go
+++ b/cmd/internal/kube/daemonset/daemonset.go
@@ -252,9 +252,11 @@ func (d *Daemonset) StartProcessInExistingPods() error {
 		args := NewPodArgs(pod.Name)
 		err := d.inspectPodForEnvVars(pod, args)
 		if err != nil {
-			switch err {
-			case requiredEnvVarMissingErr:
-				printer.Errorf("Required env var missing, skipping pod: %s\n", pod.Name)
+			switch e := err.(type) {
+			case *allRequiredEnvVarsAbsentError:
+				printer.Debugf(e.Error())
+			case *requiredEnvVarMissingError:
+				printer.Errorf(e.Error())
 			default:
 				printer.Errorf("Failed to inspect pod for env vars, pod name: %s, error: %v\n", pod.Name, err)
 			}

--- a/integrations/kube_apis/kube_apis.go
+++ b/integrations/kube_apis/kube_apis.go
@@ -174,21 +174,23 @@ func (kc *KubeClient) FilterPodsByContainerImage(pods []coreV1.Pod, containerIma
 	return filteredPods, nil
 }
 
-// GetMainContainerUUID returns the UUID of the main container of a given pod
-func (kc *KubeClient) GetMainContainerUUID(pod coreV1.Pod) (string, error) {
-	if len(pod.Status.ContainerStatuses) > 0 {
-		containerID := pod.Status.ContainerStatuses[0].ContainerID
+// GetContainerUUIDs returns the UUIDs of all containers in a given pod
+func (kc *KubeClient) GetContainerUUIDs(pod coreV1.Pod) ([]string, error) {
+	var containerUUIDs []string
+
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		containerID := containerStatus.ContainerID
 
 		// Extract UUID from the container ID
 		parts := strings.Split(containerID, "://")
 		if len(parts) == 2 {
-			return parts[1], nil
+			containerUUIDs = append(containerUUIDs, parts[1])
 		} else {
-			return "", errors.Errorf("invalid container ID: %s", containerID)
+			printer.Debugf("invalid container ID: %s\n", containerID)
 		}
 	}
 
-	return "", errors.Errorf("no containers found for pod: %s", pod.Name)
+	return containerUUIDs, nil
 }
 
 // GetPodsStatus returns the statuses for list of pods

--- a/integrations/tests/kube_cri_apis/main.go
+++ b/integrations/tests/kube_cri_apis/main.go
@@ -91,13 +91,13 @@ func k8s_funcs(kubeClient kube_apis.KubeClient) (string, error) {
 	printer.Infof("Pod Status: %s\n", podStatuses)
 
 	// Get Main Container UUID
-	containerUUID, err := kubeClient.GetMainContainerUUID(pod)
+	containerUUIDs, err := kubeClient.GetContainerUUIDs(pod)
 	if err != nil {
 		return "", fmt.Errorf("failed to get main container UUID: %v", err)
 	}
-	printer.Infof("Main Container UUID: %s\n", containerUUID)
+	printer.Infof("Container UUIDs: %s\n", containerUUIDs)
 
-	return containerUUID, nil
+	return containerUUIDs[0], nil
 }
 
 func cri_funcs(containerUUID string) error {


### PR DESCRIPTION
This pull request fixes the bug where we consider the first container to be the main container and only check it for env vars. In some cases, like service mes, the main container won't be the first container.
So we will now check for environment variables in all containers and use the container that has all the required environment variables.


Changes:
* Removed the unused `allRequiredEnvVarsAbsentErr` error and its corresponding handling in `StartProcessInExistingPods` and `handlePodModifyEvent` methods
* Simplified the error message for `requiredEnvVarMissingErr` to "required environment variables missing" since it is not printed anywhere.
* Updated the `inspectPodForEnvVars` method to retrieve UUIDs for all containers in a pod instead of just the main container
* Replaced the `GetMainContainerUUID` method with `GetContainerUUIDs` to return UUIDs of all containers in a pod
* Modified the test function `k8s_funcs` to handle multiple container UUIDs and print them