### PR TITLE
[POA-3458] - Increase default agent rate limit

### DIFF
--- a/apispec/defaults.go
+++ b/apispec/defaults.go
@@ -25,7 +25,7 @@ const (
 	DefaultParseTLSHandshakes = true
 
 	// How many requests to capture per minute.
-	DefaultRateLimit = 1000.0
+	DefaultRateLimit = 12000.0
 
 	// How often to upload client telemetry.
 	DefaultTelemetryInterval_seconds = 5 * 60 // 5 minutes


### PR DESCRIPTION
The default limit has been manually increased to 12,000 in all k8s clusters (except parcels) for some time now. This PR makes the new limit the default.