### PR TITLE
[POA-4077] Reduce buffering & flush asynchronously

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -155,6 +155,9 @@ type Args struct {
 	DropNginxTraffic bool
 
 	DaemonsetArgs optionals.Optional[DaemonsetArgs]
+
+	// The number of upload buffers. Anything larger than 1 results in async uploads.
+	MaxWitnessUploadBuffers int
 }
 
 // TODO: either remove write-to-local-HAR-file completely,
@@ -750,6 +753,7 @@ func (a *apidump) Run() error {
 						summary,
 						args.ReproMode,
 						args.Plugins,
+						args.MaxWitnessUploadBuffers,
 					)
 
 					collector = backendCollector

--- a/apispec/defaults.go
+++ b/apispec/defaults.go
@@ -38,4 +38,7 @@ const (
 
 	// Process all possible witness data
 	DefaultSampleRate = 1.0
+
+	// The maximum number of witness upload buffers
+	DefaultMaxWintessUploadBuffers = 2
 )

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -39,6 +39,7 @@ var (
 	collectTCPAndTLSReports bool
 	parseTLSHandshakes      bool
 	maxWitnessSize_bytes    int
+	maxWitnessUploadBuffers int
 	dockerExtensionMode     bool
 	healthCheckPort         int
 
@@ -234,6 +235,7 @@ func apidumpRunInternal(cmd *cobra.Command, _ []string) error {
 		CollectTCPAndTLSReports: collectTCPAndTLSReports,
 		ParseTLSHandshakes:      parseTLSHandshakes,
 		MaxWitnessSize_bytes:    maxWitnessSize_bytes,
+		MaxWitnessUploadBuffers: maxWitnessUploadBuffers,
 		DockerExtensionMode:     dockerExtensionMode,
 		HealthCheckPort:         healthCheckPort,
 		DropNginxTraffic:        viper.GetBool("drop-nginx-traffic"),
@@ -365,6 +367,14 @@ func init() {
 		"Don't send witnesses larger than this.",
 	)
 	Cmd.Flags().MarkHidden("max-witness-size-bytes")
+
+	Cmd.Flags().IntVar(
+		&maxWitnessUploadBuffers,
+		"max-witness-upload-buffers",
+		apispec.DefaultMaxWintessUploadBuffers,
+		"Controls the numbers of witness upload buffers.",
+	)
+	Cmd.Flags().MarkHidden("max-witness-upload-buffers")
 
 	Cmd.Flags().BoolVar(
 		&dockerExtensionMode,

--- a/cmd/internal/kube/daemonset/apidump_process.go
+++ b/cmd/internal/kube/daemonset/apidump_process.go
@@ -83,6 +83,7 @@ func (d *Daemonset) StartApiDumpProcess(podUID types.UID) error {
 			MaxWitnessSize_bytes:    apispec.DefaultMaxWitnessSize_bytes,
 			ReproMode:               podArgs.ReproMode,
 			DropNginxTraffic:        podArgs.DropNginxTraffic,
+			MaxWitnessUploadBuffers: apispec.DefaultMaxWintessUploadBuffers,
 			DaemonsetArgs: optionals.Some(apidump.DaemonsetArgs{
 				TargetNetworkNamespaceOpt: networkNamespace,
 				StopChan:                  podArgs.StopChan,

--- a/integrations/nginx/backend.go
+++ b/integrations/nginx/backend.go
@@ -11,6 +11,7 @@ import (
 	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/apispec"
 	"github.com/postmanlabs/postman-insights-agent/architecture"
 	"github.com/postmanlabs/postman-insights-agent/data_masks"
 	"github.com/postmanlabs/postman-insights-agent/env"
@@ -192,6 +193,7 @@ func NewNginxBackend(args *Args) (*NginxBackend, error) {
 		b.summary,
 		false,
 		args.Plugins,
+		apispec.DefaultMaxWintessUploadBuffers,
 	)
 
 	// TODO: rate-limit

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -34,10 +34,10 @@ const (
 	pairCacheExpiration = time.Minute
 
 	// How often we clean out stale partial witnesses from pairCache.
-	pairCacheCleanupInterval = 30 * time.Second
+	pairCacheCleanupInterval = 5 * time.Second
 
 	// Max size per upload batch.
-	uploadBatchMaxSize_bytes = 60_000_000 // 60 MB
+	uploadBatchMaxSize_bytes = 30_000_000 // 30 MB
 
 	// How often to flush the upload batch.
 	uploadBatchFlushDuration = 5 * time.Second

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -174,6 +174,7 @@ func NewBackendCollector(
 	packetCounts PacketCountConsumer,
 	sendWitnessPayloads bool,
 	plugins []plugin.AkitaPlugin,
+	uploadReportBuffers int,
 ) Collector {
 	col := &BackendCollector{
 		serviceID:           svc,
@@ -186,7 +187,7 @@ func NewBackendCollector(
 	}
 
 	col.uploadReportBatch = batcher.NewInMemory[rawReport](
-		newReportBuffer(col, packetCounts, uploadBatchMaxSize_bytes, maxWitnessSize_bytes, sendWitnessPayloads),
+		newReportBuffer(col, packetCounts, uploadBatchMaxSize_bytes, maxWitnessSize_bytes, sendWitnessPayloads, uploadReportBuffers),
 		uploadBatchFlushDuration,
 	)
 

--- a/trace/report_buffer.go
+++ b/trace/report_buffer.go
@@ -23,8 +23,9 @@ type rawReport struct {
 }
 
 type reportBuffer struct {
-	collector *BackendCollector
-	kgxapi.UploadReportsRequest
+	collector          *BackendCollector
+	uploadReports      chan *kgxapi.UploadReportsRequest
+	activeUploadReport *kgxapi.UploadReportsRequest
 
 	packetCounts         PacketCountConsumer
 	maxSize_bytes        int
@@ -45,8 +46,15 @@ func newReportBuffer(
 	maxWitnessSize_bytes optionals.Optional[int],
 	witnessesHavePayloads bool,
 ) *reportBuffer {
+	uploadReports := make(chan *kgxapi.UploadReportsRequest, 2)
+	uploadReports <- &kgxapi.UploadReportsRequest{}
+	uploadReports <- &kgxapi.UploadReportsRequest{}
+	activeUploadReport := <-uploadReports
+
 	return &reportBuffer{
 		collector:             collector,
+		uploadReports:         uploadReports,
+		activeUploadReport:    activeUploadReport,
 		packetCounts:          packetCounts,
 		maxSize_bytes:         maxSize_bytes,
 		maxWitnessSize_bytes:  maxWitnessSize_bytes,
@@ -60,11 +68,11 @@ func (buf *reportBuffer) Add(raw rawReport) (bool, error) {
 	}
 
 	if raw.TCPReport != nil {
-		buf.UploadReportsRequest.AddTCPConnectionReport(raw.TCPReport)
+		buf.activeUploadReport.AddTCPConnectionReport(raw.TCPReport)
 	}
 
 	if raw.TLSHandshakeReport != nil {
-		buf.UploadReportsRequest.AddTLSHandshakeReport(raw.TLSHandshakeReport)
+		buf.activeUploadReport.AddTLSHandshakeReport(raw.TLSHandshakeReport)
 	}
 
 	return buf.isFull(), nil
@@ -109,40 +117,47 @@ func (buf *reportBuffer) addWitness(w *witnessWithInfo) {
 		return
 	}
 
-	buf.UploadReportsRequest.AddWitnessReport(witnessReport)
+	buf.activeUploadReport.AddWitnessReport(witnessReport)
 }
 
 func (buf *reportBuffer) Flush() error {
-	if buf.UploadReportsRequest.IsEmpty() {
+	if buf.activeUploadReport.IsEmpty() {
 		return nil
 	}
 
-	// Ensure the buffer is empty when we return.
-	defer buf.UploadReportsRequest.Clear()
+	// Cache current active upload report and reset it to next report.
+	// If witness rate is very high, reading from the channel could still block.
+	report := buf.activeUploadReport
+	buf.activeUploadReport = <-buf.uploadReports
+	go func() {
+		// Upload to the back end.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 
-	// Upload to the back end.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	err := buf.collector.learnClient.AsyncReportsUpload(ctx, buf.collector.getLearnSession(), &buf.UploadReportsRequest)
-	if err != nil {
-		switch e := err.(type) {
-		case rest.HTTPError:
-			if e.StatusCode == http.StatusTooManyRequests {
-				// XXX Not all commands that call into this code have a --rate-limit
-				// option.
-				err = errors.Wrap(err, "your witness uploads are being throttled. Postman Insights will generate partial results. Try reducing the --rate-limit value to avoid this.")
+		err := buf.collector.learnClient.AsyncReportsUpload(ctx, buf.collector.getLearnSession(), report)
+		if err != nil {
+			switch e := err.(type) {
+			case rest.HTTPError:
+				if e.StatusCode == http.StatusTooManyRequests {
+					// XXX Not all commands that call into this code have a --rate-limit
+					// option.
+					err = errors.Wrap(err, "your witness uploads are being throttled. Postman Insights will generate partial results. Try reducing the --rate-limit value to avoid this.")
+				}
 			}
-		}
 
-		printer.Warningf("Failed to upload to Postman: %v\n", err)
-	}
-	printer.Debugf("Uploaded %d witnesses, %d TCP connection reports, and %d TLS handshake reports\n", len(buf.Witnesses), len(buf.TCPConnections), len(buf.TLSHandshakes))
+			printer.Warningf("Failed to upload to Postman: %v\n", err)
+		}
+		printer.Debugf("Uploaded %d witnesses, %d TCP connection reports, and %d TLS handshake reports\n", len(buf.activeUploadReport.Witnesses), len(buf.activeUploadReport.TCPConnections), len(buf.activeUploadReport.TLSHandshakes))
+
+		// Ensure the buffer is empty when we return.
+		report.Clear()
+		buf.uploadReports <- report
+	}()
 
 	return nil
 }
 
 // Determines whether the buffer is at or beyond capacity.
 func (buf *reportBuffer) isFull() bool {
-	return buf.UploadReportsRequest.SizeInBytes() >= buf.maxSize_bytes
+	return buf.activeUploadReport.SizeInBytes() >= buf.maxSize_bytes
 }


### PR DESCRIPTION
Changes:

- Reduces the frequency we check the witness pair cache for partial witnesses from 30 seconds to 5 seconds. 
  - **Note:** the partial witness must still go unpaired for at least a minute before being flushed
- Reduce the witness upload batch size from 60MB to 30 MB. 
  - **Note:** max witness size is 30MB, so we can't go any lower here.
- Refactors the witness upload logic to be asynchronous**
  - ** **Note:** under very high load it might still be possible to have two concurrent witness uploads at the same time as a `Flush` call. If that were to happen the `Flush` call would block until one of the concurrent uploads puts a `UploadReportsRequest` instance back in the channel.