### PR TITLE
[POA-3499] Remove separate package for interface mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ bin/
 
 # Go mocks
 *.mock.go
+mock_*.go
+mock/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean build test mock
+.PHONY: clean build test generate-test-dependencies
 
 export GO111MODULE = on
 
@@ -11,8 +11,8 @@ docker-build:
 clean:
 	go clean
 
-mock:
-	go generate ./...
+generate-test-dependencies:
+	go generate ./rest
 
-test: mock
+test: generate-test-dependencies
 	go test ./...

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ clean:
 	go clean
 
 mock:
-	mkdir -p ./rest/mock
-	mockgen -source ./rest/interface.go -destination ./rest/mock/interface.mock.go -package mock
+	go generate ./...
 
 test: mock
 	go test ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean build test generate-test-dependencies
+.PHONY: clean build test mock
 
 export GO111MODULE = on
 
@@ -11,8 +11,8 @@ docker-build:
 clean:
 	go clean
 
-generate-test-dependencies:
+mock:
 	go generate ./rest
 
-test: generate-test-dependencies
+test: mock
 	go test ./...

--- a/cmd/internal/kube/print_fragment.go
+++ b/cmd/internal/kube/print_fragment.go
@@ -32,7 +32,7 @@ var printHelmChartFragmentCmd = &cobra.Command{
 
 var printTerraformFragmentCmd = &cobra.Command{
 	Use:              "tf-fragment",
-	Short:            "Print an Terraform (HCL) code fragment for adding the Postman Insights Agent to an existing kubernetes deployment.",
+	Short:            "Print a Terraform (HCL) code fragment for adding the Postman Insights Agent to an existing kubernetes deployment.",
 	Long:             "Print a Terraform (HCL) code fragment that can be inserted into a Terraform kubernetes_deployment resource spec to add the Postman Insights Agent as a sidecar container.",
 	RunE:             printTerraformFragment,
 	PersistentPreRun: kubeCommandPreRun,

--- a/data_masks/redaction_test.go
+++ b/data_masks/redaction_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/postmanlabs/postman-insights-agent/rest"
+	mockrest "github.com/postmanlabs/postman-insights-agent/rest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -86,7 +86,7 @@ func TestRedaction(t *testing.T) {
 	for testName, testCase := range testCases {
 		func() {
 			ctrl := gomock.NewController(t)
-			mockClient := rest.NewMockLearnClient(ctrl)
+			mockClient := mockrest.NewMockLearnClient(ctrl)
 			defer ctrl.Finish()
 
 			agentConfig := kgxapi.NewServiceAgentConfig()
@@ -134,7 +134,7 @@ func TestZeroAllPrimitives(t *testing.T) {
 	for testName, testCase := range testCases {
 		func() {
 			ctrl := gomock.NewController(t)
-			mockClient := rest.NewMockLearnClient(ctrl)
+			mockClient := mockrest.NewMockLearnClient(ctrl)
 			defer ctrl.Finish()
 
 			agentConfig := kgxapi.NewServiceAgentConfig()
@@ -165,7 +165,7 @@ func TestZeroAllPrimitives(t *testing.T) {
 
 func BenchmarkRedaction(b *testing.B) {
 	ctrl := gomock.NewController(b)
-	mockClient := rest.NewMockLearnClient(ctrl)
+	mockClient := mockrest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 
 	mockClient.
@@ -188,7 +188,7 @@ func BenchmarkRedaction(b *testing.B) {
 
 func BenchmarkZeroAllPrimitives(b *testing.B) {
 	ctrl := gomock.NewController(b)
-	mockClient := rest.NewMockLearnClient(ctrl)
+	mockClient := mockrest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 
 	mockClient.

--- a/data_masks/redaction_test.go
+++ b/data_masks/redaction_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	mockrest "github.com/postmanlabs/postman-insights-agent/rest/mock"
+	"github.com/postmanlabs/postman-insights-agent/rest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -86,7 +86,7 @@ func TestRedaction(t *testing.T) {
 	for testName, testCase := range testCases {
 		func() {
 			ctrl := gomock.NewController(t)
-			mockClient := mockrest.NewMockLearnClient(ctrl)
+			mockClient := rest.NewMockLearnClient(ctrl)
 			defer ctrl.Finish()
 
 			agentConfig := kgxapi.NewServiceAgentConfig()
@@ -134,7 +134,7 @@ func TestZeroAllPrimitives(t *testing.T) {
 	for testName, testCase := range testCases {
 		func() {
 			ctrl := gomock.NewController(t)
-			mockClient := mockrest.NewMockLearnClient(ctrl)
+			mockClient := rest.NewMockLearnClient(ctrl)
 			defer ctrl.Finish()
 
 			agentConfig := kgxapi.NewServiceAgentConfig()
@@ -165,7 +165,7 @@ func TestZeroAllPrimitives(t *testing.T) {
 
 func BenchmarkRedaction(b *testing.B) {
 	ctrl := gomock.NewController(b)
-	mockClient := mockrest.NewMockLearnClient(ctrl)
+	mockClient := rest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 
 	mockClient.
@@ -188,7 +188,7 @@ func BenchmarkRedaction(b *testing.B) {
 
 func BenchmarkZeroAllPrimitives(b *testing.B) {
 	ctrl := gomock.NewController(b)
-	mockClient := mockrest.NewMockLearnClient(ctrl)
+	mockClient := rest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 
 	mockClient.

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -1,6 +1,6 @@
 package rest
 
-//go:generate mockgen -source=interface.go -destination=./mock/interface.mock.go
+//go:generate mockgen -source=interface.go -destination=mock_interface.go -package=rest
 
 import (
 	"context"

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -1,5 +1,6 @@
 package rest
 
+// Generate mock in this package to avoid import issues with other packages
 //go:generate mockgen -source=interface.go -destination=mock_interface.go -package=rest
 
 import (

--- a/rest/interface.go
+++ b/rest/interface.go
@@ -1,5 +1,7 @@
 package rest
 
+//go:generate mockgen -source=interface.go -destination=./mock/interface.mock.go
+
 import (
 	"context"
 	"regexp"

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/postmanlabs/postman-insights-agent/data_masks"
-	"github.com/postmanlabs/postman-insights-agent/rest"
+	mockrest "github.com/postmanlabs/postman-insights-agent/rest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,7 +57,7 @@ func (wr *witnessRecorder) recordAsyncReportsUpload(args ...interface{}) {
 // Make sure we redact values before uploading.
 func TestRedact(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockClient := rest.NewMockLearnClient(ctrl)
+	mockClient := mockrest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 
 	var rec witnessRecorder
@@ -437,7 +437,7 @@ func TestTiming(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.Name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			mockClient := rest.NewMockLearnClient(ctrl)
+			mockClient := mockrest.NewMockLearnClient(ctrl)
 			defer ctrl.Finish()
 
 			var rec witnessRecorder
@@ -486,7 +486,7 @@ func TestTiming(t *testing.T) {
 // Demonstrate race condition with multiple interfaces
 func TestMultipleInterfaces(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockClient := rest.NewMockLearnClient(ctrl)
+	mockClient := mockrest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 	mockClient.EXPECT().
 		AsyncReportsUpload(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -571,7 +571,7 @@ func TestFlushExit(t *testing.T) {
 
 func TestOnlyRedactNonErrorResponses(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockClient := rest.NewMockLearnClient(ctrl)
+	mockClient := mockrest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 
 	var rec witnessRecorder
@@ -1441,7 +1441,7 @@ func TestRedactionConfigs(t *testing.T) {
 
 	// Setup for running tests
 	ctrl := gomock.NewController(t)
-	mockClient := rest.NewMockLearnClient(ctrl)
+	mockClient := mockrest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 
 	var rec witnessRecorder

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/akitasoftware/akita-ir/go/api_spec"
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akinet"
@@ -746,7 +745,7 @@ func TestRedactionConfigs(t *testing.T) {
 	type testCase struct {
 		request           akinet.HTTPRequest
 		response          akinet.HTTPResponse
-		expectedWitnesses *api_spec.Witness
+		expectedWitnesses *pb.Witness
 	}
 	testCases := map[string]testCase{
 		"no sensitive data": {
@@ -1431,7 +1430,7 @@ func TestRedactionConfigs(t *testing.T) {
 								Method:       "POST",
 								PathTemplate: "/",
 								Host:         "example.com",
-								Obfuscation:  api_spec.HTTPMethodMeta_NONE,
+								Obfuscation:  pb.HTTPMethodMeta_NONE,
 							},
 						},
 					},

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/postmanlabs/postman-insights-agent/data_masks"
-	mockrest "github.com/postmanlabs/postman-insights-agent/rest/mock"
+	"github.com/postmanlabs/postman-insights-agent/rest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,7 +57,7 @@ func (wr *witnessRecorder) recordAsyncReportsUpload(args ...interface{}) {
 // Make sure we redact values before uploading.
 func TestRedact(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockClient := mockrest.NewMockLearnClient(ctrl)
+	mockClient := rest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 
 	var rec witnessRecorder
@@ -437,7 +437,7 @@ func TestTiming(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.Name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			mockClient := mockrest.NewMockLearnClient(ctrl)
+			mockClient := rest.NewMockLearnClient(ctrl)
 			defer ctrl.Finish()
 
 			var rec witnessRecorder
@@ -486,7 +486,7 @@ func TestTiming(t *testing.T) {
 // Demonstrate race condition with multiple interfaces
 func TestMultipleInterfaces(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockClient := mockrest.NewMockLearnClient(ctrl)
+	mockClient := rest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 	mockClient.EXPECT().
 		AsyncReportsUpload(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -571,7 +571,7 @@ func TestFlushExit(t *testing.T) {
 
 func TestOnlyRedactNonErrorResponses(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockClient := mockrest.NewMockLearnClient(ctrl)
+	mockClient := rest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 
 	var rec witnessRecorder
@@ -1441,7 +1441,7 @@ func TestRedactionConfigs(t *testing.T) {
 
 	// Setup for running tests
 	ctrl := gomock.NewController(t)
-	mockClient := mockrest.NewMockLearnClient(ctrl)
+	mockClient := rest.NewMockLearnClient(ctrl)
 	defer ctrl.Finish()
 
 	var rec witnessRecorder


### PR DESCRIPTION
In this PR, we have moved the `interface.go` mock file outside of its own package to the main `rest` package.

**Why?**
Since we don't push mock files to VCS _(which is the right practice)_ the `mock` package is missing from the publicly available package. This was causing issues with the `go mod tidy` command in the superstar service, where the package is used.
```
go: finding module for package github.com/postmanlabs/postman-insights-agent/rest/mock
go: akitasoftware.com/superstar/cli-postman imports
        github.com/postmanlabs/postman-insights-agent/cmd imports
        github.com/postmanlabs/postman-insights-agent/pcap imports
        github.com/postmanlabs/postman-insights-agent/trace tested by
        github.com/postmanlabs/postman-insights-agent/trace.test imports
        github.com/postmanlabs/postman-insights-agent/rest/mock: module github.com/postmanlabs/postman-insights-agent@latest found (v0.37.0), but does not contain package github.com/postmanlabs/postman-insights-agent/rest/mock
```

**Behaviour after changes:**
* After moving the `mock_interface.go` file to the parent `rest` package, we are not getting a missing import error while running `go mod tidy`, though the functions will be missing in the `backend_collection_test.go` file, but it should be okay since this file will never be used by the superstar service.

**Other:**
Also done small linting and typo fixes.