### PR TITLE
[POA-3519] Report telemetry observation window start and duration

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -282,11 +282,13 @@ func isBpfFilterError(e error) bool {
 }
 
 // Update the backend with new current capture stats.
-func (a *apidump) SendPacketTelemetry(observedDuration int) {
+func (a *apidump) SendPacketTelemetry(observationDuration int, windowStartTime time.Time, windowDuration int) {
 	req := &kgxapi.PostClientPacketCaptureStatsRequest{
-		AgentResourceUsage:        usage.Get(),
-		ObservedDurationInSeconds: observedDuration,
-		AgentRateLimit:            a.WitnessesPerMinute,
+		AgentResourceUsage:              usage.Get(),
+		ObservedDurationInSeconds:       observationDuration,
+		ObservedWindowStartAt:           windowStartTime,
+		ObservedWindowDurationInSeconds: windowDuration,
+		AgentRateLimit:                  a.WitnessesPerMinute,
 	}
 	if a.dumpSummary != nil {
 		req.PacketCountSummary = a.dumpSummary.FilterSummary.Summary(topNForSummary)
@@ -470,18 +472,25 @@ func (a *apidump) TelemetryWorker(done <-chan struct{}) {
 	if a.TelemetryInterval > 0 {
 		ticker := time.NewTicker(time.Duration(a.TelemetryInterval) * time.Second)
 
+		lastReport := time.Now()
 		for {
 			select {
 			case <-done:
 				return
 			case now := <-ticker.C:
-				duration := int(now.Sub(a.startTime) / time.Second)
-				a.SendPacketTelemetry(duration)
+				observationDuration := int(now.Sub(a.startTime) / time.Second)
+				windowStart := lastReport
+				windowDuration := int(now.Sub(windowStart) / time.Second)
+				lastReport = time.Now()
+				a.SendPacketTelemetry(observationDuration, windowStart, windowDuration)
 				subsequentTelemetrySent = true
 			case <-a.successTelemetry.Channel:
 				if !subsequentTelemetrySent {
-					duration := int(time.Since(a.startTime) / time.Second)
-					a.SendPacketTelemetry(duration)
+					observationDuration := int(time.Since(a.startTime) / time.Second)
+					windowStart := lastReport
+					windowDuration := int(time.Since(windowStart) / time.Second)
+					lastReport = time.Now()
+					a.SendPacketTelemetry(observationDuration, windowStart, windowDuration)
 				}
 			}
 		}

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -286,7 +286,7 @@ func (a *apidump) SendPacketTelemetry(observationDuration int, windowStartTime t
 	req := &kgxapi.PostClientPacketCaptureStatsRequest{
 		AgentResourceUsage:              usage.Get(),
 		ObservedDurationInSeconds:       observationDuration,
-		ObservedWindowStartAt:           windowStartTime,
+		ObservedWindowStartingAt:        windowStartTime,
 		ObservedWindowDurationInSeconds: windowDuration,
 		AgentRateLimit:                  a.WitnessesPerMinute,
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/akitasoftware/akita-ir v0.0.0-20241213050034-057d7b6097e8
-	github.com/akitasoftware/akita-libs v0.0.0-20250430223533-06e05e3725df
+	github.com/akitasoftware/akita-libs v0.0.0-20250505211512-67888a517c64
 	github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803
 	github.com/andybalholm/brotli v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/akitasoftware/akita-libs v0.0.0-20250428180153-cb2e977a2ee3 h1:ANLqfV
 github.com/akitasoftware/akita-libs v0.0.0-20250428180153-cb2e977a2ee3/go.mod h1:Fg14kX6+N7we3KdP1c11W/SzbKsgapV1hP5d4Z/Hqwc=
 github.com/akitasoftware/akita-libs v0.0.0-20250430223533-06e05e3725df h1:NLeQdXerlr1FOXvVgwrYpAat2UeIFKyb+AmRlOz2otQ=
 github.com/akitasoftware/akita-libs v0.0.0-20250430223533-06e05e3725df/go.mod h1:Fg14kX6+N7we3KdP1c11W/SzbKsgapV1hP5d4Z/Hqwc=
+github.com/akitasoftware/akita-libs v0.0.0-20250505211512-67888a517c64 h1:DYjWUWnXOwvuMle72HdQokPDGtzs4cfHLsKHBfnGHiI=
+github.com/akitasoftware/akita-libs v0.0.0-20250505211512-67888a517c64/go.mod h1:Fg14kX6+N7we3KdP1c11W/SzbKsgapV1hP5d4Z/Hqwc=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803 h1:ebIh/EFuaP8GczzMe8EwVID/blSv5Tej6S8NE4xyarQ=
 github.com/akitasoftware/go-utils v0.0.0-20240213133309-b95d4ace8803/go.mod h1:+IOXf7l/QCAQECJzjJwhTp1sBkRoJ6WciZwJezUwBa4=
 github.com/akitasoftware/gopacket v1.1.18-0.20240820200020-7289ae956f70 h1:VnU7QLDBwRujpQoHwShs5yu0Ahv1fSalNJa4UijwlmY=


### PR DESCRIPTION
These changes will report the observation window start and duration. The observation window resets every time we send a telemetry report. These new values will help us calculate averages more precisely without flattening them over a long observation session. Additionally the window start time will help us build better rollup windows.

TODO:
- [x] pull in `api_schema` changes in https://github.com/postmanlabs/observability-shared-libs/pull/232