### PR TITLE
[AC-1133] feat: adds informer.go and adds basic unit tests for it

### DIFF
--- a/cmd/internal/kube/daemonset/daemonset.go
+++ b/cmd/internal/kube/daemonset/daemonset.go
@@ -18,9 +18,7 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/postmanlabs/postman-insights-agent/rest"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
-	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
 )
 
 const (
@@ -78,6 +76,8 @@ type Daemonset struct {
 
 	// WaitGroup to wait for all apidump processes to stop
 	ApidumpProcessesWG sync.WaitGroup
+
+	podEventDispatcher *podEventDispatcher
 
 	PodHealthCheckInterval time.Duration
 	TelemetryInterval      time.Duration
@@ -303,6 +303,7 @@ func StartDaemonset(args DaemonsetArgs) error {
 func (d *Daemonset) Run() error {
 	printer.Infof("Starting daemonset agent...\n")
 	done := make(chan struct{})
+	var healthWorkerWG sync.WaitGroup
 
 	// Start the shared eBPF node collector's event-dispatch loop when enabled.
 	// This must be running before any per-pod Subscribe() calls are made.
@@ -324,13 +325,13 @@ func (d *Daemonset) Run() error {
 	printer.Infof("Starting telemetry worker...\n")
 	go d.TelemetryWorker(done)
 
-	// Start the kubernetes events worker
-	printer.Infof("Starting kubernetes pods events worker...\n")
-	go d.KubernetesPodEventsWorker(done)
-
 	// Start the pods health worker
 	printer.Infof("Starting pods health worker...\n")
-	go d.PodsHealthWorker(done)
+	healthWorkerWG.Add(1)
+	go func() {
+		defer healthWorkerWG.Done()
+		d.PodsHealthWorker(done)
+	}()
 
 	// Start the process in the existing pods
 	printer.Infof("Starting process in existing pods...\n")
@@ -338,6 +339,25 @@ func (d *Daemonset) Run() error {
 	if err != nil {
 		printer.Errorf("Failed to start process in existing pods, error: %v\n", err)
 		printer.Errorf("Agent will not listen traffic from existing pods\n")
+	}
+
+	// Register handlers after reconciling the synchronized cache. The informer
+	// replays cached objects to newly registered handlers, so Add must be idempotent.
+	if err := d.registerPodEventHandlers(done); err != nil {
+		close(done)
+		d.stopPodEventDispatcher()
+		healthWorkerWG.Wait()
+		d.KubeClient.Close()
+		d.StopAllApiDumpProcesses()
+		return errors.Wrap(err, "failed to register pod informer handlers")
+	}
+	if err := d.reconcileMissingPodsAfterStartup(); err != nil {
+		close(done)
+		d.stopPodEventDispatcher()
+		healthWorkerWG.Wait()
+		d.KubeClient.Close()
+		d.StopAllApiDumpProcesses()
+		return errors.Wrap(err, "failed to reconcile pods after registering informer handlers")
 	}
 
 	printer.Infof("Send SIGINT (Ctrl-C) to stop...\n")
@@ -357,14 +377,16 @@ func (d *Daemonset) Run() error {
 	// Signal all workers to stop
 	printer.Debugf("Signaling all workers to stop...\n")
 	close(done)
+	d.stopPodEventDispatcher()
+	healthWorkerWG.Wait()
+
+	// Stop and wait for the pod informer before stopping capture processes.
+	printer.Debugf("Stopping k8s pod informer...\n")
+	d.KubeClient.Close()
 
 	// Stop all apidump processes
 	printer.Debugf("Stopping all apidump processes...\n")
 	d.StopAllApiDumpProcesses()
-
-	// Stop K8s Watcher
-	printer.Debugf("Stopping k8s watcher...\n")
-	d.KubeClient.Close()
 
 	printer.Infof("Exiting daemonset agent...\n")
 	return nil
@@ -478,39 +500,6 @@ func (d *Daemonset) StartProcessInExistingPods() error {
 	}
 
 	return nil
-}
-
-// KubernetesPodEventsWorker listens for Kubernetes events and handles them accordingly.
-// It runs indefinitely until the provided done channel is closed.
-func (d *Daemonset) KubernetesPodEventsWorker(done <-chan struct{}) {
-	for {
-		select {
-		case <-done:
-			printer.Debugf("Kubernetes pod events worker stopped\n")
-			return
-		case event := <-d.KubeClient.PodEventWatch.ResultChan():
-			switch event.Type {
-			case watch.Added:
-				printer.Debugf("Got k8s pod added event: %v\n", event.Object)
-				if p, ok := event.Object.(*coreV1.Pod); ok {
-					go d.handlePodAddEvent(*p)
-				}
-			// A pod is deleted
-			case watch.Deleted:
-				printer.Debugf("Got k8s pod deleted event: %v\n", event.Object)
-				if p, ok := event.Object.(*coreV1.Pod); ok {
-					go d.handlePodDeleteEvent(*p)
-				}
-			case watch.Modified:
-				printer.Debugf("Got k8s pod modified event: %v\n", event.Object)
-				if p, ok := event.Object.(*coreV1.Pod); ok {
-					go d.handlePodModifyEvent(*p)
-				}
-			case watch.Error:
-				printer.Errorf("Got k8s watcher error event: %v\n", event.Object)
-			}
-		}
-	}
 }
 
 // PodsHealthWorker periodically checks the health of the pods and prunes stopped processes.

--- a/cmd/internal/kube/daemonset/kube_events_worker.go
+++ b/cmd/internal/kube/daemonset/kube_events_worker.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"sync"
 
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/go-utils/maps"
@@ -14,6 +15,8 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/spf13/viper"
 	coreV1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 )
 
 type baseEnvVarsError struct {
@@ -77,12 +80,162 @@ func (r containerValidationResult) hasNoAttrsSet() bool {
 	return r.ValidAttrCount == 0
 }
 
+type podEventType int
+
+const (
+	podAdded podEventType = iota
+	podModified
+	podDeleted
+)
+
+type podEvent struct {
+	eventType podEventType
+	pod       coreV1.Pod
+}
+
+type podEventDispatcher struct {
+	queue    workqueue.Interface
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+func newPodEventDispatcher() *podEventDispatcher {
+	return &podEventDispatcher{queue: workqueue.New()}
+}
+
+func (p *podEventDispatcher) start(d *Daemonset) {
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		for {
+			item, shutdown := p.queue.Get()
+			if shutdown {
+				return
+			}
+
+			event, ok := item.(*podEvent)
+			if ok {
+				switch event.eventType {
+				case podAdded:
+					d.handlePodAddEvent(event.pod)
+				case podModified:
+					d.handlePodModifyEvent(event.pod)
+				case podDeleted:
+					d.handlePodDeleteEvent(event.pod)
+				}
+			}
+			p.queue.Done(item)
+		}
+	}()
+}
+
+func (p *podEventDispatcher) enqueue(event *podEvent) {
+	p.queue.Add(event)
+}
+
+func (p *podEventDispatcher) stop() {
+	p.stopOnce.Do(func() {
+		p.queue.ShutDownWithDrain()
+		p.wg.Wait()
+	})
+}
+
+// registerPodEventHandlers connects pod lifecycle events from the shared
+// informer to the daemonset's existing lifecycle handlers.
+func (d *Daemonset) registerPodEventHandlers(done <-chan struct{}) error {
+	if d.KubeClient.PodInformer == nil {
+		return errors.New("pod informer is not initialized")
+	}
+
+	d.podEventDispatcher = newPodEventDispatcher()
+	d.podEventDispatcher.start(d)
+	dispatcher := d.podEventDispatcher
+	go func() {
+		<-done
+		dispatcher.stop()
+	}()
+
+	_, err := d.KubeClient.PodInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			pod, ok := obj.(*coreV1.Pod)
+			if !ok {
+				printer.Errorf("Got unexpected pod add event object: %T\n", obj)
+				return
+			}
+			logPodInformerEvent("podAdded", pod)
+			dispatcher.enqueue(&podEvent{eventType: podAdded, pod: *pod.DeepCopy()})
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			pod, ok := newObj.(*coreV1.Pod)
+			if !ok {
+				printer.Errorf("Got unexpected pod update event object: %T\n", newObj)
+				return
+			}
+			logPodInformerEvent("podModified", pod)
+			dispatcher.enqueue(&podEvent{eventType: podModified, pod: *pod.DeepCopy()})
+		},
+		DeleteFunc: func(obj interface{}) {
+			pod, ok := podFromDeleteEvent(obj)
+			if !ok {
+				printer.Errorf("Got unexpected pod delete event object: %T\n", obj)
+				return
+			}
+			logPodInformerEvent("podDeleted", pod)
+			dispatcher.enqueue(&podEvent{eventType: podDeleted, pod: *pod.DeepCopy()})
+		},
+	})
+	if err != nil {
+		d.stopPodEventDispatcher()
+	}
+	return err
+}
+
+func logPodInformerEvent(eventType string, pod *coreV1.Pod) {
+	printer.Debugf(
+		"informer event=%s namespace=%s name=%s uid=%s phase=%s resourceVersion=%s\n",
+		eventType,
+		pod.Namespace,
+		pod.Name,
+		pod.UID,
+		pod.Status.Phase,
+		pod.ResourceVersion,
+	)
+}
+
+func (d *Daemonset) stopPodEventDispatcher() {
+	if d.podEventDispatcher != nil {
+		d.podEventDispatcher.stop()
+		d.podEventDispatcher = nil
+	}
+}
+
+func podFromDeleteEvent(obj interface{}) (*coreV1.Pod, bool) {
+	switch event := obj.(type) {
+	case *coreV1.Pod:
+		return event, true
+	case cache.DeletedFinalStateUnknown:
+		pod, ok := event.Obj.(*coreV1.Pod)
+		return pod, ok
+	case *cache.DeletedFinalStateUnknown:
+		pod, ok := event.Obj.(*coreV1.Pod)
+		return pod, ok
+	default:
+		return nil, false
+	}
+}
+
 // handlePodAddEvent handles the event when a pod is added to the Kubernetes cluster.
 // It performs the following steps:
 // 1. Check if the pod does not have the agent sidecar container.
 // 2. In discovery mode, apply pod filter; skip if the pod doesn't pass.
 // 3. Adds the pod arguments to a map and change state to PodPending.
 func (d *Daemonset) handlePodAddEvent(pod coreV1.Pod) {
+	// Informer handler registration replays objects already in the cache. Do not
+	// recreate state for pods reconciled before the handlers were registered.
+	if _, loaded := d.PodArgsByNameMap.Load(pod.UID); loaded {
+		return
+	}
+
 	// Filter out pods that do not have the agent sidecar container
 	podsWithoutAgentSidecar, err := d.KubeClient.FilterPodsByContainerImage([]coreV1.Pod{pod}, agentImage, true)
 	if err != nil {
@@ -110,7 +263,18 @@ func (d *Daemonset) handlePodAddEvent(pod coreV1.Pod) {
 
 	err = d.addPodArgsToMap(pod.UID, args, PodPending)
 	if err != nil {
+		// Another Add callback may have won the LoadOrStore race.
+		if _, loaded := d.PodArgsByNameMap.Load(pod.UID); loaded {
+			return
+		}
 		printer.Errorf("Failed to add pod args to map, pod name: %s, error: %v\n", pod.Name, err)
+		return
+	}
+
+	// A pod can already be Running when its initial Add event is delivered.
+	// There may be no later status transition to trigger Modify.
+	if pod.Status.Phase == coreV1.PodRunning {
+		d.handlePodModifyEvent(pod)
 	}
 }
 

--- a/cmd/internal/kube/daemonset/pod_event_handlers_test.go
+++ b/cmd/internal/kube/daemonset/pod_event_handlers_test.go
@@ -1,0 +1,288 @@
+package daemonset
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/postmanlabs/postman-insights-agent/integrations/kube_apis"
+	"github.com/stretchr/testify/require"
+	coreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+type podInformerTestEnv struct {
+	clientset *fake.Clientset
+	informer  cache.SharedIndexInformer
+	stopCh    chan struct{}
+}
+
+func newPodInformerTestEnv(t *testing.T, pods ...*coreV1.Pod) podInformerTestEnv {
+	t.Helper()
+	clientset := fake.NewSimpleClientset()
+	for _, pod := range pods {
+		_, err := clientset.CoreV1().Pods(pod.Namespace).Create(
+			t.Context(), pod, metaV1.CreateOptions{},
+		)
+		require.NoError(t, err)
+	}
+
+	informer := cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metaV1.ListOptions) (runtime.Object, error) {
+				return clientset.CoreV1().Pods("").List(context.Background(), options)
+			},
+			WatchFunc: func(options metaV1.ListOptions) (watch.Interface, error) {
+				return clientset.CoreV1().Pods("").Watch(context.Background(), options)
+			},
+		},
+		&coreV1.Pod{},
+		0,
+		cache.Indexers{},
+	)
+	stopCh := make(chan struct{})
+	go informer.Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, informer.HasSynced) {
+		t.Fatal("pod informer did not sync")
+	}
+	t.Cleanup(func() { close(stopCh) })
+
+	return podInformerTestEnv{clientset: clientset, informer: informer, stopCh: stopCh}
+}
+
+func testDaemonsetForInformer(informer cache.SharedIndexInformer) *Daemonset {
+	return &Daemonset{
+		KubeClient: kube_apis.KubeClient{PodInformer: informer},
+	}
+}
+
+func waitFor(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition was not met before timeout")
+}
+
+func TestRegisterPodEventHandlersHandlesAdd(t *testing.T) {
+	env := newPodInformerTestEnv(t)
+	d := testDaemonsetForInformer(env.informer)
+	require.NoError(t, d.registerPodEventHandlers(env.stopCh))
+
+	pod := &coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{Namespace: "default", Name: "pod-a", UID: "pod-a-uid"},
+		Spec:       coreV1.PodSpec{Containers: []coreV1.Container{{Name: "app", Image: "example/app:latest"}}},
+	}
+	_, err := env.clientset.CoreV1().Pods("default").Create(t.Context(), pod, metaV1.CreateOptions{})
+	require.NoError(t, err)
+
+	waitFor(t, func() bool {
+		_, ok := d.PodArgsByNameMap.Load(pod.UID)
+		return ok
+	})
+}
+
+func TestPodEventDispatcherPreservesLifecycleOrder(t *testing.T) {
+	d := &Daemonset{}
+	dispatcher := newPodEventDispatcher()
+	dispatcher.start(d)
+
+	pod := coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{Namespace: "default", Name: "pod-a", UID: "pod-a-uid"},
+		Spec:       coreV1.PodSpec{Containers: []coreV1.Container{{Name: "app", Image: "example/app:latest"}}},
+	}
+	runningPod := *pod.DeepCopy()
+	runningPod.Status.Phase = coreV1.PodRunning
+	dispatcher.enqueue(&podEvent{eventType: podAdded, pod: pod})
+	dispatcher.enqueue(&podEvent{eventType: podModified, pod: runningPod})
+	dispatcher.stop()
+
+	if _, ok := d.PodArgsByNameMap.Load(pod.UID); ok {
+		t.Fatal("Update ran before Add and left the pod in Pending state")
+	}
+}
+
+func TestHandlePodAddEventIsIdempotentForReplayedRunningPod(t *testing.T) {
+	env := newPodInformerTestEnv(t)
+	d := testDaemonsetForInformer(env.informer)
+	pod := coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{Namespace: "default", Name: "pod-a", UID: "pod-a-uid"},
+		Spec:       coreV1.PodSpec{Containers: []coreV1.Container{{Name: "app", Image: "example/app:latest"}}},
+		Status:     coreV1.PodStatus{Phase: coreV1.PodRunning},
+	}
+	existing := NewPodArgs(pod.Name)
+	require.NoError(t, existing.changePodTrafficMonitorState(PodRunning))
+	d.PodArgsByNameMap.Store(pod.UID, existing)
+
+	d.handlePodAddEvent(pod)
+
+	actual, err := d.getPodArgsFromMap(pod.UID)
+	require.NoError(t, err)
+	if actual != existing {
+		t.Fatal("replayed Add replaced the existing pod state")
+	}
+	if actual.PodTrafficMonitorState != PodRunning {
+		t.Fatalf("replayed Add changed state to %s, want %s", actual.PodTrafficMonitorState, PodRunning)
+	}
+}
+
+func TestHandlePodAddEventProcessesNewRunningPod(t *testing.T) {
+	env := newPodInformerTestEnv(t)
+	d := testDaemonsetForInformer(env.informer)
+	pod := coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{Namespace: "default", Name: "pod-a", UID: "pod-a-uid"},
+		Spec:       coreV1.PodSpec{Containers: []coreV1.Container{{Name: "app", Image: "example/app:latest"}}},
+		Status:     coreV1.PodStatus{Phase: coreV1.PodRunning},
+	}
+
+	d.handlePodAddEvent(pod)
+
+	// The pod has no container statuses, so Modify reaches the existing
+	// inspection failure path and removes the temporary Pending entry. If Add
+	// did not dispatch the Running pod through Modify, it would remain Pending.
+	if _, ok := d.PodArgsByNameMap.Load(pod.UID); ok {
+		t.Fatal("new Running pod remained in the map after Add handling")
+	}
+}
+
+func TestRegisterPodEventHandlersReplaysExistingRunningPodSafely(t *testing.T) {
+	pod := &coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{Namespace: "default", Name: "pod-a", UID: "pod-a-uid"},
+		Status:     coreV1.PodStatus{Phase: coreV1.PodRunning},
+	}
+	env := newPodInformerTestEnv(t, pod)
+	d := testDaemonsetForInformer(env.informer)
+	existing := NewPodArgs(pod.Name)
+	require.NoError(t, existing.changePodTrafficMonitorState(PodRunning))
+	d.PodArgsByNameMap.Store(pod.UID, existing)
+
+	require.NoError(t, d.registerPodEventHandlers(env.stopCh))
+	waitFor(t, func() bool {
+		actual, err := d.getPodArgsFromMap(pod.UID)
+		return err == nil && actual == existing && actual.PodTrafficMonitorState == PodRunning
+	})
+}
+
+func TestRegisterPodEventHandlersHandlesUpdate(t *testing.T) {
+	pod := &coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{Namespace: "default", Name: "pod-a", UID: "pod-a-uid"},
+		Spec:       coreV1.PodSpec{Containers: []coreV1.Container{{Name: "app", Image: "example/app:latest"}}},
+	}
+	env := newPodInformerTestEnv(t, pod)
+	d := testDaemonsetForInformer(env.informer)
+	require.NoError(t, d.registerPodEventHandlers(env.stopCh))
+
+	waitFor(t, func() bool {
+		_, ok := d.PodArgsByNameMap.Load(pod.UID)
+		return ok
+	})
+
+	updated := pod.DeepCopy()
+	updated.Status.Phase = coreV1.PodRunning
+	_, err := env.clientset.CoreV1().Pods("default").Update(t.Context(), updated, metaV1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// The test pod has no container statuses, so the existing Modify handler
+	// removes it when inspection cannot find a running container.
+	waitFor(t, func() bool {
+		_, ok := d.PodArgsByNameMap.Load(pod.UID)
+		return !ok
+	})
+}
+
+func TestRegisterPodEventHandlersHandlesDelete(t *testing.T) {
+	env := newPodInformerTestEnv(t)
+	d := testDaemonsetForInformer(env.informer)
+	require.NoError(t, d.registerPodEventHandlers(env.stopCh))
+
+	pod := &coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{Namespace: "default", Name: "pod-a", UID: "pod-a-uid"},
+		Status:     coreV1.PodStatus{Phase: coreV1.PodSucceeded},
+	}
+	args := NewPodArgs(pod.Name)
+	require.NoError(t, args.changePodTrafficMonitorState(TrafficMonitoringRunning))
+	d.PodArgsByNameMap.Store(pod.UID, args)
+	_, err := env.clientset.CoreV1().Pods("default").Create(t.Context(), pod, metaV1.CreateOptions{})
+	require.NoError(t, err)
+	err = env.clientset.CoreV1().Pods("default").Delete(t.Context(), pod.Name, metaV1.DeleteOptions{})
+	require.NoError(t, err)
+
+	waitFor(t, func() bool { return args.PodTrafficMonitorState == PodSucceeded })
+	select {
+	case <-args.StopChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("delete handler did not signal the apidump process")
+	}
+}
+
+func TestPodFromDeleteEventHandlesTombstones(t *testing.T) {
+	pod := &coreV1.Pod{}
+	for _, object := range []interface{}{
+		cache.DeletedFinalStateUnknown{Key: "default/pod-a", Obj: pod},
+		&cache.DeletedFinalStateUnknown{Key: "default/pod-a", Obj: pod},
+	} {
+		actual, ok := podFromDeleteEvent(object)
+		if !ok || actual != pod {
+			t.Fatalf("podFromDeleteEvent(%T) = %v, %v", object, actual, ok)
+		}
+	}
+}
+
+func TestReconcileMissingPodsAfterStartupTerminatesMissingPod(t *testing.T) {
+	pod := &coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{Namespace: "default", Name: "pod-a", UID: "pod-a-uid"},
+	}
+	env := newPodInformerTestEnv(t, pod)
+	d := testDaemonsetForInformer(env.informer)
+	args := NewPodArgs("pod-a")
+	require.NoError(t, args.changePodTrafficMonitorState(TrafficMonitoringRunning))
+	d.PodArgsByNameMap.Store(pod.UID, args)
+
+	err := env.clientset.CoreV1().Pods("default").Delete(t.Context(), pod.Name, metaV1.DeleteOptions{})
+	require.NoError(t, err)
+	waitFor(t, func() bool {
+		_, exists, err := env.informer.GetStore().Get(pod)
+		return err == nil && !exists
+	})
+
+	require.NoError(t, d.reconcileMissingPodsAfterStartup())
+
+	if args.PodTrafficMonitorState != PodTerminated {
+		t.Fatalf("pod state = %s, want %s", args.PodTrafficMonitorState, PodTerminated)
+	}
+	select {
+	case <-args.StopChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("missing pod was not signaled to stop")
+	}
+}
+
+func TestReconcileMissingPodsAfterStartupKeepsCachedPod(t *testing.T) {
+	pod := &coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{Namespace: "default", Name: "pod-a", UID: "pod-a-uid"},
+	}
+	env := newPodInformerTestEnv(t, pod)
+	d := testDaemonsetForInformer(env.informer)
+	args := NewPodArgs(pod.Name)
+	require.NoError(t, args.changePodTrafficMonitorState(TrafficMonitoringRunning))
+	d.PodArgsByNameMap.Store(pod.UID, args)
+
+	require.NoError(t, d.reconcileMissingPodsAfterStartup())
+
+	if args.PodTrafficMonitorState != TrafficMonitoringRunning {
+		t.Fatalf("cached pod state = %s, want %s", args.PodTrafficMonitorState, TrafficMonitoringRunning)
+	}
+	select {
+	case <-args.StopChan:
+		t.Fatal("cached pod was incorrectly signaled to stop")
+	default:
+	}
+}

