### PR TITLE
[POA-3567] Add rate-limit flag to kube run command

### DIFF
--- a/cmd/internal/kube/daemonset/daemonset.go
+++ b/cmd/internal/kube/daemonset/daemonset.go
@@ -28,12 +28,14 @@ const (
 
 type DaemonsetArgs struct {
 	ReproMode bool
+	RateLimit float64
 }
 
 type Daemonset struct {
 	ClusterName              string
 	InsightsEnvironment      string
 	InsightsReproModeEnabled bool
+	InsightsRateLimit        float64
 
 	KubeClient  kube_apis.KubeClient
 	CRIClient   *cri_apis.CriClient
@@ -103,6 +105,7 @@ func StartDaemonset(args DaemonsetArgs) error {
 		ClusterName:              clusterName,
 		InsightsEnvironment:      os.Getenv(POSTMAN_INSIGHTS_ENV),
 		InsightsReproModeEnabled: args.ReproMode,
+		InsightsRateLimit:        args.RateLimit,
 		KubeClient:               kubeClient,
 		CRIClient:                criClient,
 		FrontClient:              frontClient,

--- a/cmd/internal/kube/daemonset/kube_events_worker.go
+++ b/cmd/internal/kube/daemonset/kube_events_worker.go
@@ -277,7 +277,7 @@ func (d *Daemonset) inspectPodForEnvVars(pod coreV1.Pod, podArgs *PodArgs) error
 	// Check if ReproMode is explicitly disabled at the pod level
 	podArgs.ReproMode = !parseBoolConfig(mainContainerConfig.disableReproMode, "disableReproMode", pod.Name, !d.InsightsReproModeEnabled)
 
-	podArgs.AgentRateLimit = 0.0
+	podArgs.AgentRateLimit = d.InsightsRateLimit
 	if mainContainerConfig.agentRateLimit != "" {
 		if limit, err := strconv.ParseFloat(mainContainerConfig.agentRateLimit, 64); err == nil {
 			podArgs.AgentRateLimit = limit

--- a/cmd/internal/kube/run.go
+++ b/cmd/internal/kube/run.go
@@ -8,10 +8,14 @@ import (
 
 var (
 	reproMode bool
+	rateLimit float64
 )
 
 func StartDaemonsetAndHibernateOnError(_ *cobra.Command, args []string) error {
-	err := daemonset.StartDaemonset(daemonset.DaemonsetArgs{ReproMode: reproMode})
+	err := daemonset.StartDaemonset(daemonset.DaemonsetArgs{
+		ReproMode: reproMode,
+		RateLimit: rateLimit,
+	})
 	if err == nil {
 		return nil
 	}
@@ -31,6 +35,12 @@ var runCmd = &cobra.Command{
 }
 
 func init() {
+	runCmd.PersistentFlags().Float64Var(
+		&rateLimit,
+		"rate-limit",
+		0.0,
+		"Number of requests per minute to capture",
+	)
 	runCmd.PersistentFlags().BoolVar(
 		&reproMode,
 		"repro-mode",


### PR DESCRIPTION
I started by adding all of the common apidump flags to the `kube run` command, but then decided against it. I'm not sure if it makes sense to set `Interfaces`, `HostAllowlist`, etc. at the daemonset level. So for now I am just adding the `rate-limit` flag.