### PR TITLE
Add latency calculation tests & logs

### DIFF
--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -265,11 +265,17 @@ func (s *Summary) printHostHighlights(top *client_telemetry.PacketCountSummary) 
 // any packets, capturing packets but failing to parse them, etc.
 func (s *Summary) PrintWarnings() {
 	// Report on recoverable error counts during trace
-	if pcap.CountNilAssemblerContext > 0 || pcap.CountNilAssemblerContextAfterParse > 0 || pcap.CountBadAssemblerContextType > 0 {
-		printer.Stderr.Infof("Detected packet assembly context problems during capture: %v empty, %v bad type, %v empty after parse. ",
+	if pcap.CountNilAssemblerContext > 0 ||
+		pcap.CountNilAssemblerContextAfterParse > 0 ||
+		pcap.CountBadAssemblerContextType > 0 ||
+		pcap.CountZeroValuePacketTimestamp > 0 ||
+		pcap.CountLastPacketBeforeFirstPacket > 0 {
+		printer.Stderr.Infof("Detected packet assembly context problems during capture: %v empty, %v bad type, %v empty after parse, %v zero timestamp, %v last before first timestamp. ",
 			pcap.CountNilAssemblerContext,
 			pcap.CountBadAssemblerContextType,
-			pcap.CountNilAssemblerContextAfterParse)
+			pcap.CountNilAssemblerContextAfterParse,
+			pcap.CountZeroValuePacketTimestamp,
+			pcap.CountLastPacketBeforeFirstPacket)
 		printer.Stderr.Infof("These errors may cause some packets to be missing from the trace.\n")
 	}
 
@@ -383,5 +389,4 @@ func DumpPacketCounters(logf func(f string, args ...interface{}), interfaces map
 	}
 
 	logf("==================================================\n")
-
 }

--- a/pcap/stream.go
+++ b/pcap/stream.go
@@ -230,15 +230,22 @@ func (f *tcpFlow) toPNT(firstPacketTime time.Time, lastPacketTime time.Time,
 	c akinet.ParsedNetworkContent,
 ) akinet.ParsedNetworkTraffic {
 	if firstPacketTime.IsZero() || lastPacketTime.IsZero() {
-		firstPacketTime = f.clock.Now()
-		lastPacketTime = firstPacketTime
-		printer.V(6).Infof("ParsedNetworkTraffic with zero value packet timestamps. first: %v last: %v", firstPacketTime, lastPacketTime)
+		now := f.clock.Now()
+		printer.V(6).Infof("ParsedNetworkTraffic with zero value packet timestamps. first: %v last: %v now: %v", firstPacketTime, lastPacketTime, now)
 		atomic.AddUint64(&CountZeroValuePacketTimestamp, 1)
+
+		if firstPacketTime.IsZero() {
+			firstPacketTime = now
+		}
+		if lastPacketTime.IsZero() {
+			lastPacketTime = now
+		}
 	}
 	if lastPacketTime.Before(firstPacketTime) {
-		lastPacketTime = firstPacketTime
 		printer.V(6).Infof("ParsedNetworkTraffic with last packet before first packet. first: %v last: %v", firstPacketTime, lastPacketTime)
 		atomic.AddUint64(&CountLastPacketBeforeFirstPacket, 1)
+
+		lastPacketTime = firstPacketTime
 	}
 
 	// Endpoint interpretation logic from

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -421,6 +421,8 @@ func TestTiming(t *testing.T) {
 			ExpectedLatencies: []float32{3.0, 3.0},
 		},
 		{
+			// Here we are testing the existance of a bug (the two requests get matched together and the two responses get matched together)
+			// If it suddenly starts failing there is a very good chance that you fixed the bug!
 			Name: "pipelined request + response pairs",
 			PNTs: []akinet.ParsedNetworkTraffic{
 				request(streamID, seq, startTime, startTime.Add(2*time.Millisecond)),


### PR DESCRIPTION
Added witness latency calculation tests. Specifically the following scenarios are now being tested:

- the request and the response have 8 ms of latency
- the request and the response have 0 ms of latency
- the request and the response overlap by -1 ms of latency
- the request and the response fully overlap each other have 0 ms of latency
- the request and the response are in the wrong order have -4 ms of latency
- the request and the response timestamps are the zero value have 0 ms of latency
- a stream with two interleaved request and response each with 3 ms of latency
- two pipelined requests and responses have 0 ms of latency

Added 2 validations in the stream processing layer:
- if the first or last packet timestamps are the default zero value, override to `time.Now()`.
- if the last packet timestamp is before the first packet timestamp, override last packet timestamp to first packet timestamp.

^These are being logged and printed as part of the `PrintWarnings` report at the end of a session.

Added 3 validations in the backend collector layer:
- if the collector matches 2 requests or 2 responses together (due to HTTP/1.1 pipelining and matching on `ACK`s), log it and leave latency default value of `0.0`.
- if the collector sees timestamp zero values, log it and leave latency default value of `0.0`
- if the collector sees negative latency calculation, log and report it.