### PR TITLE
Add a supervisor process to the agent

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,8 +168,8 @@ func printFlagsWarning(cmd *cobra.Command) {
 func Execute() {
 	err := runSupervisor()
 	if err != nil {
-		printer.Stderr.Errorf("%s\n", err)
-		os.Exit(1)
+		printer.Errorln(err)
+		os.Exit(126)
 	}
 
 	defer telemetry.Shutdown()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -166,6 +166,12 @@ func printFlagsWarning(cmd *cobra.Command) {
 }
 
 func Execute() {
+	err := runSupervisor()
+	if err != nil {
+		printer.Stderr.Errorf("%s\n", err)
+		os.Exit(1)
+	}
+
 	defer telemetry.Shutdown()
 
 	if cmd, err := rootCmd.ExecuteC(); err != nil {

--- a/cmd/supervisor.go
+++ b/cmd/supervisor.go
@@ -47,11 +47,13 @@ func collectStatus(pid int) (*os.ProcessState, error) {
 }
 
 func runningInsideDocker() bool {
-	return os.Getenv("__X_AKITA_CLI_DOCKER") == "true"
+	c, _ := strconv.ParseBool(os.Getenv("__X_AKITA_CLI_DOCKER"))
+	return c == true
 }
 
 func isChildProcess() bool {
-	return os.Getenv("__X_AKITA_CHILD") == "true"
+	c, _ := strconv.ParseBool(os.Getenv("__X_AKITA_CHILD"))
+	return c == true
 }
 
 func runSupervisor() error {

--- a/cmd/supervisor.go
+++ b/cmd/supervisor.go
@@ -98,7 +98,7 @@ func runSupervisor() error {
 			switch sigNum {
 			case syscall.SIGINT, syscall.SIGTERM:
 				if pid != 0 {
-					printer.Warningf("sending %v to child\n", sigNum)
+					printer.Debugf("sending %v to child\n", sigNum)
 
 					err := syscall.Kill(pid, sigNum)
 					if err != nil {

--- a/cmd/supervisor.go
+++ b/cmd/supervisor.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/postmanlabs/postman-insights-agent/printer"
+)
+
+func runChild(pwd string, numRuns uint64) (int, uint64, error) {
+	numRuns += 1
+
+	args := os.Args
+	env := os.Environ()
+
+	env = append(env, "__X_AKITA_NO_FORK=1")
+	env = append(env, fmt.Sprintf("__X_AKITA_NUM_RUNS=%d", numRuns))
+
+	pid, err := syscall.ForkExec(args[0], args, &syscall.ProcAttr{
+		Dir: pwd,
+		Env: env,
+		Sys: &syscall.SysProcAttr{
+			Setsid: true,
+		},
+		Files: []uintptr{0, 1, 2},
+	})
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return pid, numRuns, nil
+}
+
+func collectStatus(pid int) (*os.ProcessState, error) {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	return proc.Wait()
+}
+
+func runSupervisor() error {
+	e := os.Getenv("__X_AKITA_NO_FORK")
+
+	if e == "1" {
+		return nil
+	}
+
+	maxRuns, err := strconv.ParseUint(os.Getenv("__X_AKITA_MAX_RUNS"), 10, 64)
+	if err != nil {
+		maxRuns = 0
+		printer.Warningln("unable to parse __X_AKITA_MAX_RUNS, using default value of 0 (no restriction)")
+	}
+
+	delay, err := strconv.ParseUint(os.Getenv("__X_AKITA_DELAY"), 10, 64)
+	if err != nil {
+		delay = 1
+		printer.Warningln("unable to parse __X_AKITA_DELAY, using default value of 1")
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	sigs := make(chan os.Signal)
+	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGINT, syscall.SIGCHLD)
+
+	printer.Infof("starting the child process, run %d of %d", 1, maxRuns)
+
+	pid, numRuns, err := runChild(pwd, 0)
+	if err != nil {
+		return err
+	}
+
+	for {
+		sig := <- sigs
+
+		if sig.(syscall.Signal) == syscall.SIGINT || sig.(syscall.Signal) == syscall.SIGTERM {
+			if pid != 0 {
+				printer.Infof("sending %s to child", sig.(syscall.Signal))
+
+				syscall.Kill(pid, sig.(syscall.Signal))
+
+				status, err := collectStatus(pid)
+				if err != nil {
+					return err
+				}
+
+				syscall.Exit(status.ExitCode())
+			}
+
+			break
+		}
+
+		if sig.(syscall.Signal) == syscall.SIGCHLD {
+			status, err := collectStatus(pid)
+			if err != nil {
+				return err
+			}
+
+			printer.Infof("child exited with %d", status.ExitCode())
+
+			if status.Success() {
+				break
+			}
+
+			pid = 0
+
+			if numRuns == maxRuns {
+				return fmt.Errorf("maximum number of runs reached (%d), bailing out", maxRuns)
+			}
+
+			printer.Errorf("retrying after %d seconds", delay)
+
+			go func() {
+				<- time.After(time.Duration(delay) * time.Second)
+				sigs <- syscall.SIGALRM
+			} ()
+		}
+
+		if sig.(syscall.Signal) == syscall.SIGALRM {
+			printer.Infof("starting the child process, run %d of %d", numRuns + 1, maxRuns)
+
+			pid, numRuns, err = runChild(pwd, numRuns)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/supervisor.go
+++ b/cmd/supervisor.go
@@ -54,18 +54,18 @@ func runSupervisor() error {
 	maxRuns, err := strconv.ParseUint(os.Getenv("__X_AKITA_MAX_RUNS"), 10, 64)
 	if err != nil {
 		maxRuns = 0
-		printer.Warningln("unable to parse __X_AKITA_MAX_RUNS, using default value of 0 (no restriction)")
+		printer.Debugf("unable to parse __X_AKITA_MAX_RUNS, using default value of 0 (no restriction)\n")
 	}
 
 	delay, err := strconv.ParseInt(os.Getenv("__X_AKITA_DELAY"), 10, 64)
 	if err != nil {
 		delay = 1
-		printer.Warningln("unable to parse __X_AKITA_DELAY, using default value of 1")
+		printer.Debugf("unable to parse __X_AKITA_DELAY, using default value of 1\n")
 	}
 
 	if delay <= 0 {
 		delay = 1
-		printer.Warningln("__X_AKITA_DELAY must be greater than 0, using default value of 1")
+		printer.Debugf("__X_AKITA_DELAY must be greater than 0, using default value of 1\n")
 	}
 
 	pwd, err := os.Getwd()
@@ -76,7 +76,7 @@ func runSupervisor() error {
 	sigs := make(chan os.Signal)
 	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGINT, syscall.SIGCHLD)
 
-	printer.Infof("starting the child process, run %d of %d", 1, maxRuns)
+	printer.Debugf("starting the child process, run %d of %d\n", 1, maxRuns)
 
 	pid, numRuns, err := runChild(pwd, 0)
 	if err != nil {
@@ -88,7 +88,7 @@ func runSupervisor() error {
 
 		if sig.(syscall.Signal) == syscall.SIGINT || sig.(syscall.Signal) == syscall.SIGTERM {
 			if pid != 0 {
-				printer.Infof("sending %s to child", sig.(syscall.Signal))
+				printer.Debugf("sending %s to child\n", sig.(syscall.Signal))
 
 				syscall.Kill(pid, sig.(syscall.Signal))
 
@@ -109,7 +109,7 @@ func runSupervisor() error {
 				return err
 			}
 
-			printer.Infof("child exited with %d", status.ExitCode())
+			printer.Debugf("child exited with %d\n", status.ExitCode())
 
 			if status.Success() {
 				break
@@ -121,7 +121,7 @@ func runSupervisor() error {
 				return fmt.Errorf("maximum number of runs reached (%d), bailing out", maxRuns)
 			}
 
-			printer.Errorf("retrying after %d seconds", delay)
+			printer.Debugf("retrying after %d seconds\n", delay)
 
 			go func() {
 				<- time.After(time.Duration(delay) * time.Second)
@@ -130,7 +130,7 @@ func runSupervisor() error {
 		}
 
 		if sig.(syscall.Signal) == syscall.SIGALRM {
-			printer.Infof("starting the child process, run %d of %d", numRuns + 1, maxRuns)
+			printer.Debugf("starting the child process, run %d of %d\n", numRuns + 1, maxRuns)
 
 			pid, numRuns, err = runChild(pwd, numRuns)
 			if err != nil {

--- a/cmd/supervisor.go
+++ b/cmd/supervisor.go
@@ -119,7 +119,7 @@ func runSupervisor() error {
 			printer.Errorf("retrying after %d seconds", delay)
 
 			go func() {
-				<- time.After(time.Duration(delay) * time.Second)
+				<- time.After(time.Duration(int(delay)) * time.Second)
 				sigs <- syscall.SIGALRM
 			} ()
 		}

--- a/cmd/supervisor.go
+++ b/cmd/supervisor.go
@@ -57,10 +57,15 @@ func runSupervisor() error {
 		printer.Warningln("unable to parse __X_AKITA_MAX_RUNS, using default value of 0 (no restriction)")
 	}
 
-	delay, err := strconv.ParseUint(os.Getenv("__X_AKITA_DELAY"), 10, 64)
+	delay, err := strconv.ParseInt(os.Getenv("__X_AKITA_DELAY"), 10, 64)
 	if err != nil {
 		delay = 1
 		printer.Warningln("unable to parse __X_AKITA_DELAY, using default value of 1")
+	}
+
+	if delay <= 0 {
+		delay = 1
+		printer.Warningln("__X_AKITA_DELAY must be greater than 0, using default value of 1")
 	}
 
 	pwd, err := os.Getwd()
@@ -119,7 +124,7 @@ func runSupervisor() error {
 			printer.Errorf("retrying after %d seconds", delay)
 
 			go func() {
-				<- time.After(time.Duration(int(delay)) * time.Second)
+				<- time.After(time.Duration(delay) * time.Second)
 				sigs <- syscall.SIGALRM
 			} ()
 		}

--- a/cmd/supervisor.go
+++ b/cmd/supervisor.go
@@ -123,13 +123,9 @@ func runSupervisor() error {
 					return err
 				}
 
-				if !status.Exited() {
-					continue
-				}
-
 				printer.Debugf("child exited with %d\n", status.ExitCode())
 
-				if status.ExitCode() < 126 {
+				if status.ExitCode() >= 0 && status.ExitCode() < 126 {
 					syscall.Exit(status.ExitCode())
 				}
 

--- a/cmd/supervisor.go
+++ b/cmd/supervisor.go
@@ -100,7 +100,7 @@ func runSupervisor() error {
 				syscall.Exit(status.ExitCode())
 			}
 
-			break
+			syscall.Exit(0)
 		}
 
 		if sig.(syscall.Signal) == syscall.SIGCHLD {
@@ -112,7 +112,7 @@ func runSupervisor() error {
 			printer.Debugf("child exited with %d\n", status.ExitCode())
 
 			if status.Success() {
-				break
+				syscall.Exit(status.ExitCode())
 			}
 
 			pid = 0
@@ -138,6 +138,9 @@ func runSupervisor() error {
 			}
 		}
 	}
+
+	// Unreachable
+	panic("internal error")
 
 	return nil
 }


### PR DESCRIPTION
With this patch, we use the agent process to be it's own supervisor. This is controlled with __X_AKITA_NO_FORK environment variable. If it's set to "1", the process won't fork itself and we will have the old behaviour. For all other values, the first thing it is going to do is fork and execute itself. The root process will then monitor the child process and restart it if necessary.