### PR TITLE
[POA-2246] Display warning when repro mode flag is used

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -143,12 +143,10 @@ func stopProfiling(cmd *cobra.Command, args []string) {
 
 func printFlagsWarning(cmd *cobra.Command) {
 	if enabled, err := cmd.Flags().GetBool("repro-mode"); err == nil && enabled {
-		warningMsg := "Turning on the %s flag enables the Postman Insights Agent to send payload data to the Postman cloud.\n\n" +
-			"The Postman Insights Agent will automatically redact values in a default list of sensitive fields, as well as any additionally specified fields.\n" +
-			"For more information, please see: %s.\n"
-		printer.Warningf(warningMsg,
-			printer.Color.Yellow("--repro-mode"),
-			printer.Color.Blue("https://postmanlabs.atlassian.net/wiki/spaces/PIIUG/pages/5513740658/Data+handling+and+access#When-Repro-Mode-is-enabled"))
+		util.PrintReproModeWarning("--repro-mode")
+	}
+	if enabled, err := cmd.Flags().GetBool("send-witness-payloads"); err == nil && enabled {
+		util.PrintReproModeWarning("--send-witness-payloads")
 	}
 
 	testingFlags := make(map[string]string)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,23 +42,21 @@ var (
 	logFormatFlag                       string
 )
 
-var (
-	rootCmd = &cobra.Command{
-		Use:           "postman-insights-agent",
-		Short:         "The Postman Insights Agent",
-		Long:          "Documentation is available at https://learning.postman.com/docs/insights/insights-early-access/",
-		Version:       version.CLIDisplayString(),
-		SilenceErrors: true, // We print our own errors from subcommands in Execute function
-		// Don't print usage after error, we only print help if we cannot parse
-		// flags. See init function below.
-		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
-		},
-		PersistentPreRun:  preRun,
-		PersistentPostRun: stopProfiling,
-	}
-)
+var rootCmd = &cobra.Command{
+	Use:           "postman-insights-agent",
+	Short:         "The Postman Insights Agent",
+	Long:          "Documentation is available at https://learning.postman.com/docs/insights/insights-early-access/",
+	Version:       version.CLIDisplayString(),
+	SilenceErrors: true, // We print our own errors from subcommands in Execute function
+	// Don't print usage after error, we only print help if we cannot parse
+	// flags. See init function below.
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+	PersistentPreRun:  preRun,
+	PersistentPostRun: stopProfiling,
+}
 
 func preRun(cmd *cobra.Command, args []string) {
 	// Decide on the domain name to use, _before_ initializing telemetry,
@@ -96,7 +94,7 @@ func preRun(cmd *cobra.Command, args []string) {
 
 	startProfiling(cmd, args)
 
-	printFlagsWarning()
+	printFlagsWarning(cmd)
 }
 
 func startProfiling(cmd *cobra.Command, args []string) {
@@ -143,7 +141,16 @@ func stopProfiling(cmd *cobra.Command, args []string) {
 	}
 }
 
-func printFlagsWarning() {
+func printFlagsWarning(cmd *cobra.Command) {
+	if enabled, err := cmd.Flags().GetBool("repro-mode"); err == nil && enabled {
+		warningMsg := "Turning on the %s flag enables the Postman Insights Agent to send payload data to the Postman cloud.\n\n" +
+			"The Postman Insights Agent will automatically redact values in a default list of sensitive fields, as well as any additionally specified fields.\n" +
+			"For more information, please see: %s.\n"
+		printer.Warningf(warningMsg,
+			printer.Color.Yellow("--repro-mode"),
+			printer.Color.Blue("https://postmanlabs.atlassian.net/wiki/spaces/PIIUG/pages/5513740658/Data+handling+and+access#When-Repro-Mode-is-enabled"))
+	}
+
 	testingFlags := make(map[string]string)
 
 	if testOnlyUseHTTPSFlag {

--- a/util/printWarningMsg.go
+++ b/util/printWarningMsg.go
@@ -36,3 +36,15 @@ func PrintFlagsWarning(warningFlags map[string]string) {
 	// Print new line
 	fmt.Printf("\n")
 }
+
+const reproModeMessage = `Turning on the %s flag enables the Postman Insights Agent to send payload data to the Postman cloud.
+
+The Postman Insights Agent will automatically redact values in a default list of sensitive fields, as well as any additionally specified fields.
+For more information, please see: %s.
+`
+
+func PrintReproModeWarning(flag string) {
+	printer.Warningf(reproModeMessage,
+		printer.Color.Yellow(flag),
+		printer.Color.Blue("https://postmanlabs.atlassian.net/wiki/spaces/PIIUG/pages/5513740658/Data+handling+and+access#When-Repro-Mode-is-enabled"))
+}


### PR DESCRIPTION
This change will display the following warning when the `--repro-mode` flag is set on a command that supports it:
```
[WARNING] Turning on the --repro-mode flag enbales the Postman Insights Agent to send payload data to the Postman cloud.

The Postman Insights Agent will automatically redact values in a default list of sensitive fields, as well as any additionally specified fields.
For more information, please see: https://postmanlabs.atlassian.net/wiki/spaces/PIIUG/pages/5513740658/Data+handling+and+access#When-Repro-Mode-is-enabled.
```

---
### Previews with various log formats
With `--log-format` set to `color`:
<img width="1172" alt="Screenshot 2025-03-13 at 2 23 15 PM" src="https://github.com/user-attachments/assets/96f8aad3-023c-45d5-a189-6691c6baadc8" />

With `--log-format` set to `plain`:
<img width="1172" alt="Screenshot 2025-03-13 at 2 24 54 PM" src="https://github.com/user-attachments/assets/2f88e456-0a8c-4245-87ba-27f2ae6f4121" />

With `--log-format` set to `json`:
<img width="1172" alt="Screenshot 2025-03-13 at 2 25 47 PM" src="https://github.com/user-attachments/assets/054ed581-3773-43c4-815f-d3b85d055c8b" />

---
### Manual tests
I manually verified, doesn't look like we have a test suite for this, that the warning is only shown on on commands that actually support the flag. For example, passing `--repro-mode` to `./bin/postman-insights-agent kube` or just `./bin/postman-insights-agent` will display an error:
```
[ERROR] unknown flag: --repro-mode
```