### PR TITLE
[POA-3089] Change telemetry package to handle daemon set sub processes

### DIFF
--- a/apidump/net.go
+++ b/apidump/net.go
@@ -17,7 +17,6 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/env"
 	"github.com/postmanlabs/postman-insights-agent/pcap"
 	"github.com/postmanlabs/postman-insights-agent/printer"
-	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
 
 // An interface that's compatible with net.Interface so we can use mock
@@ -197,7 +196,7 @@ func checkPcapPermissions(interfaces map[string]interfaceInfo, targetNetworkName
 			defer wg.Done()
 			h, err := pcap.GetPcapHandle(iface, 1600, true, pcap.BlockForever, targetNetworkNamespaceOpt)
 			if err != nil {
-				telemetry.Error("pcap permissions", err)
+				apidumpTelemetry.Error("pcap permissions", err)
 				errChan <- &pcapPermErr{iface: iface, err: err}
 				return
 			}

--- a/cmd/internal/cmderr/checks.go
+++ b/cmd/internal/cmderr/checks.go
@@ -42,7 +42,7 @@ func CheckAPIKeyAndInsightsProjectID(projectID string) error {
 		return errors.New("project ID is missing, it must be specified")
 	}
 
-	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID(), nil)
+	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID(), nil, nil)
 	var serviceID akid.ServiceID
 	err = akid.ParseIDAs(projectID, &serviceID)
 	if err != nil {

--- a/cmd/internal/kube/daemonset/daemonset.go
+++ b/cmd/internal/kube/daemonset/daemonset.go
@@ -64,6 +64,7 @@ func StartDaemonset(args DaemonsetArgs) error {
 		rest.Domain,
 		telemetry.GetClientID(),
 		rest.DaemonsetAuthHandler(postmanInsightsVerificationToken),
+		nil,
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), apiContextTimeout)
 	defer cancel()

--- a/cmd/internal/kube/inject.go
+++ b/cmd/internal/kube/inject.go
@@ -188,7 +188,7 @@ func lookupService(insightsProjectID string) error {
 		return fmt.Errorf("Can't parse %q as project ID.", insightsProjectID)
 	}
 
-	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID(), nil)
+	frontClient := rest.NewFrontClient(rest.Domain, telemetry.GetClientID(), nil, nil)
 
 	_, err = util.GetServiceNameByServiceID(frontClient, serviceID)
 	return err

--- a/cmd/internal/legacy/specs.go
+++ b/cmd/internal/legacy/specs.go
@@ -122,7 +122,7 @@ func runGetSpec(specIdentifier string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to parse project ID")
 	}
-	learnClient := rest.NewLearnClient(rest.Domain, clientID, serviceID, nil)
+	learnClient := rest.NewLearnClient(rest.Domain, clientID, serviceID, nil, nil)
 
 	// Check to see if the user specified an AkID or a version name.
 	var specID akid.APISpecID

--- a/integrations/nginx/backend.go
+++ b/integrations/nginx/backend.go
@@ -160,13 +160,13 @@ func NewNginxBackend(args *Args) (*NginxBackend, error) {
 		startTime:  time.Now(),
 	}
 
-	frontClient := rest.NewFrontClient(args.Domain, args.ClientID, nil)
+	frontClient := rest.NewFrontClient(args.Domain, args.ClientID, nil, nil)
 	backendSvc, err := util.GetServiceIDByName(frontClient, args.ServiceName)
 	if err != nil {
 		return nil, err
 	}
 	b.backendSvc = backendSvc
