### PR TITLE
Report observation window counters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20241213050034-057d7b6097e8
-	github.com/akitasoftware/akita-libs v0.0.0-20250428180153-cb2e977a2ee3
+	github.com/akitasoftware/akita-libs v0.0.0-20250430223533-06e05e3725df
 	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20250314233547-6ff5afce3bf6 h1:kuJ8kv
 github.com/akitasoftware/akita-libs v0.0.0-20250314233547-6ff5afce3bf6/go.mod h1:Fg14kX6+N7we3KdP1c11W/SzbKsgapV1hP5d4Z/Hqwc=
 github.com/akitasoftware/akita-libs v0.0.0-20250428180153-cb2e977a2ee3 h1:ANLqfVeDdlJoLf1jCjWlxtKaj65N8bLJ9OLmp1h8w/o=
 github.com/akitasoftware/akita-libs v0.0.0-20250428180153-cb2e977a2ee3/go.mod h1:Fg14kX6+N7we3KdP1c11W/SzbKsgapV1hP5d4Z/Hqwc=
+github.com/akitasoftware/akita-libs v0.0.0-20250430223533-06e05e3725df h1:NLeQdXerlr1FOXvVgwrYpAat2UeIFKyb+AmRlOz2otQ=
+github.com/akitasoftware/akita-libs v0.0.0-20250430223533-06e05e3725df/go.mod h1:Fg14kX6+N7we3KdP1c11W/SzbKsgapV1hP5d4Z/Hqwc=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20240820200020-7289ae956f70 h1:VnU7QLDBwRujpQoHwShs5yu0Ahv1fSalNJa4UijwlmY=


### PR DESCRIPTION
With this change each telemetry report will include the count of http requests, responses, rate limited requests, etc. during the observation window. These count get reset each time we report.