### PR TITLE
[POA-3218] Fill in pod names in initial telemetry.

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -241,6 +241,14 @@ func (a *apidump) SendInitialTelemetry() {
 		DockerDesktop:             env.HasDockerInternalHostAddress(),
 	}
 
+	if pod, present := a.Args.Tags[tags.XAkitaKubernetesPod]; present {
+		req.MonitoredPodName = pod
+		hostname, err := os.Hostname()
+		if err != nil {
+			req.AgentPodName = hostname
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), telemetryTimeout)
 	defer cancel()
 	err := a.learnClient.PostInitialClientTelemetry(ctx, a.backendSvc, req)


### PR DESCRIPTION
The daemonset (or an environment variable) uses tags on the learn session to identify the pod; this copies them into the telemetry as well.

Depends on https://github.com/postmanlabs/observability-shared-libs/pull/227 (won't compile until `go get` updated.)