### PR TITLE
[POA-2849] Add systemd restart for already running service in ec2

### DIFF
--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -269,6 +269,27 @@ func enablePostmanInsightsAgent() error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to run systemctl daemon-reload")
 	}
+
+	// systemctl get status of postman-insights-agent.service
+	cmd = exec.Command("systemctl", []string{"status", serviceFileName}...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to run systemctl status")
+	}
+
+	// If service is running then restart it
+	if strings.Contains(string(output), "Active: active (running)") {
+		printer.Infof("postman-insights-agent is already running as a systemd service\n")
+		printer.Infof("Restarting the service\n")
+
+		// systemctl restart postman-insights-agent.service
+		cmd = exec.Command("systemctl", []string{"restart", serviceFileName}...)
+		_, err = cmd.CombinedOutput()
+		if err != nil {
+			return errors.Wrapf(err, "failed to run systemctl restart")
+		}
+	}
+
 	// systemctl start postman-insights-agent.service
 	cmd = exec.Command("systemctl", []string{"enable", "--now", serviceFileName}...)
 	_, err = cmd.CombinedOutput()

--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -270,23 +270,22 @@ func enablePostmanInsightsAgent() error {
 		return errors.Wrapf(err, "failed to run systemctl daemon-reload")
 	}
 
-	// systemctl get status of postman-insights-agent.service
-	cmd = exec.Command("systemctl", []string{"status", serviceFileName}...)
+	// systemctl check if postman-insights-agent.service is active
+	cmd = exec.Command("systemctl", []string{"is-active", serviceFileName}...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return errors.Wrapf(err, "failed to run systemctl status")
-	}
-
-	// If service is running then restart it
-	if strings.Contains(string(output), "Active: active (running)") {
-		printer.Infof("postman-insights-agent is already running as a systemd service\n")
-		printer.Infof("Restarting the service\n")
+		printer.Infof("Postman Insights Agent is not running as a systemd service, status: %v\n", err)
+	} else if strings.Contains(string(output), "active") {
+		printer.Infof("Postman Insights Agent is already running as a systemd service\n")
+		printer.Infof("Restarting the service with new configurations\n")
 
 		// systemctl restart postman-insights-agent.service
 		cmd = exec.Command("systemctl", []string{"restart", serviceFileName}...)
 		_, err = cmd.CombinedOutput()
 		if err != nil {
-			return errors.Wrapf(err, "failed to run systemctl restart")
+			printer.Errorf("Failed to restart the service. Err: %v", err)
+			printer.Errorf("Please run the below command to restart the service\n")
+			printer.Errorf("systemctl restart postman-insights-agent\n")
 		}
 	}
 

--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -33,6 +33,9 @@ const (
 	enabled     = "enabled"                                                                                     // exit code: 0
 	disabled    = "disabled"                                                                                    // exit code: 1
 	nonExisting = "Failed to get unit file state for postman-insights-agent.service: No such file or directory" // exit code: 1
+
+	// Output of command: systemctl is-active postman-insights-agent
+	active = "active" // exit code: 0
 )
 
 var (
@@ -275,7 +278,7 @@ func enablePostmanInsightsAgent() error {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		printer.Infof("Postman Insights Agent is not running as a systemd service, status: %v\n", err)
-	} else if strings.Contains(string(output), "active") {
+	} else if strings.Contains(string(output), active) {
 		printer.Infof("Postman Insights Agent is already running as a systemd service\n")
 		printer.Infof("Restarting the service with new configurations\n")
 


### PR DESCRIPTION
This pull request includes changes to the `cmd/internal/ec2/add.go` file to enhance the handling of the `postman-insights-agent` service.

Enhancements to service handling:

* [`cmd/internal/ec2/add.go`](diffhunk://#diff-de4c0d4aa9b0bc2881e1a3420db0ab595602fc4d945fbad5383e1586cd62a8d5R36-R38): Added a new constant `active` to represent the active state of the `postman-insights-agent` service.
* [`cmd/internal/ec2/add.go`](diffhunk://#diff-de4c0d4aa9b0bc2881e1a3420db0ab595602fc4d945fbad5383e1586cd62a8d5R275-R294): Modified the `enablePostmanInsightsAgent` function to check if the `postman-insights-agent` service is active, and if so, restart it with the new configurations. This includes handling errors and providing informative messages to the user.