### PR TITLE
[POA-4122] Make kubernetes requests retryable

### DIFF
--- a/integrations/kube_apis/kube_apis.go
+++ b/integrations/kube_apis/kube_apis.go
@@ -5,14 +5,17 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/akitasoftware/go-utils/maps"
 	"github.com/pkg/errors"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	coreV1 "k8s.io/api/core/v1"
+	kubeErrs "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -25,6 +28,15 @@ const (
 	// Env variable key for Kubernetes node name
 	POSTMAN_INSIGHTS_K8S_NODE = "POSTMAN_INSIGHTS_K8S_NODE"
 )
+
+// An exponential retry backoff policy that results in approximately 24 retires over a 24 hour period.
+var retry = wait.Backoff{
+	Duration: 10 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.1,
+	Steps:    24,
+	Cap:      24 * time.Hour,
+}
 
 // KubeClient struct holds the Kubernetes clientset and event watcher
 type KubeClient struct {
@@ -84,9 +96,21 @@ func (kc *KubeClient) Close() {
 // initPodsEventsWatcher creates a new go-channel to listen for pod events in the cluster
 func (kc *KubeClient) initPodsEventsWatcher() error {
 	// Fetch own pod details and get the ResourceVersion
-	fieldSelector := fmt.Sprintf("metadata.name=%s", kc.AgentHost)
-	pods, err := kc.Clientset.CoreV1().Pods("").List(context.Background(), metaV1.ListOptions{
-		FieldSelector: fieldSelector,
+	podsResourceVersion := ""
+	err := wait.ExponentialBackoff(retry, func() (bool, error) {
+		fieldSelector := fmt.Sprintf("metadata.name=%s", kc.AgentHost)
+		pods, err := kc.Clientset.CoreV1().Pods("").List(context.Background(), metaV1.ListOptions{
+			FieldSelector: fieldSelector,
+		})
+		if err != nil {
+			if kubeErrs.IsTimeout(err) {
+				printer.Debugf("request to get agent pod details timeout, retrying...")
+				return false, nil
+			}
+			return false, err
+		}
+		podsResourceVersion = pods.ResourceVersion
+		return true, nil
 	})
 	if err != nil {
 		return errors.Wrap(err, "error getting own pod details")
@@ -94,8 +118,8 @@ func (kc *KubeClient) initPodsEventsWatcher() error {
 
 	// Create a watcher for pod events
 	// Here ResourceVersion is set to the pod's ResourceVersion to watch events after the pod's creation
-	fieldSelector = fmt.Sprintf("spec.nodeName=%s", kc.AgentNode)
-	retryWatcher, err := watchTool.NewRetryWatcher(pods.ResourceVersion, &cache.ListWatch{
+	fieldSelector := fmt.Sprintf("spec.nodeName=%s", kc.AgentNode)
+	retryWatcher, err := watchTool.NewRetryWatcher(podsResourceVersion, &cache.ListWatch{
 		ListFunc: func(options metaV1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = fieldSelector
 			return kc.Clientset.CoreV1().Pods("").List(context.Background(), options)
@@ -115,15 +139,26 @@ func (kc *KubeClient) initPodsEventsWatcher() error {
 
 // GetPodsInNode returns the names of all pods running in a given node
 func (kc *KubeClient) GetPodsInAgentNode() ([]coreV1.Pod, error) {
-	fieldSelector := fmt.Sprintf("spec.nodeName=%s", kc.AgentNode)
-	pods, err := kc.Clientset.CoreV1().Pods("").List(context.Background(), metaV1.ListOptions{
-		FieldSelector: fieldSelector,
+	var pods []coreV1.Pod
+	err := wait.ExponentialBackoff(retry, func() (bool, error) {
+		fieldSelector := fmt.Sprintf("spec.nodeName=%s", kc.AgentNode)
+		podList, err := kc.Clientset.CoreV1().Pods("").List(context.Background(), metaV1.ListOptions{
+			FieldSelector: fieldSelector,
+		})
+		if err != nil {
+			if kubeErrs.IsTimeout(err) {
+				printer.Debugf("request to get pods in agent node timeout, retrying...")
+			}
+			return false, err
+		}
+		pods = podList.Items
+		return true, nil
 	})
 	if err != nil {
 		return []coreV1.Pod{}, errors.Wrap(err, "error getting pods")
 	}
 
-	return pods.Items, nil
+	return pods, nil
 }
 
 // GetPods returns a list of pods running on the agent node with the given names

--- a/integrations/kube_apis/kube_apis.go
+++ b/integrations/kube_apis/kube_apis.go
@@ -104,7 +104,7 @@ func (kc *KubeClient) initPodsEventsWatcher() error {
 		})
 		if err != nil {
 			if kubeErrs.IsTimeout(err) {
-				printer.Debugf("request to get agent pod details timeout, retrying...")
+				printer.Warningf("request to get agent pod details timeout, retrying...")
 				return false, nil
 			}
 			return false, err
@@ -147,7 +147,7 @@ func (kc *KubeClient) GetPodsInAgentNode() ([]coreV1.Pod, error) {
 		})
 		if err != nil {
 			if kubeErrs.IsTimeout(err) {
-				printer.Debugf("request to get pods in agent node timeout, retrying...")
+				printer.Warningf("request to get pods in agent node timeout, retrying...")
 			}
 			return false, err
 		}


### PR DESCRIPTION
Makes requests to the Kubernetes control plane retryable. 

@mgritter the retry policy I put together will do exponential backoff over 24 hours. With retries roughly spaced out as so:
```
10.287155ms
20.192638ms
40.386001ms
83.404268ms
175.904924ms
333.353542ms
688.884691ms
1.403393012s
2.67855389s
5.186614127s
10.281018786s
21.183672466s
43.16988402s
1m24.308865015s
2m45.132908715s
5m40.246872485s
11m44.495217975s
23m51.207256068s
44m2.192306181s
1h28m45.802551329s
3h10m48.696636639s
6h11m47.786646951s
12h29m6.553887233s
23h53m43.937483075s
```

Let me know if you think this is too much or too little. Or if you'd like me to tweak the spacing between retries.

Also, let me know if you would like me to also add a loop around `StartDaemonset` in `cmd/internal/kube/run.go` that checks for retyable errors rather than always going into the `select {}`