### PR TITLE
[POA-4078] Add agent metrics

### DIFF
--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -161,8 +161,6 @@ func (p *NetworkTrafficParser) ParseFromInterface(
 
 					return
 				}
-				p.observer(packet)
-				p.packetToParsedNetworkTraffic(out, assembler, packet)
 
 				now := time.Now()
 				if now.Sub(startTime) >= intervalLength {
@@ -172,6 +170,9 @@ func (p *NetworkTrafficParser) ParseFromInterface(
 					startTime = now
 				}
 				bufferTimeSum += now.Sub(packet.Metadata().Timestamp)
+
+				p.observer(packet)
+				p.packetToParsedNetworkTraffic(out, assembler, packet)
 			case <-ticker.C:
 				// The assembler stops reassembly for streams older than streamFlushTimeout.
 				// This means the corresponding tcpFlow readers will return EOF.

--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -140,6 +140,9 @@ func (p *NetworkTrafficParser) ParseFromInterface(
 		// Signal caller that we're done on exit
 		defer close(out)
 
+		startTime := time.Now()
+		bufferTimeSum := 0 * time.Second
+		intervalLength := 1 * time.Minute
 		for {
 			select {
 			// packets channel is going to read until EOF or when signalClose is
@@ -160,6 +163,15 @@ func (p *NetworkTrafficParser) ParseFromInterface(
 				}
 				p.observer(packet)
 				p.packetToParsedNetworkTraffic(out, assembler, packet)
+
+				now := time.Now()
+				if now.Sub(startTime) >= intervalLength {
+					bufferLength := float64(bufferTimeSum.Nanoseconds()) / float64(intervalLength.Nanoseconds())
+					printer.Debugf("Approximate unprocessed-packets buffer length: %v", bufferLength)
+					bufferTimeSum = 0 * time.Second
+					startTime = now
+				}
+				bufferTimeSum += now.Sub(packet.Metadata().Timestamp)
 			case <-ticker.C:
 				// The assembler stops reassembly for streams older than streamFlushTimeout.
 				// This means the corresponding tcpFlow readers will return EOF.

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -64,14 +64,6 @@ func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter
 				return
 			case pkt, ok := <-pktChan:
 				if ok {
-					wrappedChan <- pkt
-
-					if firstPacket {
-						firstPacket = false
-						ttfp := time.Since(startTime)
-						printer.Debugf("Time to first packet on %s: %s\n", interfaceName, ttfp)
-					}
-
 					now := time.Now()
 					if now.Sub(startTime) >= intervalLength {
 						bufferLength := float64(bufferTimeSum.Nanoseconds()) / float64(intervalLength.Nanoseconds())
@@ -80,6 +72,15 @@ func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter
 						startTime = now
 					}
 					bufferTimeSum += now.Sub(pkt.Metadata().Timestamp)
+
+					wrappedChan <- pkt
+
+					if firstPacket {
+						firstPacket = false
+						ttfp := time.Since(startTime)
+						printer.Debugf("Time to first packet on %s: %s\n", interfaceName, ttfp)
+					}
+
 				} else {
 					return
 				}

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -75,7 +75,7 @@ func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter
 					now := time.Now()
 					if now.Sub(startTime) >= intervalLength {
 						bufferLength := float64(bufferTimeSum.Nanoseconds()) / float64(intervalLength.Nanoseconds())
-						printer.Debugf("Aproximate pcap buffer length: %v", bufferLength)
+						printer.Debugf("Aproximate captured-packets buffer length: %v", bufferLength)
 						bufferTimeSum = 0 * time.Second
 						startTime = now
 					}

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -74,7 +74,7 @@ func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter
 
 					now := time.Now()
 					if now.Sub(startTime) >= intervalLength {
-						bufferLength := bufferTimeSum.Seconds() / intervalLength.Seconds()
+						bufferLength := float64(bufferTimeSum.Nanoseconds()) / float64(intervalLength.Nanoseconds())
 						printer.Debugf("Aproximate pcap buffer length: %v", bufferLength)
 						bufferTimeSum = 0 * time.Second
 						startTime = now

--- a/pcap/run.go
+++ b/pcap/run.go
@@ -64,8 +64,8 @@ func Collect(
 			bufferTimeSum = 0 * time.Second
 			startTime = now
 		}
-
 		bufferTimeSum += now.Sub(t.ObservationTime)
+
 		t.Interface = intf
 		err := proc.Process(t)
 		t.Content.ReleaseBuffers()

--- a/pcap/run.go
+++ b/pcap/run.go
@@ -57,13 +57,6 @@ func Collect(
 	bufferTimeSum := 0 * time.Second
 	intervalLength := 1 * time.Minute
 	for t := range parsedChan {
-		t.Interface = intf
-		err := proc.Process(t)
-		t.Content.ReleaseBuffers()
-		if err != nil {
-			return err
-		}
-
 		now := time.Now()
 		if now.Sub(startTime) >= intervalLength {
 			bufferLength := float64(bufferTimeSum.Nanoseconds()) / float64(intervalLength.Nanoseconds())
@@ -71,7 +64,14 @@ func Collect(
 			bufferTimeSum = 0 * time.Second
 			startTime = now
 		}
+
 		bufferTimeSum += now.Sub(t.ObservationTime)
+		t.Interface = intf
+		err := proc.Process(t)
+		t.Content.ReleaseBuffers()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -425,8 +425,8 @@ func (c *BackendCollector) periodicFlush() {
 }
 
 func (c *BackendCollector) flushPairCache(cutoffTime time.Time) {
-	now := time.Now()
-	bufferTimeSum := 0 * time.Second
+	totalWitnesses := 0
+	flushedWitnesses := 0
 	c.pairCache.Range(func(k, v interface{}) bool {
 		e := v.(*witnessWithInfo)
 		if e.observationTime.Before(cutoffTime) {
@@ -438,12 +438,10 @@ func (c *BackendCollector) flushPairCache(cutoffTime time.Time) {
 			c.queueUpload(e)
 			c.pairCache.Delete(k)
 
-			if !e.witnessFlushed {
-				bufferTimeSum += now.Sub(e.observationTime)
-			}
+			flushedWitnesses += 1
 		}
+		totalWitnesses += 1
 		return true
 	})
-	bufferLength := float64(bufferTimeSum.Nanoseconds()) / float64(pairCacheCleanupInterval.Nanoseconds())
-	printer.Debugf("Approximate unpaired-witness-cache buffer length: %v", bufferLength)
+	printer.Debugf("flushed-witnesses in cache: %v, total-witnesses in cache: %v", flushedWitnesses, totalWitnesses)
 }


### PR DESCRIPTION
Adds metrics to the agent letting us know:
- How long is the buffer of pcap capture packets
- How long is the buffer of unprocessed packets
- How long is the buffer of parsed network traffic
- How long is the buffer of unpaired partial witnesses