### PR TITLE
[POA-3798] Show error message when using ec2 setup on macos

### DIFF
--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -72,7 +72,7 @@ func reportStep(stepName string) {
 func setupAgentForServer(projectID string) error {
 	// Check if the agent is running in a linux environment
 	if runtime.GOOS != "linux" {
-		return errors.New("This command is only supported on linux")
+		return errors.New("This command is only supported on Linux.")
 	}
 
 	err := checkUserPermissions()

--- a/cmd/internal/ec2/add.go
+++ b/cmd/internal/ec2/add.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/user"
 	"strings"
+	"runtime"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/pkg/errors"
@@ -69,6 +70,10 @@ func reportStep(stepName string) {
 }
 
 func setupAgentForServer(projectID string) error {
+	// Check if the agent is running in a linux environment
+	if runtime.GOOS != "linux" {
+		return errors.New("This command is only supported on linux")
+	}
 
 	err := checkUserPermissions()
 	if err != nil {


### PR DESCRIPTION
New output:
```
❯ sudo POSTMAN_ENV=beta POSTMAN_API_KEY=PMAK-**** ./bin/postman-insights-agent ec2 setup --project svc_11PHSa7GenVKdVCZN9r4Ya --repro-mode
Password:
[INFO] Telemetry unavailable; no Amplitude key configured.
[INFO] This is caused by building from source rather than using an official build.
[INFO] Postman Insights Agent 0.0.0
[WARNING] Turning on the --repro-mode flag enables the Postman Insights Agent to send payload data to the Postman cloud.

The Postman Insights Agent will automatically redact values in a default list of sensitive fields, as well as any additionally specified fields.
It is your reponsibility to ensure that any additional sensitive fields are appropriately redacted.
For more information, please see: https://learning.postman.com/docs/insights/repro.

By enabling this flag you acknowledge that you have read this message and accompanying documentation, and that you both understand the risks and have appropriate permission to proceed.
Usage:
  postman-insights-agent ec2 setup [flags]

Flags:
  -f, --force   If the service files already exist, overwrite them without asking for confirmation
  -h, --help    help for setup

Global Flags:
      --filter string             Used to match packets going to and coming from your API service.
      --host-allow strings        Allows only HTTP hosts matching regular expressions.
      --host-exclusions strings   Removes HTTP hosts matching regular expressions.
      --interfaces strings        List of network interfaces to listen on. Defaults to all interfaces on host.
      --log-format string         Set to 'color', 'plain' or 'json' to control the log format.
      --path-allow strings        Allows only HTTP paths matching regular expressions.
      --path-exclusions strings   Removes HTTP paths matching regular expressions.
      --project string            Your Insights Project ID
      --proxy string              The domain name, IP address, or URL of an HTTP proxy server to use
      --rate-limit float          Number of requests per minute to capture.
      --repro-mode                Enable repro mode to send request and response payloads to Postman.

[ERROR] This command is only supported on linux
```