### PR TITLE
Check for NaN value in usage

### DIFF
--- a/usage/usage.go
+++ b/usage/usage.go
@@ -1,7 +1,6 @@
 package usage
 
 import (
-	"math"
 	"os"
 	"sync"
 	"time"
@@ -158,12 +157,12 @@ func poll(pollingInterval time.Duration) error {
 		float64(allStat.CPUStatAll.System-lastAllStat.CPUStatAll.System) +
 		float64(allStat.CPUStatAll.Idle-lastAllStat.CPUStatAll.Idle)
 
-	relativeCPU := selfCPU / allCPU
-	// If selfCPU and allCPU are both zero we will end up with NaN
-	// any operation using a NaN value results in a NaN value.
-	// So we must ensure that we don't end up with NaN.
-	if math.IsNaN(relativeCPU) {
-		relativeCPU = 0.0
+	var relativeCPU float64 = 0.0
+	if allCPU > 0.0 {
+		// If allCPU is `0.0` we would get a `NaN` value which would
+		// result in all subsequent operations involving `relativeCPU`
+		// also resulting in a `NaN` value.
+		relativeCPU = selfCPU / allCPU
 	}
 	peakRelativeCPU = akimath.Max(peakRelativeCPU, relativeCPU)
 

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/akitasoftware/akita-libs/api_schema"
-	akimath "github.com/akitasoftware/go-utils/math"
+	"github.com/akitasoftware/go-utils/math"
 	"github.com/akitasoftware/go-utils/queues"
 	"github.com/c9s/goprocinfo/linux"
 	"github.com/pkg/errors"
@@ -164,18 +164,18 @@ func poll(pollingInterval time.Duration) error {
 		// also resulting in a `NaN` value.
 		relativeCPU = selfCPU / allCPU
 	}
-	peakRelativeCPU = akimath.Max(peakRelativeCPU, relativeCPU)
+	peakRelativeCPU = math.Max(peakRelativeCPU, relativeCPU)
 
 	coresUsed := relativeCPU * float64(len(allStat.CPUStats))
-	peakCoresUsed = akimath.Max(peakCoresUsed, coresUsed)
+	peakCoresUsed = math.Max(peakCoresUsed, coresUsed)
 
 	// Get highest recorded VM high water mark.
 	vmHWM := status.VmHWM
 	history.ForEach(func(h statHistory) {
-		vmHWM = akimath.Max(vmHWM, h.status.VmHWM)
+		vmHWM = math.Max(vmHWM, h.status.VmHWM)
 	})
 
-	peakVM = akimath.Max(peakVM, vmHWM)
+	peakVM = math.Max(peakVM, vmHWM)
 
 	// Update history.
 	observedAt := time.Now()
@@ -188,7 +188,7 @@ func poll(pollingInterval time.Duration) error {
 
 	// If the history has filled the sliding window, evict the oldest.  There
 	// will always be at least one element in the history.
-	if history.Size() > akimath.Max(int(slidingWindowSize/pollingInterval), 1) {
+	if history.Size() > math.Max(int(slidingWindowSize/pollingInterval), 1) {
 		history.Dequeue()
 	}
 


### PR DESCRIPTION
When calculating the `relativeCPU` we divide `selfCPU` by `allCPU` if both values are zero we end up with `NaN`. Any mathematical operation with a `NaN` value results in a `NaN` value. So we must correct this to ensure later on we can serialize the value.