### PR TITLE
[POA-3567] add common apidump flags to kube commands

### DIFF
--- a/cmd/internal/kube/inject.go
+++ b/cmd/internal/kube/inject.go
@@ -7,6 +7,7 @@ import (
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/cmd/internal/apidump"
 	"github.com/postmanlabs/postman-insights-agent/cmd/internal/cmderr"
 	"github.com/postmanlabs/postman-insights-agent/cmd/internal/kube/injector"
 	"github.com/postmanlabs/postman-insights-agent/printer"
@@ -32,6 +33,8 @@ var (
 
 	// Postman related flags
 	insightsProjectID string
+
+	apidumpFlags *apidump.CommonApidumpFlags
 )
 
 var injectCmd = &cobra.Command{
@@ -118,8 +121,9 @@ var injectCmd = &cobra.Command{
 
 		var container v1.Container
 
+		apidumpArgs := apidump.ConvertCommonApiDumpFlagsToArgs(apidumpFlags)
 		// Inject the sidecar into the input file
-		container = createPostmanSidecar(insightsProjectID, true)
+		container = createPostmanSidecar(insightsProjectID, true, apidumpArgs)
 
 		rawInjected, err := injector.ToRawYAML(injectr, container)
 		if err != nil {
@@ -218,6 +222,8 @@ func init() {
 	)
 	// Default value is "true" when the flag is given without an argument.
 	injectCmd.Flags().Lookup("secret").NoOptDefVal = "true"
+
+	apidumpFlags = apidump.AddCommonApiDumpFlags(injectCmd)
 
 	Cmd.AddCommand(injectCmd)
 }

--- a/cmd/internal/kube/print_fragment.go
+++ b/cmd/internal/kube/print_fragment.go
@@ -98,21 +98,21 @@ func createTerraformContainer(insightsProjectID string) *hclwrite.File {
 		cty.StringVal("NET_RAW"),
 	}))
 
-	// Add the args to the container
-	args := cty.ListVal([]cty.Value{
+	argList := []cty.Value{
 		cty.StringVal("apidump"),
 		cty.StringVal("--project"),
 		cty.StringVal(insightsProjectID),
-	})
+	}
 	// If a non default --domain flag was used, specify it for the container as well.
 	if rest.Domain != rest.DefaultDomain() {
-		args.Add(cty.StringVal("--domain"))
-		args.Add(cty.StringVal(rest.Domain))
+		argList = append(argList, cty.StringVal("--domain"), cty.StringVal(rest.Domain))
 	}
 	apidumpArgs := apidump.ConvertCommonApiDumpFlagsToArgs(printTFApidumpFlags)
 	for _, arg := range apidumpArgs {
-		args.Add(cty.StringVal(arg))
+		argList = append(argList, cty.StringVal(arg))
 	}
+	// Add the args to the container
+	args := cty.ListVal(argList)
 	containerBody.SetAttributeValue("args", args)
 
 	// Add the environment variables to the container

--- a/cmd/internal/kube/util.go
+++ b/cmd/internal/kube/util.go
@@ -73,13 +73,14 @@ func createFile(path string) (*os.File, error) {
 	return outputFile, nil
 }
 
-func createPostmanSidecar(insightsProjectID string, addAPIKeyAsSecret bool) v1.Container {
+func createPostmanSidecar(insightsProjectID string, addAPIKeyAsSecret bool, apidumpArgs []string) v1.Container {
 	args := []string{"apidump", "--project", insightsProjectID}
 
 	// If a non default --domain flag was used, specify it for the container as well.
 	if rest.Domain != rest.DefaultDomain() {
 		args = append(args, "--domain", rest.Domain)
 	}
+	args = append(args, apidumpArgs...)
 
 	pmKey, pmEnv := cfg.GetPostmanAPIKeyAndEnvironment()
 	envs := []v1.EnvVar{}


### PR DESCRIPTION
Adds the common apidump flags to the `kube inject`, `kube helm-fragment`, and `kube tf-fragment` commands.