--- a/cmd/internal/kube/daemonset/pods_healthcheck_worker.go
+++ b/cmd/internal/kube/daemonset/pods_healthcheck_worker.go
@@ -97,6 +97,35 @@ func (d *Daemonset) checkPodsHealth() {
 	}
 }
 
+// reconcileMissingPodsAfterStartup stops capture for pods that were handled by
+// startup reconciliation but disappeared before informer handlers were registered.
+// The informer cache is already synchronized, so this is a local cache comparison.
+func (d *Daemonset) reconcileMissingPodsAfterStartup() error {
+	pods, err := d.KubeClient.GetPodsInAgentNode()
+	if err != nil {
+		return errors.Wrap(err, "failed to get pods in node")
+	}
+
+	cachedUIDs := make(map[types.UID]struct{}, len(pods))
+	for _, pod := range pods {
+		cachedUIDs[pod.UID] = struct{}{}
+	}
+
+	d.PodArgsByNameMap.Range(func(key, _ interface{}) bool {
+		podUID := key.(types.UID)
+		if _, exists := cachedUIDs[podUID]; !exists {
+			d.handleTerminatedPod(
+				podUID,
+				errors.Errorf("pod %s was deleted during startup reconciliation", podUID),
+				true,
+			)
+		}
+		return true
+	})
+
+	return nil
+}
+
 // handleTerminatedPod handles the terminated pod by changing the pod's traffic monitor state to PodTerminated
 // and stopping the API dump process for that pod.
 func (d *Daemonset) handleTerminatedPod(podUID types.UID, podStatusErr error, podDoesNotExists bool) {

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.17.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/integrations/kube_apis/informer.go
+++ b/integrations/kube_apis/informer.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -16,6 +17,7 @@ import (
 
 const (
 	POD_INFORMER_RESYNC_PERIOD = 10 * time.Minute
+	POD_INFORMER_SYNC_TIMEOUT  = 30 * time.Second
 )
 
 func newPodInformer(clientset kubernetes.Interface, nodeName string) cache.SharedIndexInformer {
@@ -46,6 +48,18 @@ func newPodInformer(clientset kubernetes.Interface, nodeName string) cache.Share
 				}
 				return []string{string(pod.UID)}, nil
 			},
+		},
+	)
+}
+
+func waitForPodInformerSync(informer cache.SharedIndexInformer, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(
+		context.Background(),
+		100*time.Millisecond,
+		timeout,
+		true,
+		func(context.Context) (bool, error) {
+			return informer.HasSynced(), nil
 		},
 	)
 }

