### PR TITLE
[1289] Fix eBPF kernel 5.10 compatibility: use PERCPU_HASH for rate buckets

### DIFF
--- a/ebpf/loader/loader_linux.go
+++ b/ebpf/loader/loader_linux.go
@@ -86,10 +86,20 @@ func (l *Loader) SetRateCapPerSec(v uint32) error {
 	return l.libssl.RateCapPerSec.Set(v)
 }
 
-// RefillRateBucket sets a single PID's bucket to `tokens`. Userspace calls
-// this once per second from the per-PID refill goroutine.
+// RefillRateBucket sets a single PID's bucket to `tokens` on all CPUs.
+// Userspace calls this once per second from the per-PID refill goroutine.
+// PidRateBuckets is a PERCPU_HASH map so the value must be a slice of
+// length >= possible CPUs — one slot per CPU.
 func (l *Loader) RefillRateBucket(pid uint32, tokens uint64) error {
-	return l.libssl.PidRateBuckets.Update(&pid, &tokens, ebpf.UpdateAny)
+	nCPU, err := ebpf.PossibleCPU()
+	if err != nil {
+		return fmt.Errorf("ebpf: get possible CPUs: %w", err)
+	}
+	values := make([]uint64, nCPU)
+	for i := range values {
+		values[i] = tokens
+	}
+	return l.libssl.PidRateBuckets.Update(&pid, values, ebpf.UpdateAny)
 }
 
 // DeleteRateBucket removes a PID from the rate-bucket map (called on PID exit).

--- a/ebpf/loader/loader_stub.go
+++ b/ebpf/loader/loader_stub.go
@@ -44,7 +44,7 @@ func (*Loader) RateBucketsMap() any                     { return nil }
 func (*Loader) SSLFdMap() (any, bool)                   { return nil, false }
 func (*Loader) SetRateCapPerSec(_ uint32) error         { return ErrUnsupported }
 func (*Loader) RefillRateBucket(_ uint32, _ uint64) error { return ErrUnsupported }
-func (*Loader) DeleteRateBucket(_ uint32) error         { return ErrUnsupported }
+func (*Loader) DeleteRateBucket(_ uint32) error           { return ErrUnsupported }
 func OpenExecutable(_ string) (any, error)              { return nil, ErrUnsupported }
 
 // Counter index constants (mirrored from loader_linux.go) so non-eBPF builds

--- a/ebpf/loader/ratecap_test.go
+++ b/ebpf/loader/ratecap_test.go
@@ -7,11 +7,27 @@ package loader
 import (
 	"os"
 	"testing"
+
+	"github.com/cilium/ebpf"
 )
 
+// lookupPerCPU is a helper that reads all per-CPU slots for a PID from
+// PidRateBuckets (PERCPU_HASH) and returns the slice.
+func lookupPerCPU(t *testing.T, l *Loader, pid uint32) []uint64 {
+	t.Helper()
+	nCPU, err := ebpf.PossibleCPU()
+	if err != nil {
+		t.Fatalf("PossibleCPU: %v", err)
+	}
+	got := make([]uint64, nCPU)
+	if err := l.libssl.PidRateBuckets.Lookup(&pid, &got); err != nil {
+		t.Fatalf("Lookup bucket pid=%d: %v", pid, err)
+	}
+	return got
+}
+
 // TestRateCapKnob loads the BPF program, sets a rate cap, manually populates