-	b.learnClient = rest.NewLearnClient(args.Domain, args.ClientID, backendSvc, nil)
+	b.learnClient = rest.NewLearnClient(args.Domain, args.ClientID, backendSvc, nil, nil)
 
 	traceTags := map[tags.Key]string{
 		tags.XAkitaSource: "nginx",
@@ -195,6 +195,7 @@ func NewNginxBackend(args *Args) (*NginxBackend, error) {
 		false,
 		args.Plugins,
 		apispec.DefaultMaxWintessUploadBuffers,
+		telemetry.Default(),
 	)
 
 	// TODO: rate-limit

--- a/integrations/nginx/install.go
+++ b/integrations/nginx/install.go
@@ -86,9 +86,6 @@ func InstallModule(args *InstallArgs) error {
 		return err
 	}
 
-	// Report the version being attempted
-	telemetry.InstallIntegrationVersion("NGINX", arch, platform, version)
-
 	// The downside of using Github is we don't get any hierarchy, so it
 	// all has to be crammed into the name.
 	expectedFilename := fmt.Sprintf("ngx_http_akita_module_%s_%s_%s.so",

--- a/pcap/net_parse_test.go
+++ b/pcap/net_parse_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/gopacket"
+	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
 
 var (
@@ -97,7 +98,7 @@ func makeUDPPackets(split int, ms ...*testMessage) []gopacket.Packet {
 }
 
 func setupParseFromInterface(pcap pcapWrapper, signalClose <-chan struct{}, facts ...akinet.TCPParserFactory) (<-chan akinet.ParsedNetworkTraffic, error) {
-	p := NewNetworkTrafficParser(akid.GenerateServiceID(), map[tags.Key]string{}, 1.0)
+	p := NewNetworkTrafficParser(akid.GenerateServiceID(), map[tags.Key]string{}, 1.0, telemetry.Default())
 	p.pcap = pcap
 	p.clock = &fakeClock{testTime}
 	rawOut, err := p.ParseFromInterface("dummy0", "", optionals.None[string](), signalClose, facts...)

--- a/pcap/pcap_replay_test.go
+++ b/pcap/pcap_replay_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/gopacket/pcap"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
 
 // Constants wrapped as functions because we can't read the testdata file at
@@ -178,7 +179,7 @@ func (filePcapWrapper) getInterfaceAddrs(interfaceName string) ([]net.IP, error)
 }
 
 func readFromPcapFile(file string, pool buffer_pool.BufferPool) ([]akinet.ParsedNetworkTraffic, error) {
-	p := NewNetworkTrafficParser(akid.GenerateServiceID(), map[tags.Key]string{}, 1.0)
+	p := NewNetworkTrafficParser(akid.GenerateServiceID(), map[tags.Key]string{}, 1.0, telemetry.Default())
 	p.pcap = filePcapWrapper(file)
 
 	done := make(chan struct{})

--- a/pcap/run.go
+++ b/pcap/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/pkg/errors"
 	"github.com/postmanlabs/postman-insights-agent/printer"
+	"github.com/postmanlabs/postman-insights-agent/telemetry"
 	"github.com/postmanlabs/postman-insights-agent/trace"
 )
 
@@ -31,6 +32,7 @@ func Collect(
 	proc trace.Collector,
 	packetCount trace.PacketCountConsumer,
 	pool buffer_pool.BufferPool,
+	telemetry telemetry.Tracker,
 ) error {
 	defer proc.Close()
 
@@ -46,7 +48,7 @@ func Collect(
 		)
 	}
 
-	parser := NewNetworkTrafficParser(serviceID, traceTags, bufferShare)
+	parser := NewNetworkTrafficParser(serviceID, traceTags, bufferShare, telemetry)
 
 	if packetCount != nil {
 		parser.InstallObserver(CountTcpPackets(intf, packetCount))

--- a/rest/base_client.go
+++ b/rest/base_client.go
@@ -15,71 +15,73 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Use a proxy, "" is none. (This is because the flags package doesn't support Optional)
-// May be a URL, a domain name, or an IP address.  HTTP is assumed as the protocol if
-// none is provided.
-var ProxyAddress string
+type (
+	// Error handling (to call into the telemetry library without
+	// creating a circular dependency.)
+	APIErrorHandler = func(method string, path string, e error)
 
-// Accept a server name other than the expected one in the TLS handshake
-var ExpectedServerName string
-
-// Error handling (to call into the telemetry library without
-// creating a circular dependency.)
-type APIErrorHandler = func(method string, path string, e error)
-
-var (
-	apiErrorHandler      APIErrorHandler = nil
-	apiErrorHandlerMutex sync.RWMutex
+	// Authentication handler
+	AuthHandler = func(*http.Request) error
 )
 
-func reportError(method string, path string, e error) {
-	apiErrorHandlerMutex.RLock()
-	defer apiErrorHandlerMutex.RUnlock()
-	if apiErrorHandler != nil {
-		apiErrorHandler(method, path, e)
-	}
-}
+var (
+	// Use a proxy, "" is none. (This is because the flags package doesn't support Optional)
+	// May be a URL, a domain name, or an IP address.  HTTP is assumed as the protocol if
+	// none is provided.
+	ProxyAddress string
+	// Accept a server name other than the expected one in the TLS handshake
+	ExpectedServerName string
 
-func SetAPIErrorHandler(f APIErrorHandler) {
-	apiErrorHandlerMutex.Lock()
-	defer apiErrorHandlerMutex.Unlock()
-	apiErrorHandler = f
+	BaseAPIErrorHandler APIErrorHandler
+)
+
+func reportError(client *BaseClient, method string, path string, e error) {
+	client.errorReporterMutex.RLock()
+	defer client.errorReporterMutex.RUnlock()
+	client.apiErrorHandler(method, path, e)
 }
 
 type BaseClient struct {
-	host        string
-	scheme      string // http or https
-	clientID    akid.ClientID
-	authHandler func(*http.Request) error
+	host               string
+	scheme             string // http or https
+	clientID           akid.ClientID
+	authHandler        func(*http.Request) error
+	apiErrorHandler    APIErrorHandler
+	errorReporterMutex sync.RWMutex
 }
 
-func NewBaseClient(rawHost string, cli akid.ClientID, authHandler func(*http.Request) error) BaseClient {
+func NewBaseClient(rawHost string, cli akid.ClientID, authHandler AuthHandler, apiErrorHandler APIErrorHandler) *BaseClient {
 	if authHandler == nil {
 		authHandler = baseAuthHandler
 	}
 
+	if apiErrorHandler == nil {
+		apiErrorHandler = BaseAPIErrorHandler
+	}
+
 	c := BaseClient{
-		scheme:      "https",
-		host:        rawHost,
-		clientID:    cli,
-		authHandler: authHandler,
+		scheme:          "https",
+		host:            rawHost,
+		clientID:        cli,
+		authHandler:     authHandler,
+		apiErrorHandler: apiErrorHandler,
 	}
 	if viper.GetBool("test_only_disable_https") {
 		fmt.Fprintf(os.Stderr, "WARNING: using test backend without SSL\n")
 		c.scheme = "http"
 	}
-	return c
+	return &c
 }
 
 // Sends GET request and parses the response as JSON.
-func (c BaseClient) Get(ctx context.Context, path string, resp interface{}) error {
+func (c *BaseClient) Get(ctx context.Context, path string, resp interface{}) error {
 	return c.GetWithQuery(ctx, path, nil, resp)
 }
 
-func (c BaseClient) GetWithQuery(ctx context.Context, path string, query url.Values, resp interface{}) (e error) {
+func (c *BaseClient) GetWithQuery(ctx context.Context, path string, query url.Values, resp interface{}) (e error) {
 	defer func() {
 		if e != nil {
-			reportError(http.MethodGet, path, e)
+			reportError(c, http.MethodGet, path, e)
 		}
 	}()
 	u := &url.URL{
@@ -105,10 +107,10 @@ func (c BaseClient) GetWithQuery(ctx context.Context, path string, query url.Val
 
 // Sends POST request after marshaling body into JSON and parses the response as
 // JSON.
-func (c BaseClient) Post(ctx context.Context, path string, body interface{}, resp interface{}) (e error) {
+func (c *BaseClient) Post(ctx context.Context, path string, body interface{}, resp interface{}) (e error) {
 	defer func() {
 		if e != nil {
-			reportError(http.MethodPost, path, e)
+			reportError(c, http.MethodPost, path, e)
 		}
 	}()
 

--- a/rest/base_client.go
+++ b/rest/base_client.go
@@ -38,7 +38,9 @@ var (
 func reportError(client *BaseClient, method string, path string, e error) {
 	client.errorReporterMutex.RLock()
 	defer client.errorReporterMutex.RUnlock()
-	client.apiErrorHandler(method, path, e)
+	if client.apiErrorHandler != nil {
+		client.apiErrorHandler(method, path, e)
+	}
 }
 
 type BaseClient struct {

--- a/rest/front_client.go
+++ b/rest/front_client.go
@@ -2,7 +2,6 @@ package rest
 
 import (
 	"context"
-	"net/http"
 	"path"
 
 	"github.com/akitasoftware/akita-libs/akid"
@@ -11,14 +10,14 @@ import (
 )
 
 type frontClientImpl struct {
-	BaseClient
+	*BaseClient
 }
 
 var _ FrontClient = (*frontClientImpl)(nil)
 
-func NewFrontClient(host string, cli akid.ClientID, authHandler func(*http.Request) error) *frontClientImpl {
+func NewFrontClient(host string, cli akid.ClientID, authHandler AuthHandler, apiErrorHandler APIErrorHandler) *frontClientImpl {
 	return &frontClientImpl{
-		BaseClient: NewBaseClient(host, cli, authHandler),
+		BaseClient: NewBaseClient(host, cli, authHandler, apiErrorHandler),
 	}
 }
 

--- a/rest/learn_client.go
+++ b/rest/learn_client.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 	"path"
 	"strconv"
@@ -16,16 +15,16 @@ import (
 )
 
 type learnClientImpl struct {
-	BaseClient
+	*BaseClient
 
 	serviceID akid.ServiceID
 }
 
 var _ LearnClient = (*learnClientImpl)(nil)
 
-func NewLearnClient(host string, cli akid.ClientID, svc akid.ServiceID, authHandler func(*http.Request) error) *learnClientImpl {
+func NewLearnClient(host string, cli akid.ClientID, svc akid.ServiceID, authHandler AuthHandler, apiErrorHandler APIErrorHandler) *learnClientImpl {
 	return &learnClientImpl{
-		BaseClient: NewBaseClient(host, cli, authHandler),
+		BaseClient: NewBaseClient(host, cli, authHandler, apiErrorHandler),
 		serviceID:  svc,
 	}
 }

--- a/setversion/run.go
+++ b/setversion/run.go
@@ -10,7 +10,7 @@ import (
 
 func Run(args Args) error {
 	// Resolve service ID.
-	frontClient := rest.NewFrontClient(args.Domain, args.ClientID, nil)
+	frontClient := rest.NewFrontClient(args.Domain, args.ClientID, nil, nil)
 	serviceName := args.ModelURI.ServiceName
 	serviceID, err := util.GetServiceIDByName(frontClient, serviceName)
 	if err != nil {
@@ -18,7 +18,7 @@ func Run(args Args) error {
 	}
 
 	// Resolve API model ID.
-	learnClient := rest.NewLearnClient(args.Domain, args.ClientID, serviceID, nil)
+	learnClient := rest.NewLearnClient(args.Domain, args.ClientID, serviceID, nil, nil)
 	modelID, err := util.ResolveSpecURI(learnClient, args.ModelURI)
 	if err != nil {
 		return err

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -281,6 +281,14 @@ func (t *trackerImpl) Error(inContext string, e error) {
 	)
 }
 
+// Report an error in a particular operation (inContext), including
+// the text of the error.  Send only one trace event per minute for
+// this particular context; count the remainder.
+//
+// Rate-limited errors are not flushed when telemetry is shut down.
+//
+// TODO: consider using the error too, but that could increase
+// the cardinality of the map by a lot.
 func (t *trackerImpl) RateLimitError(inContext string, e error) {
 	newRecord := eventRecord{
 		Count:    0,

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -35,7 +35,7 @@ var (
 	defaultAmplitudeKey = ""
 
 	// Default tracking user for root instance
-	defaultTrackingUser *TrackingUser
+	defaultTrackingUser *TrackingUser = &TrackingUser{}
 
 	serviceIDRegex = regexp.MustCompile(`^svc_[A-Za-z0-9]{22}$`)
 

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -163,6 +163,8 @@ type BackendCollector struct {
 	plugins []plugin.AkitaPlugin
 
 	redactor *data_masks.Redactor
+
+	telemetry telemetry.Tracker
 }
 
 var _ LearnSessionCollector = (*BackendCollector)(nil)
@@ -178,6 +180,7 @@ func NewBackendCollector(
 	sendWitnessPayloads bool,
 	plugins []plugin.AkitaPlugin,
 	uploadReportBuffers int,
+	telemetry telemetry.Tracker,
 ) Collector {
 	col := &BackendCollector{
 		serviceID:           svc,
@@ -188,6 +191,7 @@ func NewBackendCollector(
 		plugins:             plugins,
 		sendWitnessPayloads: sendWitnessPayloads,
 		redactor:            redactor,
+		telemetry:           telemetry,
 	}
 
 	col.uploadReportBatch = batcher.NewInMemory[rawReport](
@@ -220,7 +224,7 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 	}
 
 	if parseHTTPErr != nil {
-		telemetry.RateLimitError("parse HTTP", parseHTTPErr)
+		c.telemetry.RateLimitError("parse HTTP", parseHTTPErr)
 		printer.Debugf("Failed to parse HTTP, skipping: %v\n", parseHTTPErr)
 		return nil
 	}

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/apispec"
 	"github.com/postmanlabs/postman-insights-agent/data_masks"
 	mockrest "github.com/postmanlabs/postman-insights-agent/rest"
+	"github.com/postmanlabs/postman-insights-agent/telemetry"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -147,6 +148,7 @@ func TestRedact(t *testing.T) {
 		false,
 		nil,
 		apispec.DefaultMaxWintessUploadBuffers,
+		telemetry.Default(),
 	)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
@@ -496,6 +498,7 @@ func TestTiming(t *testing.T) {
 				false,
 				nil,
 				apispec.DefaultMaxWintessUploadBuffers,
+				telemetry.Default(),
 			)
 			for _, pnt := range test.PNTs {
 				assert.NoError(t, col.Process(pnt))
@@ -536,6 +539,7 @@ func TestMultipleInterfaces(t *testing.T) {
 		false,
 		nil,
 		apispec.DefaultMaxWintessUploadBuffers,
+		telemetry.Default(),
 	)
 
 	var wg sync.WaitGroup
@@ -686,6 +690,7 @@ func TestOnlyRedactNonErrorResponses(t *testing.T) {
 		true,
 		nil,
 		apispec.DefaultMaxWintessUploadBuffers,
+		telemetry.Default(),
 	)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
@@ -1504,6 +1509,7 @@ func TestRedactionConfigs(t *testing.T) {
 			true,
 			nil,
 			apispec.DefaultMaxWintessUploadBuffers,
+			telemetry.Default(),
 		)
 		assert.NoError(t, col.Process(req))
 		assert.NoError(t, col.Process(resp))

--- a/util/util.go
+++ b/util/util.go
@@ -22,7 +22,6 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/consts"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/postmanlabs/postman-insights-agent/rest"
-	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
 
 var (
@@ -95,7 +94,6 @@ func GetServiceIDByName(c rest.FrontClient, name string) (akid.ServiceID, error)
 		printer.Stderr.Debugf("Project name %q is %q\n", name, akid.String(result))
 		return result, nil
 	}
-	telemetry.Failure("Unknown project ID")
 	return akid.ServiceID{}, errors.Errorf("cannot determine project ID for %s", name)
 }
 
@@ -322,7 +320,7 @@ func GetTraceURIByTags(
 		return akiuri.URI{}, fmt.Errorf("%q currently supports only a single tag", flagName)
 	}
 
-	learnClient := rest.NewLearnClient(domain, clientID, serviceID, nil)
+	learnClient := rest.NewLearnClient(domain, clientID, serviceID, nil, nil)
 	learnSession, err := GetLearnSessionByTags(learnClient, serviceID, tags)
 	if err != nil {
 		return akiuri.URI{}, errors.Wrapf(err, "failed to list traces for %q", serviceName)


### PR DESCRIPTION
In this PR, we have changed the telemetry package to provide telemetry support for subprocesses (go routines) under the main processes.

Changes:
- Telemetry package changes:
  - Move the global functions under an interface and struct model.
  - Created a root (Default) telemetry object, which is used by the existing processes for sending telemetry
  - A new constructor which will create a new scoped telemetry object.
  - Removed the irrelevant analytics functions which were used in deprecated functions.
- apidump and rest client changes:
  - Change the way the error report function is set in the base client, not it will be passed as a parameter to the constructor, just like the auth handler
  - Set a global package telemetry variable in the apidump package to use it in various functions instead of passing it as a parameter down the chain.
  - Changes in pcap and trace package functions to use the telemetry function used by the apidump process. _(Yes, this is contradicting to what we did in the previous point)_
- Other syntactical changes and rearrangements.