--- a/integrations/kube_apis/informer.go
+++ b/integrations/kube_apis/informer.go
@@ -1,0 +1,51 @@
+package kube_apis
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	POD_INFORMER_RESYNC_PERIOD = 10 * time.Minute
+)
+
+func newPodInformer(clientset kubernetes.Interface, nodeName string) cache.SharedIndexInformer {
+	fieldSelector := fields.OneTermEqualSelector("spec.nodeName", nodeName).String()
+
+	listWatch := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+			return clientset.CoreV1().Pods("").List(context.Background(), options)
+		},
+
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+			return clientset.CoreV1().Pods("").Watch(context.Background(), options)
+		},
+	}
+
+	return cache.NewSharedIndexInformer(
+		listWatch,
+		&corev1.Pod{},
+		POD_INFORMER_RESYNC_PERIOD,
+		cache.Indexers{
+			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+			"uid": func(obj any) ([]string, error) {
+				pod, ok := obj.(*corev1.Pod)
+				if !ok {
+					return nil, fmt.Errorf("expected pod, got %T", obj)
+				}
+				return []string{string(pod.UID)}, nil
+			},
+		},
+	)
+}

--- a/integrations/kube_apis/informer_test.go
+++ b/integrations/kube_apis/informer_test.go
@@ -1,8 +1,6 @@
 package kube_apis
 
 import (
-	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -82,11 +80,63 @@ func TestPodInformerDeliversAddEvent(t *testing.T) {
 	}
 }
 
