### PR TITLE
Ensure agent exits if process receives SIGINT or SIGTERM signal

### DIFF
--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -18,6 +18,7 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 	"github.com/postmanlabs/postman-insights-agent/util"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -95,16 +96,18 @@ func applyRandomizedStart() {
 // think there is a reliable way to tell the context otherwise.
 func apidumpRunWithoutAbnormalExit(cmd *cobra.Command, args []string) error {
 	err := apidumpRunInternal(cmd, args)
-
 	if err == nil {
 		return nil
 	}
 
 	// Log the error and wait forever.
 	printer.Stderr.Errorf("Error during initiaization: %v\n", err)
-	printer.Stdout.Infof("This process will not exit, to avoid boot loops. Please correct the command line flags or environment and retry.\n")
 
-	select {}
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		printer.Stdout.Infof("This process will not exit, to avoid boot loops. Please correct the command line flags or environment and retry.\n")
+		select {}
+	}
+	return nil
 }
 
 func apidumpRunInternal(cmd *cobra.Command, _ []string) error {

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -18,7 +18,6 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 	"github.com/postmanlabs/postman-insights-agent/util"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 var (
@@ -100,13 +99,12 @@ func apidumpRunWithoutAbnormalExit(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Log the error and wait forever.
-	printer.Stderr.Errorf("Error during initiaization: %v\n", err)
-
-	if !term.IsTerminal(int(os.Stdout.Fd())) {
+	if !errors.Is(err, apidump.ProcessSignalErr) {
+		printer.Stderr.Errorf("Error during initiaization: %v\n", err)
 		printer.Stdout.Infof("This process will not exit, to avoid boot loops. Please correct the command line flags or environment and retry.\n")
 		select {}
 	}
+
 	return nil
 }
 

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -18,6 +18,7 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 	"github.com/postmanlabs/postman-insights-agent/util"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -101,8 +102,10 @@ func apidumpRunWithoutAbnormalExit(cmd *cobra.Command, args []string) error {
 
 	if !errors.Is(err, apidump.ProcessSignalErr) {
 		printer.Stderr.Errorf("Error during initiaization: %v\n", err)
-		printer.Stdout.Infof("This process will not exit, to avoid boot loops. Please correct the command line flags or environment and retry.\n")
-		select {}
+		if !term.IsTerminal(int(os.Stdout.Fd())) {
+			printer.Stdout.Infof("This process will not exit, to avoid boot loops. Please correct the command line flags or environment and retry.\n")
+			select {}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Ensure that the agent process exits if the process receives a `SIGINT` or `SIGTERM` signal.

**Tests:**
- Validate process will exit if TTY is set:
  - Created a new Ubuntu arm64 VM
  - Built agent with `make docker-build`
  - Ran agent in VM and sent a `Ctrl-C` signal
  - Confirmed agent process exited
- Validate process will exit when run as daemon:
  - Created a new Ubuntu arm64 VM
  - Built agent with `make docker-build`
  - Added a new `.service` file
  - Reloaded systemd configuration with `systemctl daemon-reload`
  - Enabled service with `systemctl enable postman-insights-agent.service`
  - Confirmed successful daemon startup with `journalctl -fu postman-insights-agent.service`
  - Sent SIGINT signal with `kill -2 {process-id}`
  - Confirmed agent process exited

**Logs:**
*Interactive (TTY is set) logs:*
```sh
dev@ubuntu-insights-agent:~$ sudo POSTMAN_API_KEY=$INSIGHTS_KEY ./postman-insights-agent apidump --project $PROJECT_ID
[INFO] Telemetry unavailable; no Amplitude key configured.
[INFO] This is caused by building from source rather than using an official build.
[INFO] Postman Insights Agent 0.0.0
[INFO] Created new trace on Postman Cloud: akita://Test Project:trace:aquamarine-mark-f6c0e9b5
[INFO] Failed to clear VmHWM.  Memory usage telemetry will report the high-water mark as computed by /proc/self/status.
[INFO] Running learn mode on interfaces lo, enp0s5
[INFO] --filter flag is not set; capturing all network traffic to and from your services.
[INFO] Send SIGINT (Ctrl-C) to stop...
^C[INFO] Received interrupt, stopping trace collection...
[INFO] Trace collection stopped
[INFO] Captured 454 TCP packets total; 301 unparsed TCP segments. No TLS headers were found, so this may represent a network protocol that the agent does not know how to parse.
[ERROR] No HTTP calls captured! 🛑

```

*Systemd daemon logs:*
```sh
Mar 26 20:01:32 ubuntu-insights-agent systemd[1]: Started postman-insights-agent.service - Postman Insights Agent.
Mar 26 20:01:32 ubuntu-insights-agent postman-insights-agent[5069]: [INFO] Telemetry unavailable; no Amplitude key configured.
Mar 26 20:01:32 ubuntu-insights-agent postman-insights-agent[5069]: [INFO] This is caused by building from source rather than using an official build.
Mar 26 20:01:32 ubuntu-insights-agent postman-insights-agent[5069]: [INFO] Postman Insights Agent 0.0.0
Mar 26 20:01:33 ubuntu-insights-agent postman-insights-agent[5069]: [INFO] Created new trace on Postman Cloud: akita://Test Project:trace:tree-lady-44b4e9a1
Mar 26 20:01:33 ubuntu-insights-agent postman-insights-agent[5069]: [INFO] Failed to clear VmHWM.  Memory usage telemetry will report the high-water mark as computed by /proc/self/status.
Mar 26 20:01:33 ubuntu-insights-agent postman-insights-agent[5069]: [INFO] Running learn mode on interfaces lo, enp0s5
Mar 26 20:01:33 ubuntu-insights-agent postman-insights-agent[5069]: [INFO] --filter flag is not set; capturing all network traffic to and from your services.
Mar 26 20:01:33 ubuntu-insights-agent postman-insights-agent[5069]: [INFO] Send SIGINT (Ctrl-C) to stop...
Mar 26 20:02:25 ubuntu-insights-agent postman-insights-agent[5069]: [INFO] Received interrupt, stopping trace collection...
Mar 26 20:02:30 ubuntu-insights-agent postman-insights-agent[5069]: [INFO] Trace collection stopped
Mar 26 20:02:30 ubuntu-insights-agent postman-insights-agent[5069]: [INFO] Captured 2 TLS handshake messages out of 6997 total TCP segments. This may mean you are trying to capture HTTPS traffic, which is currently unsupported.
Mar 26 20:02:30 ubuntu-insights-agent postman-insights-agent[5069]: [ERROR] No HTTP calls captured! 🛑
Mar 26 20:02:30 ubuntu-insights-agent systemd[1]: postman-insights-agent.service: Deactivated successfully.
Mar 26 20:02:30 ubuntu-insights-agent systemd[1]: postman-insights-agent.service: Consumed 1.703s CPU time, 48.1M memory peak, 0B memory swap peak.

```