### PR TITLE
[POA-4157] Capture service ID on buffer metrics logs

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -746,6 +746,7 @@ func (a *apidump) Run() error {
 				if args.Out.AkitaURI != nil {
 					backendCollector = trace.NewBackendCollector(
 						a.backendSvc,
+						traceTags,
 						backendLrn,
 						a.learnClient,
 						redactor,
@@ -836,7 +837,7 @@ func (a *apidump) Run() error {
 			go func(interfaceName, filter string) {
 				defer doneWG.Done()
 				// Collect trace. This blocks until stop is closed or an error occurs.
-				if err := pcap.Collect(args.ServiceID, stop, interfaceName, filter, targetNetworkNamespace, bufferShare, args.ParseTLSHandshakes, collector, summary, pool); err != nil {
+				if err := pcap.Collect(args.ServiceID, traceTags, stop, interfaceName, filter, targetNetworkNamespace, bufferShare, args.ParseTLSHandshakes, collector, summary, pool); err != nil {
 					errChan <- interfaceError{
 						interfaceName: interfaceName,
 						err:           errors.Wrapf(err, "failed to collect trace on interface %s", interfaceName),

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -836,7 +836,7 @@ func (a *apidump) Run() error {
 			go func(interfaceName, filter string) {
 				defer doneWG.Done()
 				// Collect trace. This blocks until stop is closed or an error occurs.
-				if err := pcap.Collect(stop, interfaceName, filter, targetNetworkNamespace, bufferShare, args.ParseTLSHandshakes, collector, summary, pool); err != nil {
+				if err := pcap.Collect(args.ServiceID, stop, interfaceName, filter, targetNetworkNamespace, bufferShare, args.ParseTLSHandshakes, collector, summary, pool); err != nil {
 					errChan <- interfaceError{
 						interfaceName: interfaceName,
 						err:           errors.Wrapf(err, "failed to collect trace on interface %s", interfaceName),

--- a/integrations/nginx/backend.go
+++ b/integrations/nginx/backend.go
@@ -186,6 +186,7 @@ func NewNginxBackend(args *Args) (*NginxBackend, error) {
 	b.summary = trace.NewPacketCounter()
 	b.collector = trace.NewBackendCollector(
 		b.backendSvc,
+		traceTags,
 		backendLrn,
 		b.learnClient,
 		redactor,

--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -6,6 +6,7 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akinet"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/google/gopacket"
@@ -79,15 +80,16 @@ func (fact *tcpStreamFactory) New(netFlow, tcpFlow gopacket.Flow, _ *layers.TCP,
 type NetworkTrafficObserver func(gopacket.Packet)
 
 type NetworkTrafficParser struct {
+	serviceID   akid.ServiceID
 	pcap        pcapWrapper
 	clock       clockWrapper
 	observer    NetworkTrafficObserver // This function is called for every packet.
 	bufferShare float32
 }
 
-func NewNetworkTrafficParser(bufferShare float32) *NetworkTrafficParser {
+func NewNetworkTrafficParser(serviceID akid.ServiceID, bufferShare float32) *NetworkTrafficParser {
 	return &NetworkTrafficParser{
-		pcap:        &pcapImpl{},
+		pcap:        &pcapImpl{serviceID},
 		clock:       &realClock{},
 		observer:    func(gopacket.Packet) {},
 		bufferShare: bufferShare,
@@ -165,7 +167,7 @@ func (p *NetworkTrafficParser) ParseFromInterface(
 				now := time.Now()
 				if now.Sub(startTime) >= intervalLength {
 					bufferLength := float64(bufferTimeSum.Nanoseconds()) / float64(intervalLength.Nanoseconds())
-					printer.Debugf("Approximate unprocessed-packets buffer length: %v", bufferLength)
+					printer.Debugf("For %v approximate unprocessed-packets buffer length: %v for: %v", p.serviceID, bufferLength)
 					bufferTimeSum = 0 * time.Second
 					startTime = now
 				}

--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akinet"
+	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
@@ -81,15 +82,18 @@ type NetworkTrafficObserver func(gopacket.Packet)
 
 type NetworkTrafficParser struct {
 	serviceID   akid.ServiceID
+	traceTags   map[tags.Key]string
 	pcap        pcapWrapper
 	clock       clockWrapper
 	observer    NetworkTrafficObserver // This function is called for every packet.
 	bufferShare float32
 }
 
-func NewNetworkTrafficParser(serviceID akid.ServiceID, bufferShare float32) *NetworkTrafficParser {
+func NewNetworkTrafficParser(serviceID akid.ServiceID, traceTags map[tags.Key]string, bufferShare float32) *NetworkTrafficParser {
 	return &NetworkTrafficParser{
-		pcap:        &pcapImpl{serviceID},
+		serviceID:   serviceID,
+		traceTags:   traceTags,
+		pcap:        &pcapImpl{serviceID, traceTags},
 		clock:       &realClock{},
 		observer:    func(gopacket.Packet) {},
 		bufferShare: bufferShare,
@@ -167,7 +171,11 @@ func (p *NetworkTrafficParser) ParseFromInterface(
 				now := time.Now()
 				if now.Sub(startTime) >= intervalLength {
 					bufferLength := float64(bufferTimeSum.Nanoseconds()) / float64(intervalLength.Nanoseconds())
-					printer.Debugf("For %v approximate unprocessed-packets buffer length: %v for: %v", p.serviceID, bufferLength)
+					podName, ok := p.traceTags[tags.XAkitaKubernetesPod]
+					if !ok {
+						podName = "unknown"
+					}
+					printer.Debugf("Approximate unprocessed-packets buffer length: %v for svc: %v and pod: %v", bufferLength, p.serviceID, podName)
 					bufferTimeSum = 0 * time.Second
 					startTime = now
 				}

--- a/pcap/net_parse_test.go
+++ b/pcap/net_parse_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akinet"
 	"github.com/akitasoftware/akita-libs/akinet/http"
 	"github.com/akitasoftware/akita-libs/buffer_pool"
+	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/gopacket"
@@ -95,7 +97,7 @@ func makeUDPPackets(split int, ms ...*testMessage) []gopacket.Packet {
 }
 
 func setupParseFromInterface(pcap pcapWrapper, signalClose <-chan struct{}, facts ...akinet.TCPParserFactory) (<-chan akinet.ParsedNetworkTraffic, error) {
-	p := NewNetworkTrafficParser(1.0)
+	p := NewNetworkTrafficParser(akid.GenerateServiceID(), map[tags.Key]string{}, 1.0)
 	p.pcap = pcap
 	p.clock = &fakeClock{testTime}
 	rawOut, err := p.ParseFromInterface("dummy0", "", optionals.None[string](), signalClose, facts...)

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/google/gopacket"
 	_ "github.com/google/gopacket/layers"
@@ -23,7 +24,9 @@ type pcapWrapper interface {
 	getInterfaceAddrs(interfaceName string) ([]net.IP, error)
 }
 
-type pcapImpl struct{}
+type pcapImpl struct {
+	ServiceID akid.ServiceID
+}
 
 func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter string, targetNetworkNamespaceOpt optionals.Optional[string]) (<-chan gopacket.Packet, error) {
 	handle, err := GetPcapHandle(interfaceName, defaultSnapLen, true, BlockForever, targetNetworkNamespaceOpt)
@@ -67,7 +70,7 @@ func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter
 					now := time.Now()
 					if now.Sub(startTime) >= intervalLength {
 						bufferLength := float64(bufferTimeSum.Nanoseconds()) / float64(intervalLength.Nanoseconds())
-						printer.Debugf("Aproximate captured-packets buffer length: %v", bufferLength)
+						printer.Debugf("For %v aproximate captured-packets buffer length: %v for %v", p.ServiceID, bufferLength)
 						bufferTimeSum = 0 * time.Second
 						startTime = now
 					}

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/google/gopacket"
 	_ "github.com/google/gopacket/layers"
@@ -26,6 +27,7 @@ type pcapWrapper interface {
 
 type pcapImpl struct {
 	ServiceID akid.ServiceID
+	TraceTags map[tags.Key]string
 }
 
 func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter string, targetNetworkNamespaceOpt optionals.Optional[string]) (<-chan gopacket.Packet, error) {
@@ -70,7 +72,11 @@ func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter
 					now := time.Now()
 					if now.Sub(startTime) >= intervalLength {
 						bufferLength := float64(bufferTimeSum.Nanoseconds()) / float64(intervalLength.Nanoseconds())
-						printer.Debugf("For %v aproximate captured-packets buffer length: %v for %v", p.ServiceID, bufferLength)
+						podName, ok := p.TraceTags[tags.XAkitaKubernetesPod]
+						if !ok {
+							podName = "unknown"
+						}
+						printer.Debugf("Aproximate captured-packets buffer length: %v, for svc %v and pod: %v", bufferLength, p.ServiceID, podName)
 						bufferTimeSum = 0 * time.Second
 						startTime = now
 					}

--- a/pcap/run.go
+++ b/pcap/run.go
@@ -3,6 +3,7 @@ package pcap
 import (
 	"time"
 
+	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/akinet"
 	akihttp "github.com/akitasoftware/akita-libs/akinet/http"
 	akihttp2 "github.com/akitasoftware/akita-libs/akinet/http2"
@@ -18,6 +19,7 @@ import (
 )
 
 func Collect(
+	serviceID akid.ServiceID,
 	stop <-chan struct{},
 	intf string,
 	bpfFilter string,
@@ -42,7 +44,7 @@ func Collect(
 		)
 	}
 
-	parser := NewNetworkTrafficParser(bufferShare)
+	parser := NewNetworkTrafficParser(serviceID, bufferShare)
 
 	if packetCount != nil {
 		parser.InstallObserver(CountTcpPackets(intf, packetCount))
@@ -60,7 +62,7 @@ func Collect(
 		now := time.Now()
 		if now.Sub(startTime) >= intervalLength {
 			bufferLength := float64(bufferTimeSum.Nanoseconds()) / float64(intervalLength.Nanoseconds())
-			printer.Debugf("Aproximate parsed-network-traffic buffer length: %v", bufferLength)
+			printer.Debugf("For %v aproximate parsed-network-traffic buffer length: %v for %v", serviceID, bufferLength)
 			bufferTimeSum = 0 * time.Second
 			startTime = now
 		}

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -17,6 +17,7 @@ import (
 	"github.com/akitasoftware/akita-libs/http_rest_methods"
 	"github.com/akitasoftware/akita-libs/spec_util"
 	"github.com/akitasoftware/akita-libs/spec_util/ir_hash"
+	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/akitasoftware/go-utils/sets"
 	"github.com/golang/protobuf/proto"
@@ -138,6 +139,7 @@ type LearnSessionCollector interface {
 // Sends witnesses up to akita cloud.
 type BackendCollector struct {
 	serviceID      akid.ServiceID
+	traceTags      map[tags.Key]string
 	learnSessionID akid.LearnSessionID
 	learnClient    rest.LearnClient
 
@@ -167,6 +169,7 @@ var _ LearnSessionCollector = (*BackendCollector)(nil)
 
 func NewBackendCollector(
 	svc akid.ServiceID,
+	traceTags map[tags.Key]string,
 	lrn akid.LearnSessionID,
 	lc rest.LearnClient,
 	redactor *data_masks.Redactor,
@@ -178,6 +181,7 @@ func NewBackendCollector(
 ) Collector {
 	col := &BackendCollector{
 		serviceID:           svc,
+		traceTags:           traceTags,
 		learnSessionID:      lrn,
 		learnClient:         lc,
 		flushDone:           make(chan struct{}),
@@ -443,5 +447,9 @@ func (c *BackendCollector) flushPairCache(cutoffTime time.Time) {
 		totalWitnesses += 1
 		return true
 	})
-	printer.Debugf("For %v flushed-witnesses in cache: %v, total-witnesses in cache: %v for %v", c.serviceID, flushedWitnesses, totalWitnesses)
+	podName, ok := c.traceTags[tags.XAkitaKubernetesPod]
+	if !ok {
+		podName = "unknown"
+	}
+	printer.Debugf("flushed-witnesses in cache: %v, total-witnesses in cache: %v for svc: %v and pod: %v", flushedWitnesses, totalWitnesses, c.serviceID, podName)
 }

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -443,5 +443,5 @@ func (c *BackendCollector) flushPairCache(cutoffTime time.Time) {
 		totalWitnesses += 1
 		return true
 	})
-	printer.Debugf("flushed-witnesses in cache: %v, total-witnesses in cache: %v", flushedWitnesses, totalWitnesses)
+	printer.Debugf("For %v flushed-witnesses in cache: %v, total-witnesses in cache: %v for %v", c.serviceID, flushedWitnesses, totalWitnesses)
 }

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/akitasoftware/akita-libs/batcher"
 	"github.com/akitasoftware/akita-libs/memview"
 	"github.com/akitasoftware/akita-libs/spec_util"
+	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
@@ -137,6 +138,7 @@ func TestRedact(t *testing.T) {
 
 	col := NewBackendCollector(
 		fakeSvc,
+		map[tags.Key]string{},
 		fakeLrn,
 		mockClient,
 		redactor,
@@ -485,6 +487,7 @@ func TestTiming(t *testing.T) {
 
 			col := NewBackendCollector(
 				fakeSvc,
+				map[tags.Key]string{},
 				fakeLrn,
 				mockClient,
 				redactor,
@@ -524,6 +527,7 @@ func TestMultipleInterfaces(t *testing.T) {
 
 	bc := NewBackendCollector(
 		fakeSvc,
+		map[tags.Key]string{},
 		fakeLrn,
 		mockClient,
 		redactor,
@@ -673,6 +677,7 @@ func TestOnlyRedactNonErrorResponses(t *testing.T) {
 
 	col := NewBackendCollector(
 		fakeSvc,
+		map[tags.Key]string{},
 		fakeLrn,
 		mockClient,
 		redactor,
@@ -1490,6 +1495,7 @@ func TestRedactionConfigs(t *testing.T) {
 
 		col := NewBackendCollector(
 			fakeSvc,
+			map[tags.Key]string{},
 			fakeLrn,
 			mockClient,
 			redactor,


### PR DESCRIPTION
As far as I can tell the traceTags should be flowing through the codebase, so not sure why we are not seeing them on the backend. This PR attempts to log the pod name by passing the tracetags to the apidump layer.