### PR TITLE
[POA-3263] Set drop-nginx-traffic arg at apidump cmd also

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -786,16 +786,12 @@ func (a *apidump) Run() error {
 			// Eliminate Akita CLI traffic, unless --dogfood has been specified
 			dropDogfoodTraffic := !viper.GetBool("dogfood")
 
-			// Always eliminate Nginx traffic.
-			// Default value of both flags is true, unless explicitly set to false.
-			dropNginxTraffic := a.DropNginxTraffic && viper.GetBool("drop-nginx-traffic")
-
 			// Construct userTrafficCollector
-			if dropDogfoodTraffic || dropNginxTraffic {
+			if dropDogfoodTraffic || a.DropNginxTraffic {
 				collector = &trace.UserTrafficCollector{
 					Collector:          collector,
 					DropDogfoodTraffic: dropDogfoodTraffic,
-					DropNginxTraffic:   dropNginxTraffic,
+					DropNginxTraffic:   a.DropNginxTraffic,
 				}
 			}
 

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -18,6 +18,7 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 	"github.com/postmanlabs/postman-insights-agent/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"golang.org/x/term"
 )
 
@@ -222,6 +223,7 @@ func apidumpRunInternal(cmd *cobra.Command, _ []string) error {
 		MaxWitnessSize_bytes:    maxWitnessSize_bytes,
 		DockerExtensionMode:     dockerExtensionMode,
 		HealthCheckPort:         healthCheckPort,
+		DropNginxTraffic:        viper.GetBool("drop-nginx-traffic"),
 
 		// TODO: remove the SendWitnessPayloads flag once all existing users are migrated to new flag.
 		ReproMode: commonApidumpFlags.EnableReproMode || commonApidumpFlags.SendWitnessPayloads,

--- a/cmd/internal/kube/daemonset/kube_events_worker.go
+++ b/cmd/internal/kube/daemonset/kube_events_worker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/postmanlabs/postman-insights-agent/deployment"
 	"github.com/postmanlabs/postman-insights-agent/printer"
+	"github.com/spf13/viper"
 	coreV1 "k8s.io/api/core/v1"
 )
 
@@ -258,8 +259,8 @@ func (d *Daemonset) inspectPodForEnvVars(pod coreV1.Pod, podArgs *PodArgs) error
 		InsightsEnvironment: d.InsightsEnvironment,
 	}
 
-	// Check if Nginx traffic should be dropped, with a default value of true
-	podArgs.DropNginxTraffic = parseBoolConfig(mainContainerConfig.dropNginxTraffic, "dropNginxTraffic", pod.Name, true)
+	// Check if Nginx traffic should be dropped, with a default fallback to the DaemonSet config
+	podArgs.DropNginxTraffic = parseBoolConfig(mainContainerConfig.dropNginxTraffic, "dropNginxTraffic", pod.Name, viper.GetBool("drop-nginx-traffic"))
 
 	// Determine ReproMode flag for the apidump process
 	podArgs.ReproMode = d.InsightsReproModeEnabled


### PR DESCRIPTION
Changes:
* `apidump/apidump.go`: Refactored the logic to check for dropping Nginx traffic by directly using the `a.DropNginxTraffic` flag.
* `cmd/internal/apidump/apidump.go`: Added the `DropNginxTraffic` flag to the `apidumpRunInternal` function, allowing it to be set via the `viper` configuration.