### PR TITLE
[POA-3218] Fix sending of AgentPodName

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -250,7 +250,7 @@ func (a *apidump) SendInitialTelemetry() {
 	if pod, present := a.Args.Tags[tags.XAkitaKubernetesPod]; present {
 		req.MonitoredPodName = pod
 		hostname, err := os.Hostname()
-		if err != nil {
+		if err == nil {
 			req.AgentPodName = hostname
 		}
 	}


### PR DESCRIPTION
Error comparison was the wrong way around.