-// one bucket, drains it via the BPF-accessible counter path, and verifies
-// behaviour.
+// one bucket, reads it back across all CPU slots, and verifies deletion.
 //
 // Requires root (CAP_BPF + CAP_PERFMON).
 func TestRateCapKnob(t *testing.T) {
@@ -25,31 +41,113 @@ func TestRateCapKnob(t *testing.T) {
 	}
 	defer l.Close()
 
-	// Enable rate cap at 5/sec.
 	if err := l.SetRateCapPerSec(5); err != nil {
 		t.Fatalf("SetRateCapPerSec: %v", err)
 	}
 
-	// Pre-populate a bucket for an arbitrary PID and read it back.
 	const fakePID uint32 = 99999
 	if err := l.RefillRateBucket(fakePID, 5); err != nil {
 		t.Fatalf("RefillRateBucket: %v", err)
 	}
 
-	var got uint64
-	pid := fakePID
-	if err := l.libssl.PidRateBuckets.Lookup(&pid, &got); err != nil {
-		t.Fatalf("Lookup bucket: %v", err)
-	}
-	if got != 5 {
-		t.Errorf("bucket = %d, want 5", got)
+	// PidRateBuckets is PERCPU_HASH — all CPU slots must be set to 5.
+	for cpu, v := range lookupPerCPU(t, l, fakePID) {
+		if v != 5 {
+			t.Errorf("CPU %d: bucket = %d, want 5", cpu, v)
+		}
 	}
 
-	// Delete and verify.
+	// Delete and verify entry is gone.
 	if err := l.DeleteRateBucket(fakePID); err != nil {
 		t.Fatalf("DeleteRateBucket: %v", err)
 	}
-	if err := l.libssl.PidRateBuckets.Lookup(&pid, &got); err == nil {
+	nCPU, _ := ebpf.PossibleCPU()
+	dummy := make([]uint64, nCPU)
+	pid := fakePID
+	if err := l.libssl.PidRateBuckets.Lookup(&pid, &dummy); err == nil {
 		t.Errorf("bucket still present after Delete")
+	}
+}
+
+// TestRateCapPercpuIsolation verifies that RefillRateBucket initialises every
+// CPU slot to the requested token count. This is the key PERCPU_HASH property:
+// each CPU owns its copy so no atomic operations are needed in BPF.
+func TestRateCapPercpuIsolation(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+
+	l, err := Load(Default())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer l.Close()
+
+	const fakePID uint32 = 12345
+	const wantTokens uint64 = 10
+
+	if err := l.RefillRateBucket(fakePID, wantTokens); err != nil {
+		t.Fatalf("RefillRateBucket: %v", err)
+	}
+
+	for cpu, v := range lookupPerCPU(t, l, fakePID) {
+		if v != wantTokens {
+			t.Errorf("CPU %d: tokens = %d, want %d", cpu, v, wantTokens)
+		}
+	}
+}
+
+// TestRateCapDisabled verifies that when rate_cap_per_sec == 0 (default),
+// no bucket entry is required — the BPF program allows all events through.
+func TestRateCapDisabled(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+
+	l, err := Load(Default())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer l.Close()
+
+	// Rate cap is 0 by default — do NOT call SetRateCapPerSec.
+	nCPU, err := ebpf.PossibleCPU()
+	if err != nil {
+		t.Fatalf("PossibleCPU: %v", err)
+	}
+	const fakePID uint32 = 77777
+	pid := fakePID
+	dummy := make([]uint64, nCPU)
+	if err := l.libssl.PidRateBuckets.Lookup(&pid, &dummy); err == nil {
+		t.Errorf("expected no bucket entry when rate cap is disabled, got one")
+	}
+}
+
+// TestRateCapRefillOverwrite verifies that a second RefillRateBucket call
+// overwrites all CPU slots with the new token count.
+func TestRateCapRefillOverwrite(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+
+	l, err := Load(Default())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer l.Close()
+
+	const fakePID uint32 = 55555
+
+	if err := l.RefillRateBucket(fakePID, 3); err != nil {
+		t.Fatalf("RefillRateBucket(3): %v", err)
+	}
+	if err := l.RefillRateBucket(fakePID, 7); err != nil {
+		t.Fatalf("RefillRateBucket(7): %v", err)
+	}
+
+	for cpu, v := range lookupPerCPU(t, l, fakePID) {
+		if v != 7 {
+			t.Errorf("CPU %d: tokens = %d, want 7 after overwrite", cpu, v)
+		}
 	}
 }

--- a/ebpf/loader/ratecap_test.go
+++ b/ebpf/loader/ratecap_test.go
@@ -7,11 +7,27 @@ package loader
 import (
 	"os"
 	"testing"
+
+	"github.com/cilium/ebpf"
 )
 
+// lookupPerCPU is a helper that reads all per-CPU slots for a PID from
+// PidRateBuckets (PERCPU_HASH) and returns the slice.
+func lookupPerCPU(t *testing.T, l *Loader, pid uint32) []uint64 {
+	t.Helper()
+	nCPU, err := ebpf.PossibleCPU()
+	if err != nil {
+		t.Fatalf("PossibleCPU: %v", err)
+	}
+	got := make([]uint64, nCPU)
+	if err := l.libssl.PidRateBuckets.Lookup(&pid, &got); err != nil {
+		t.Fatalf("Lookup bucket pid=%d: %v", pid, err)
+	}
+	return got
+}
+
 // TestRateCapKnob loads the BPF program, sets a rate cap, manually populates
-// one bucket, drains it via the BPF-accessible counter path, and verifies
-// behaviour.
+// one bucket, reads it back across all CPU slots, and verifies deletion.
 //
 // Requires root (CAP_BPF + CAP_PERFMON).
 func TestRateCapKnob(t *testing.T) {
@@ -25,31 +41,139 @@ func TestRateCapKnob(t *testing.T) {
 	}
 	defer l.Close()
 
-	// Enable rate cap at 5/sec.
 	if err := l.SetRateCapPerSec(5); err != nil {
 		t.Fatalf("SetRateCapPerSec: %v", err)
 	}
 
-	// Pre-populate a bucket for an arbitrary PID and read it back.
 	const fakePID uint32 = 99999
 	if err := l.RefillRateBucket(fakePID, 5); err != nil {
 		t.Fatalf("RefillRateBucket: %v", err)
 	}
 
-	var got uint64
-	pid := fakePID
-	if err := l.libssl.PidRateBuckets.Lookup(&pid, &got); err != nil {
-		t.Fatalf("Lookup bucket: %v", err)
-	}
-	if got != 5 {
-		t.Errorf("bucket = %d, want 5", got)
+	// PidRateBuckets is PERCPU_HASH — all CPU slots must be set to 5.
+	for cpu, v := range lookupPerCPU(t, l, fakePID) {
+		if v != 5 {
+			t.Errorf("CPU %d: bucket = %d, want 5", cpu, v)
+		}
 	}
 
-	// Delete and verify.
+	// Delete and verify entry is gone.
 	if err := l.DeleteRateBucket(fakePID); err != nil {
 		t.Fatalf("DeleteRateBucket: %v", err)
 	}
-	if err := l.libssl.PidRateBuckets.Lookup(&pid, &got); err == nil {
+	nCPU, _ := ebpf.PossibleCPU()
+	dummy := make([]uint64, nCPU)
+	pid := fakePID
+	if err := l.libssl.PidRateBuckets.Lookup(&pid, &dummy); err == nil {
 		t.Errorf("bucket still present after Delete")
+	}
+}
+
+// TestRateCapPercpuIsolation verifies that RefillRateBucket initialises every
+// CPU slot to the requested token count. This is the key PERCPU_HASH property:
+// each CPU owns its copy so no atomic operations are needed in BPF.
+func TestRateCapPercpuIsolation(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+
+	l, err := Load(Default())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer l.Close()
+
+	const fakePID uint32 = 12345
+	const wantTokens uint64 = 10
+
+	if err := l.RefillRateBucket(fakePID, wantTokens); err != nil {
+		t.Fatalf("RefillRateBucket: %v", err)
+	}
+
+	for cpu, v := range lookupPerCPU(t, l, fakePID) {
+		if v != wantTokens {
+			t.Errorf("CPU %d: tokens = %d, want %d", cpu, v, wantTokens)
+		}
+	}
+}
+
+// TestRateCapDisabled verifies that when rate_cap_per_sec == 0 (default),
+// no bucket entry is required — the BPF program allows all events through.
+func TestRateCapDisabled(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+
+	l, err := Load(Default())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer l.Close()
+
+	// Rate cap is 0 by default — do NOT call SetRateCapPerSec.
+	nCPU, err := ebpf.PossibleCPU()
+	if err != nil {
+		t.Fatalf("PossibleCPU: %v", err)
+	}
+	const fakePID uint32 = 77777
+	pid := fakePID
+	dummy := make([]uint64, nCPU)
+	if err := l.libssl.PidRateBuckets.Lookup(&pid, &dummy); err == nil {
+		t.Errorf("expected no bucket entry when rate cap is disabled, got one")
+	}
+}
+
+// TestRateCapMapTypeIsPerCPU guards against accidental reversion of
+// pid_rate_buckets to BPF_MAP_TYPE_HASH in libssl.bpf.c.
+// If the C file ever reverts to BPF_MAP_TYPE_HASH, RefillRateBucket will
+// error (it writes a per-CPU slice), but this test makes the failure explicit
+// and names the root cause.
+func TestRateCapMapTypeIsPerCPU(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+
+	l, err := Load(Default())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer l.Close()
+
+	info, err := l.libssl.PidRateBuckets.Info()
+	if err != nil {
+		t.Fatalf("Map.Info: %v", err)
+	}
+	if info.Type != ebpf.PerCPUHash {
+		t.Errorf("pid_rate_buckets map type = %v, want PerCPUHash; "+
+			"check BPF_MAP_TYPE_PERCPU_HASH is set in ebpf/programs/libssl.bpf.c", info.Type)
+	}
+}
+
+// TestRateCapRefillOverwrite verifies that a second RefillRateBucket call
+// overwrites all CPU slots with the new token count.
+func TestRateCapRefillOverwrite(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root")
+	}
+
+	l, err := Load(Default())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer l.Close()
+
+	const fakePID uint32 = 55555
+
+	if err := l.RefillRateBucket(fakePID, 3); err != nil {
+		t.Fatalf("RefillRateBucket(3): %v", err)
+	}
+	if err := l.RefillRateBucket(fakePID, 7); err != nil {
+		t.Fatalf("RefillRateBucket(7): %v", err)
+	}
+
+	for cpu, v := range lookupPerCPU(t, l, fakePID) {
+		if v != 7 {
+			t.Errorf("CPU %d: tokens = %d, want 7 after overwrite", cpu, v)
+		}
 	}
 }

--- a/ebpf/programs/libssl.bpf.c
+++ b/ebpf/programs/libssl.bpf.c
@@ -153,17 +153,22 @@ static __always_inline void counter_inc(__u32 idx, __u64 by) {
 //   Key:   tgid (__u32)
 //   Value: bucket { tokens, _pad }
 //
-// We use __sync_fetch_and_sub for the atomic decrement so multi-CPU access
-// is safe. If a PID isn't in the map (e.g. wasn't refilled yet), default to
+// PERCPU_HASH gives each CPU its own copy of the bucket, eliminating the need
+// for atomic operations entirely. Each CPU decrements its own slot; userspace
+// refills all CPU slots via a per-CPU update. The only trade-off is soft
+// over-admission of at most N_CPUs events per refill interval, which is
+// acceptable for a rate limiter. This also removes the BPF_ATOMIC dependency
+// (kernel 5.12+), making the agent compatible with kernels >= 5.8 (ringbuf).
+// If a PID isn't in the map (e.g. wasn't refilled yet), default to
 // "unlimited" — favours availability over strictness.
 struct rate_bucket {
     __u64 tokens;
 };
 
 struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);   // kernel 4.6+; no atomics needed
     __uint(max_entries, 16384);
-    __type(key, __u32);                   // tgid
+    __type(key, __u32);                        // tgid
     __type(value, struct rate_bucket);
 } pid_rate_buckets SEC(".maps");
 
@@ -180,14 +185,12 @@ static __always_inline int rate_take(__u32 tgid) {
     if (!b) {
         return 1;  // unknown PID — don't drop; let userspace catch up
     }
-    __u64 prev = __sync_fetch_and_sub(&b->tokens, 1);
-    // __sync_fetch_and_sub returns the OLD value. If it was 0, our
-    // decrement just made it underflow — we should treat that as "no
-    // tokens" and reject. Restore by re-adding so the count stays at 0.
-    if (prev == 0) {
-        __sync_fetch_and_add(&b->tokens, 1);
+    // PERCPU_HASH: each CPU owns its slot — no concurrent access from other
+    // CPUs is possible, so a plain (non-atomic) decrement is safe and correct.
+    if (b->tokens == 0) {
         return 0;
     }
+    b->tokens -= 1;
     return 1;
 }
 


### PR DESCRIPTION

BPF_ATOMIC instructions (used by __sync_fetch_and_sub / __sync_fetch_and_add in rate_take()) require kernel 5.12+. On kernel 5.10 the verifier rejects them with "BPF_STX uses reserved fields".

Fix: change pid_rate_buckets from BPF_MAP_TYPE_HASH to BPF_MAP_TYPE_PERCPU_HASH. Per-CPU maps give each CPU its own copy of the bucket, eliminating the need for atomic operations entirely. Simple non-atomic decrement is sufficient and correct — the only trade-off is soft over-admission of at most N_CPUs events per refill interval, which is acceptable for a rate limiter.

- BPF_MAP_TYPE_PERCPU_HASH available since kernel 4.6
- Removes the 5.12 BPF_ATOMIC dependency
- Compatible with all kernels >= 5.8 (ringbuf lower bound)
- Update RefillRateBucket in loader_linux.go to populate all CPU slots
- Update ratecap tests to verify per-CPU map semantics