### PR TITLE
[POA-4390] New flag to always capture payloads

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -154,6 +154,9 @@ type Args struct {
 	// Whether to enable repro mode and include request/response payloads when uploading witnesses.
 	ReproMode bool
 
+	// Always capture request and response payloads for the given paths.
+	AlwaysCapturePayloads []string
+
 	// Whether to drop traffic to/from nginx
 	DropNginxTraffic bool
 
@@ -769,6 +772,7 @@ func (a *apidump) Run() error {
 						optionals.Some(a.MaxWitnessSize_bytes),
 						summary,
 						args.ReproMode,
+						optionals.Some(args.AlwaysCapturePayloads),
 						args.Plugins,
 						args.MaxWitnessUploadBuffers,
 						apidumpTelemetry,

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -242,6 +242,9 @@ func apidumpRunInternal(_ *cobra.Command, _ []string) error {
 
 		// TODO: remove the SendWitnessPayloads flag once all existing users are migrated to new flag.
 		ReproMode: commonApidumpFlags.EnableReproMode || commonApidumpFlags.SendWitnessPayloads,
+
+		// TODO: Add this flag in kube run command to fetch from service env vars
+		AlwaysCapturePayloads: commonApidumpFlags.AlwaysCapturePayloads,
 	}
 	if err := apidump.Run(args); err != nil {
 		return cmderr.AkitaErr{Err: err}

--- a/cmd/internal/apidump/common_flags.go
+++ b/cmd/internal/apidump/common_flags.go
@@ -7,16 +7,17 @@ import (
 )
 
 type CommonApidumpFlags struct {
-	Filter              string
-	HostAllowlist       []string
-	HostExclusions      []string
-	Interfaces          []string
-	PathAllowlist       []string
-	PathExclusions      []string
-	RandomizedStart     int
-	RateLimit           float64
-	SendWitnessPayloads bool
-	EnableReproMode     bool
+	Filter                string
+	HostAllowlist         []string
+	HostExclusions        []string
+	Interfaces            []string
+	PathAllowlist         []string
+	PathExclusions        []string
+	RandomizedStart       int
+	RateLimit             float64
+	SendWitnessPayloads   bool
+	EnableReproMode       bool
+	AlwaysCapturePayloads []string
 }
 
 func AddCommonApiDumpFlags(cmd *cobra.Command) *CommonApidumpFlags {
@@ -94,6 +95,14 @@ func AddCommonApiDumpFlags(cmd *cobra.Command) *CommonApidumpFlags {
 		"Enable repro mode to send request and response payloads to Postman.",
 	)
 
+	cmd.PersistentFlags().StringSliceVar(
+		&flags.AlwaysCapturePayloads,
+		"always-capture-payloads",
+		nil,
+		"Always capture request and response payloads for the given paths.",
+	)
+	_ = cmd.PersistentFlags().MarkHidden("always-capture-payloads")
+
 	return flags
 }
 
@@ -137,6 +146,9 @@ func ConvertCommonApiDumpFlagsToArgs(flags *CommonApidumpFlags) []string {
 	}
 	for _, path := range flags.PathExclusions {
 		commonApidumpArgs = append(commonApidumpArgs, "--path-exclusions", path)
+	}
+	for _, path := range flags.AlwaysCapturePayloads {
+		commonApidumpArgs = append(commonApidumpArgs, "--always-capture-payloads", path)
 	}
 
 	return commonApidumpArgs

--- a/integrations/nginx/backend.go
+++ b/integrations/nginx/backend.go
@@ -193,6 +193,7 @@ func NewNginxBackend(args *Args) (*NginxBackend, error) {
 		optionals.Some(args.MaxWitnessSize_bytes),
 		b.summary,
 		false,
+		optionals.None[[]string](),
 		args.Plugins,
 		apispec.DefaultMaxWintessUploadBuffers,
 		telemetry.Default(),

--- a/trace/util.go
+++ b/trace/util.go
@@ -1,6 +1,57 @@
 package trace
 
-import pb "github.com/akitasoftware/akita-ir/go/api_spec"
+import (
+	"regexp"
+	"strings"
+
+	pb "github.com/akitasoftware/akita-ir/go/api_spec"
+	"github.com/akitasoftware/akita-libs/http_rest_methods"
+)
+
+// Returns true if the witness should be excluded from Repro Mode.
+//
+// XXX This is a stop-gap hack to exclude certain endpoints for Cloud API from
+// Repro Mode.
+func excludeWitnessFromReproMode(method *pb.Method) bool {
+	httpMeta := method.GetMeta().GetHttp()
+	if httpMeta == nil {
+		return false
+	}
+
+	if cloudAPIHostnames.Contains(strings.ToLower(httpMeta.Host)) {
+		switch httpMeta.Method {
+		case http_rest_methods.GET.String():
+			// Exclude GET /environments/{environment}.
+			if cloudAPIEnvironmentsPathRE.MatchString(httpMeta.PathTemplate) {
+				return true
+			}
+
+		case http_rest_methods.POST.String():
+			// Exclude POST /environments.
+			if httpMeta.PathTemplate == "/environments" {
+				return true
+			}
+
+		case http_rest_methods.PUT.String():
+			// Exclude PUT /environments/{environment}.
+			// Exclude GET /environments/{environment}.
+			if cloudAPIEnvironmentsPathRE.MatchString(httpMeta.PathTemplate) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Returns true if the witness path matches the always capture payloads regex.
+func hasMatchingPath(witness *pb.Witness, alwaysCapturePayloadsPathsRegex []*regexp.Regexp) bool {
+	for _, pathRE := range alwaysCapturePayloadsPathsRegex {
+		if pathRE.MatchString(witness.GetMethod().GetMeta().GetHttp().GetPathTemplate()) {
+			return true
+		}
+	}
+	return false
+}
 
 // Determines whether a given method has only error (4xx or 5xx) response codes.
 // Returns true if the method has at least one response and all response codes are 4xx or 5xx.
@@ -19,4 +70,24 @@ func hasOnlyErrorResponses(method *pb.Method) bool {
 	}
 
 	return true
+}
+
+// Returns true if the witness payload should be captured.
+func shouldCapturePayload(witness *pb.Witness, alwaysCapturePayloadsPathsRegex []*regexp.Regexp) bool {
+	// Step 1: Check if the witness should be excluded from Repro Mode.
+	if excludeWitnessFromReproMode(witness.GetMethod()) {
+		return false
+	}
+
+	// Step 2: Check if the method path matches the always capture payloads regex.
+	if hasMatchingPath(witness, alwaysCapturePayloadsPathsRegex) {
+		return true
+	}
+
+	// Step 3: Check if the method has only error responses.
+	if hasOnlyErrorResponses(witness.GetMethod()) {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
We have added a new flag to get the list of paths for which we will always send the payloads, regardless of the response code.

Changes:
1. Added a new flag `always-capture-payloads` flag, marked as hidden.
2. Pass this flag's value to the backend collector
3. Construct a regex slice from the list, if any regex fails to compile, log it and continue
4. Move the witness checks to util.go file and combine under a common function `shouldCapturePayload()`
4. Added test case.