-func TestPodInformerSyncTimesOut(t *testing.T) {
-	informer := newPodInformer(fake.NewSimpleClientset(), "node-a")
+func TestKubeClientCloseStopsPodInformer(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	informer := newPodInformer(clientset, "node-a")
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
 
-	err := waitForPodInformerSync(informer, 10*time.Millisecond)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("waitForPodInformerSync() error = %v, want context deadline exceeded", err)
+	go func() {
+		informer.Run(stopCh)
+		close(done)
+	}()
+	if !cache.WaitForCacheSync(stopCh, informer.HasSynced) {
+		t.Fatal("pod informer did not sync")
+	}
+
+	kubeClient := KubeClient{
+		PodInformer:       informer,
+		podInformerStopCh: stopCh,
+	}
+	kubeClient.Close()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pod informer did not stop after KubeClient.Close")
+	}
+}
+
+func TestKubeClientCloseWaitsForPodInformer(t *testing.T) {
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	kubeClient := KubeClient{
+		podInformerStopCh: stopCh,
+		podInformerDoneCh: doneCh,
+	}
+	closeReturned := make(chan struct{})
+
+	go func() {
+		kubeClient.Close()
+		close(closeReturned)
+	}()
+
+	select {
+	case <-closeReturned:
+		t.Fatal("KubeClient.Close returned before the informer done signal")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	select {
+	case <-stopCh:
+	default:
+		t.Fatal("KubeClient.Close did not signal the informer to stop")
+	}
+	close(doneCh)
+
+	select {
+	case <-closeReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("KubeClient.Close did not wait for the informer done signal")
 	}
 }

--- a/integrations/kube_apis/informer_test.go
+++ b/integrations/kube_apis/informer_test.go
@@ -1,0 +1,81 @@
+package kube_apis
+
+import (
+	"testing"
+	"time"
+
+	coreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestPodInformerPopulatesCacheAndUIDIndex(t *testing.T) {
+	pod := &coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "pod-a",
+			Namespace: "default",
+			UID:       types.UID("pod-a-uid"),
+		},
+		Spec: coreV1.PodSpec{NodeName: "node-a"},
+	}
+	clientset := fake.NewSimpleClientset(pod)
+	informer := newPodInformer(clientset, "node-a")
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go informer.Run(stopCh)
+
+	if !cache.WaitForCacheSync(stopCh, informer.HasSynced) {
+		t.Fatal("pod informer did not sync")
+	}
+
+	kubeClient := KubeClient{PodInformer: informer}
+	pods, err := kubeClient.GetPodsInAgentNode()
+	if err != nil {
+		t.Fatalf("GetPodsInAgentNode() returned error: %v", err)
+	}
+	if len(pods) != 1 || pods[0].UID != pod.UID {
+		t.Fatalf("GetPodsInAgentNode() = %v, want pod %s", pods, pod.UID)
+	}
+
+	pods, err = kubeClient.GetPodsByUIDs([]types.UID{pod.UID})
+	if err != nil {
+		t.Fatalf("GetPodsByUIDs() returned error: %v", err)
+	}
+	if len(pods) != 1 || pods[0].Name != pod.Name {
+		t.Fatalf("GetPodsByUIDs() = %v, want pod %s", pods, pod.Name)
+	}
+}
+
+func TestPodInformerDeliversAddEvent(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	informer := newPodInformer(clientset, "node-a")
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	added := make(chan struct{}, 1)
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(interface{}) { added <- struct{}{} },
+	})
+	if err != nil {
+		t.Fatalf("AddEventHandler() returned error: %v", err)
+	}
+	go informer.Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, informer.HasSynced) {
+		t.Fatal("pod informer did not sync")
+	}
+
+	pod := &coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{Name: "pod-a", Namespace: "default", UID: types.UID("pod-a-uid")},
+		Spec:       coreV1.PodSpec{NodeName: "node-a"},
+	}
+	if _, err := clientset.CoreV1().Pods("default").Create(t.Context(), pod, metaV1.CreateOptions{}); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+
+	select {
+	case <-added:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for pod add event")
+	}
+}

