### PR TITLE
[POA-2944] Add agent cpu and memory limits when running on ec2

### DIFF
--- a/cmd/internal/ec2/postman-insights-agent.service.tmpl
+++ b/cmd/internal/ec2/postman-insights-agent.service.tmpl
@@ -12,7 +12,7 @@ ExecStart={{.AgentInstallPath}} apidump --project "${PROJECT_ID}" --interfaces "
 
 # CPU resource controls
 CPUWeight=90       # lower relative CPU priority; default is 100. In case of contention main process will be prioritized.
-CPUQuota=85%       # aboslute CPU time limit (85% of CPU core). Process won't be able to take advantage of multi core.
+CPUQuota=50%       # aboslute CPU time limit (85% of CPU core). Process won't be able to take advantage of multi core.
 
 # Memory resource controls
 MemoryHigh=750M    # requested limit

--- a/cmd/internal/ec2/postman-insights-agent.service.tmpl
+++ b/cmd/internal/ec2/postman-insights-agent.service.tmpl
@@ -10,5 +10,18 @@ EnvironmentFile=/etc/default/postman-insights-agent
 # Reference: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Command%20lines
 ExecStart={{.AgentInstallPath}} apidump --project "${PROJECT_ID}" --interfaces "${INTERFACES}" --filter "${FILTER}" {{.ExtraApidumpArgs}} $EXTRA_APIDUMP_ARGS
 
+# CPU resource controls
+CPUWeight=90       # lower relative CPU priority; default is 100. In case of contention main process will be prioritized.
+CPUQuota=85%       # aboslute CPU time limit (85% of CPU core). Process won't be able to take advantage of multi core.
+
+# Memory resource controls
+MemoryHigh=750M    # requested limit
+MemoryMax=1G       # hard limit that triggers OOM kill if exceeded
+
+# Restart on OOMs
+Restart=on-failure
+RestartSec=10s
+
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Adds CPU and Memory limits to the postman insights service file.

Summary:
- Agent process CPU time will be prioritized lower than other services.
- Agent process will be restricted to 85% of a single CPU core.
- Agent process will be throttled by the OS if it exceeds 750MB of memory.
- Agent process will be OOM Killed if it exceeds 1GB of memory.
- Agent process will be restarted on failure.