### PR TITLE
Emit log if we have network traffic on reassembly complete

### DIFF
--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -269,6 +269,7 @@ func (p *NetworkTrafficParser) packetToParsedNetworkTraffic(out chan<- akinet.Pa
 }
 
 func contextFromTCPPacket(p gopacket.Packet, t *layers.TCP) *assemblerCtxWithSeq {
+	printer.V(6).Debugf("contextFromTCPPacket created with packet timestamp: %v", p.Metadata().CaptureInfo.Timestamp)
 	return &assemblerCtxWithSeq{
 		ci:  p.Metadata().CaptureInfo,
 		seq: reassembly.Sequence(t.Seq),

--- a/pcap/stream.go
+++ b/pcap/stream.go
@@ -211,6 +211,7 @@ func (f *tcpFlow) reassemblyComplete() {
 		if err != nil {
 			f.handleUnparseable(t, numBytesConsumed)
 		} else if pnc != nil {
+			printer.V(6).Infof("ReassemblyComplete parsed additional network traffic with ts: %v", t)
 			f.outChan <- f.toPNT(t, t, pnc)
 			f.handleUnparseable(t, unused.Len())
 		}


### PR DESCRIPTION
I'm suspicious of the `toPNT` call within `reassemblyComplete`. I wonder if these is where we are getting the zero timestamp.