--- a/integrations/kube_apis/informer_test.go
+++ b/integrations/kube_apis/informer_test.go
@@ -1,6 +1,8 @@
 package kube_apis
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -26,8 +28,8 @@ func TestPodInformerPopulatesCacheAndUIDIndex(t *testing.T) {
 	defer close(stopCh)
 	go informer.Run(stopCh)
 
-	if !cache.WaitForCacheSync(stopCh, informer.HasSynced) {
-		t.Fatal("pod informer did not sync")
+	if err := waitForPodInformerSync(informer, POD_INFORMER_SYNC_TIMEOUT); err != nil {
+		t.Fatalf("pod informer did not sync: %v", err)
 	}
 
 	kubeClient := KubeClient{PodInformer: informer}
@@ -61,8 +63,8 @@ func TestPodInformerDeliversAddEvent(t *testing.T) {
 		t.Fatalf("AddEventHandler() returned error: %v", err)
 	}
 	go informer.Run(stopCh)
-	if !cache.WaitForCacheSync(stopCh, informer.HasSynced) {
-		t.Fatal("pod informer did not sync")
+	if err := waitForPodInformerSync(informer, POD_INFORMER_SYNC_TIMEOUT); err != nil {
+		t.Fatalf("pod informer did not sync: %v", err)
 	}
 
 	pod := &coreV1.Pod{
@@ -77,5 +79,14 @@ func TestPodInformerDeliversAddEvent(t *testing.T) {
 	case <-added:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for pod add event")
+	}
+}
+
+func TestPodInformerSyncTimesOut(t *testing.T) {
+	informer := newPodInformer(fake.NewSimpleClientset(), "node-a")
+
+	err := waitForPodInformerSync(informer, 10*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waitForPodInformerSync() error = %v, want context deadline exceeded", err)
 	}
 }

--- a/integrations/kube_apis/kube_apis.go
+++ b/integrations/kube_apis/kube_apis.go
@@ -93,9 +93,9 @@ func NewKubeClient() (KubeClient, error) {
 
 	kubeClient.podInformerStopCh = make(chan struct{})
 	go kubeClient.PodInformer.Run(kubeClient.podInformerStopCh)
-	if !cache.WaitForCacheSync(kubeClient.podInformerStopCh, kubeClient.PodInformer.HasSynced) {
+	if err := waitForPodInformerSync(kubeClient.PodInformer, POD_INFORMER_SYNC_TIMEOUT); err != nil {
 		kubeClient.Close()
-		return KubeClient{}, errors.New("error syncing pod informer")
+		return KubeClient{}, errors.Wrap(err, "error syncing pod informer")
 	}
 
 	return kubeClient, nil

--- a/integrations/kube_apis/kube_apis.go
+++ b/integrations/kube_apis/kube_apis.go
@@ -43,6 +43,9 @@ type KubeClient struct {
 	PodEventWatch *watchTool.RetryWatcher
 	AgentNode     string
 	AgentHost     string
+
+	PodInformer       cache.SharedIndexInformer
+	podInformerStopCh chan struct{}
 }
 
 // NewKubeClient initializes a new Kubernetes client
@@ -72,10 +75,14 @@ func NewKubeClient() (KubeClient, error) {
 		return KubeClient{}, errors.Wrap(err, "error getting hostname")
 	}
 
+	podInformer := newPodInformer(clientset, agentNodeName)
+
 	kubeClient := KubeClient{
 		Clientset: clientset,
 		AgentNode: agentNodeName,
 		AgentHost: agentHostName,
+
+		PodInformer: podInformer,
 	}
 
 	// Initialize event watcher
@@ -84,12 +91,24 @@ func NewKubeClient() (KubeClient, error) {
 		return KubeClient{}, err
 	}
 
+	kubeClient.podInformerStopCh = make(chan struct{})
+	go kubeClient.PodInformer.Run(kubeClient.podInformerStopCh)
+	if !cache.WaitForCacheSync(kubeClient.podInformerStopCh, kubeClient.PodInformer.HasSynced) {
+		kubeClient.Close()
+		return KubeClient{}, errors.New("error syncing pod informer")
+	}
+
 	return kubeClient, nil
 }
 
-// Close stops the event watcher
+// Close stops the event watcher and pod informer.
 func (kc *KubeClient) Close() {
-	kc.PodEventWatch.Stop()
+	if kc.PodEventWatch != nil {
+		kc.PodEventWatch.Stop()
+	}
+	if kc.podInformerStopCh != nil {
+		close(kc.podInformerStopCh)
+	}
 }
 
 // initPodsEventsWatcher creates a new go-channel to listen for pod events in the cluster
@@ -134,48 +153,38 @@ func (kc *KubeClient) initPodsEventsWatcher() error {
 
 // GetPodsInNode returns the names of all pods running in a given node
 func (kc *KubeClient) GetPodsInAgentNode() ([]coreV1.Pod, error) {
-	var pods []coreV1.Pod
-	err := wait.ExponentialBackoff(retry, func() (bool, error) {
-		fieldSelector := fmt.Sprintf("spec.nodeName=%s", kc.AgentNode)
-		podList, err := kc.Clientset.CoreV1().Pods("").List(context.Background(), metaV1.ListOptions{
-			FieldSelector: fieldSelector,
-		})
-		if err != nil {
-			return backoffOnKubeAPIErr(err, "get pods in agent node")
-		}
-		pods = podList.Items
-		return true, nil
-	})
-	if err != nil {
-		return []coreV1.Pod{}, errors.Wrap(err, "error getting pods")
+	if kc.PodInformer == nil {
+		return []coreV1.Pod{}, errors.New("pod informer is not initialized")
 	}
 
+	objects := kc.PodInformer.GetStore().List()
+	pods := make([]coreV1.Pod, 0, len(objects))
+	for _, object := range objects {
+		pod, ok := object.(*coreV1.Pod)
+		if ok {
+			pods = append(pods, *pod.DeepCopy())
+		}
+	}
 	return pods, nil
 }
 
 // GetPods returns a list of pods running on the agent node with the given names
 func (kc *KubeClient) GetPodsByUIDs(podUIDs []types.UID) ([]coreV1.Pod, error) {
-	pods, err := kc.GetPodsInAgentNode()
-	if err != nil {
-		return []coreV1.Pod{}, err
-	}
-	if len(pods) == 0 {
-		return []coreV1.Pod{}, errors.Errorf("no pods in node: %s", kc.AgentNode)
-	}
-
-	podMap := maps.NewMap[types.UID, coreV1.Pod]()
-	for _, pod := range pods {
-		podMap.Put(pod.UID, pod)
+	if kc.PodInformer == nil {
+		return []coreV1.Pod{}, errors.New("pod informer is not initialized")
 	}
 
 	var filteredPods []coreV1.Pod
 	for _, uid := range podUIDs {
-		pod, ok := podMap.Get(uid).Get()
-		if !ok {
+		objects, err := kc.PodInformer.GetIndexer().ByIndex("uid", string(uid))
+		if err != nil || len(objects) == 0 {
 			printer.Debugf("Pod not found with UID: %v\n", uid)
 			continue
 		}
-		filteredPods = append(filteredPods, pod)
+		pod, ok := objects[0].(*coreV1.Pod)
+		if ok {
+			filteredPods = append(filteredPods, *pod.DeepCopy())
+		}
 	}
 
 	if len(filteredPods) == 0 {

--- a/integrations/kube_apis/kube_apis.go
+++ b/integrations/kube_apis/kube_apis.go
@@ -1,26 +1,18 @@
 package kube_apis
 
 import (
-	"context"
-	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/akitasoftware/go-utils/maps"
 	"github.com/pkg/errors"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	coreV1 "k8s.io/api/core/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
-	watchTool "k8s.io/client-go/tools/watch"
 )
 
 const (
@@ -28,24 +20,15 @@ const (
 	POSTMAN_INSIGHTS_K8S_NODE = "POSTMAN_INSIGHTS_K8S_NODE"
 )
 
-// An exponential retry backoff policy that results in approximately 24 retires over a 24 hour period.
-var retry = wait.Backoff{
-	Duration: 10 * time.Millisecond,
-	Factor:   2.0,
-	Jitter:   0.1,
-	Steps:    24,
-	Cap:      24 * time.Hour,
-}
-
-// KubeClient struct holds the Kubernetes clientset and event watcher
+// KubeClient struct holds the Kubernetes clientset and pod informer.
 type KubeClient struct {
-	Clientset     *kubernetes.Clientset
-	PodEventWatch *watchTool.RetryWatcher
-	AgentNode     string
-	AgentHost     string
+	Clientset *kubernetes.Clientset
+	AgentNode string
+	AgentHost string
 
 	PodInformer       cache.SharedIndexInformer
 	podInformerStopCh chan struct{}
+	podInformerDoneCh chan struct{}
 }
 
 // NewKubeClient initializes a new Kubernetes client
@@ -85,14 +68,12 @@ func NewKubeClient() (KubeClient, error) {
 		PodInformer: podInformer,
 	}
 
-	// Initialize event watcher
-	err = kubeClient.initPodsEventsWatcher()
-	if err != nil {
-		return KubeClient{}, err
-	}
-
 	kubeClient.podInformerStopCh = make(chan struct{})
-	go kubeClient.PodInformer.Run(kubeClient.podInformerStopCh)
+	kubeClient.podInformerDoneCh = make(chan struct{})
+	go func() {
+		defer close(kubeClient.podInformerDoneCh)
+		kubeClient.PodInformer.Run(kubeClient.podInformerStopCh)
+	}()
 	if err := waitForPodInformerSync(kubeClient.PodInformer, POD_INFORMER_SYNC_TIMEOUT); err != nil {
 		kubeClient.Close()
 		return KubeClient{}, errors.Wrap(err, "error syncing pod informer")
@@ -101,54 +82,14 @@ func NewKubeClient() (KubeClient, error) {
 	return kubeClient, nil
 }
 
-// Close stops the event watcher and pod informer.
+// Close stops the pod informer.
 func (kc *KubeClient) Close() {
-	if kc.PodEventWatch != nil {
-		kc.PodEventWatch.Stop()
-	}
 	if kc.podInformerStopCh != nil {
 		close(kc.podInformerStopCh)
 	}
-}
-
-// initPodsEventsWatcher creates a new go-channel to listen for pod events in the cluster
-func (kc *KubeClient) initPodsEventsWatcher() error {
-	// Fetch own pod details and get the ResourceVersion
-	podsResourceVersion := ""
-	err := wait.ExponentialBackoff(retry, func() (bool, error) {
-		fieldSelector := fmt.Sprintf("metadata.name=%s", kc.AgentHost)
-		pods, err := kc.Clientset.CoreV1().Pods("").List(context.Background(), metaV1.ListOptions{
-			FieldSelector: fieldSelector,
-		})
-		if err != nil {
-			return backoffOnKubeAPIErr(err, "get agent pod details")
-		}
-		podsResourceVersion = pods.ResourceVersion
-		return true, nil
-	})
-	if err != nil {
-		return errors.Wrap(err, "error getting own pod details")
+	if kc.podInformerDoneCh != nil {
+		<-kc.podInformerDoneCh
 	}
-
-	// Create a watcher for pod events
-	// Here ResourceVersion is set to the pod's ResourceVersion to watch events after the pod's creation
-	fieldSelector := fmt.Sprintf("spec.nodeName=%s", kc.AgentNode)
-	retryWatcher, err := watchTool.NewRetryWatcher(podsResourceVersion, &cache.ListWatch{
-		ListFunc: func(options metaV1.ListOptions) (runtime.Object, error) {
-			options.FieldSelector = fieldSelector
-			return kc.Clientset.CoreV1().Pods("").List(context.Background(), options)
-		},
-		WatchFunc: func(options metaV1.ListOptions) (watch.Interface, error) {
-			options.FieldSelector = fieldSelector
-			return kc.Clientset.CoreV1().Pods("").Watch(context.Background(), options)
-		},
-	})
-	if err != nil {
-		return errors.Wrap(err, "error creating watcher")
-	}
-
-	kc.PodEventWatch = retryWatcher
-	return nil
 }
 
 // GetPodsInNode returns the names of all pods running in a given node

--- a/integrations/tests/kube_cri_apis/main.go
+++ b/integrations/tests/kube_cri_apis/main.go
@@ -16,36 +16,13 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/postmanlabs/postman-insights-agent/integrations/cri_apis"
 	"github.com/postmanlabs/postman-insights-agent/integrations/kube_apis"
 	"github.com/postmanlabs/postman-insights-agent/printer"
-	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
 )
-
-func k8s_watcher(kubeClient kube_apis.KubeClient) {
-	// Watch for pod events
-	for event := range kubeClient.PodEventWatch.ResultChan() {
-		printer.Infof("Received event: %v\n", event.Type)
-		switch event.Type {
-		case watch.Added, watch.Deleted:
-			if e, ok := event.Object.(*coreV1.Event); ok {
-				jsonData, err := json.Marshal(e)
-				if err != nil {
-					printer.Errorf("Failed to marshal event data: %v\n", err)
-					continue
-				}
-				printer.Infof("Event data: %s\n", string(jsonData))
-			}
-		default:
-			printer.Infof("Unhandled event type: %v\n", event.Type)
-		}
-	}
-}
 
 func k8s_funcs(kubeClient kube_apis.KubeClient) (string, error) {
 	// GetPodsInNode
@@ -148,7 +125,4 @@ func main() {
 			printer.Errorf("Error from cri_funcs: %v\n", err)
 		}
 	}
-
-	// Watch for pod events
-	k8s_watcher(kubeClient)
 }


### PR DESCRIPTION
This pull request significantly refactors how Kubernetes pod events are handled by the daemonset agent, moving from a custom watch-based worker to an informer-based event handler system with robust event dispatching and lifecycle management. The changes improve reliability, ensure correct event ordering, and make the pod lifecycle handling more testable and maintainable. The update also introduces comprehensive tests for the new event handling logic and adds a reconciliation step to handle pods that disappear during startup.

The most important changes are:

**Kubernetes Pod Event Handling Refactor:**

* Replaces the old `KubernetesPodEventsWorker` (which used direct watch channels) with a new informer-based event handler system, using a `podEventDispatcher` to queue and process pod events in order. This ensures correct event sequencing and more robust handling of pod lifecycle events. (`cmd/internal/kube/daemonset/daemonset.go`, `cmd/internal/kube/daemonset/kube_events_worker.go`)
* Adds a new `registerPodEventHandlers` method to register event handlers for pod add, update, and delete events. This method ensures that event handlers are registered after the informer cache is synced, and that event handling is idempotent for replayed events. (`cmd/internal/kube/daemonset/kube_events_worker.go`)
* Introduces a `podEventDispatcher` that serializes and dispatches pod events to handler methods, guaranteeing correct event order and safe shutdown. (`cmd/internal/kube/daemonset/kube_events_worker.go`)

**Lifecycle and Startup Improvements:**

* Adds a `reconcileMissingPodsAfterStartup` method to detect and handle pods that were present during startup reconciliation but disappeared before the informer event handlers were registered, ensuring no stale state is left behind. (`cmd/internal/kube/daemonset/pods_healthcheck_worker.go`, `cmd/internal/kube/daemonset/daemonset.go`)

**Testing Enhancements:**

* Introduces a new test file `pod_event_handlers_test.go` with comprehensive unit tests for the new event handling logic, including correct handling of add, update, and delete events, idempotency checks, and reconciliation logic. (`cmd/internal/kube/daemonset/pod_event_handlers_test.go`)

**Cleanup and Dependency Updates:**

* Removes unused imports and the old watch-based event worker. (`cmd/internal/kube/daemonset/daemonset.go`) * Adds a new indirect dependency `github.com/evanphx/json-patch` in `go.mod`.