### PR TITLE
[INS-145] feat: instrument the layers that silently drop witness halves

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -724,6 +724,7 @@ func (a *apidump) TelemetryWorker(done <-chan struct{}) {
 				windowDuration := int(now.Sub(windowStart) / time.Second)
 				lastReport = time.Now()
 				a.SendPacketTelemetry(observationDuration, windowStart, windowDuration)
+				a.logCaptureDiagnostics()
 				subsequentTelemetrySent = true
 			case <-a.successTelemetry.Channel:
 				if !subsequentTelemetrySent {
@@ -1083,8 +1084,14 @@ func (a *apidump) Run() error {
 				}
 			}
 
-			// Count packets before user filters for diagnostics
-			if filterState == matchedFilter && numUserFilters > 0 {
+			// Count packets before user filters for diagnostics.
+			//
+			// This used to be installed only when the user had configured filters.
+			// It is now unconditional, because the difference between this counter
+			// and the post-filter one is what attributes a missing response to the
+			// collector chain (filters, rate limiting) rather than to parsing.
+			// Without both, the two are indistinguishable. See LogCaptureDiagnostics.
+			if filterState == matchedFilter {
 				collector = &trace.PacketCountCollector{
 					PacketCounts: prefilterSummary,
 					Collector:    collector,

--- a/apidump/diagnostics.go
+++ b/apidump/diagnostics.go
@@ -81,7 +81,7 @@ func LogCaptureDiagnostics(clientID, podName, serviceID string, prefilter, postf
 	printer.Stderr.Infof(
 		"Capture diagnostics: client=%s pod=%s service=%s "+
 			"kernel[recv=%d drop=%d ifdrop=%d] "+
-			"parse[nil_ctx=%d bad_ctx=%d nil_ctx_after=%d zero_ts=%d ts_inverted=%d] "+
+			"parse[nil_ctx=%d bad_ctx=%d nil_ctx_after=%d zero_ts=%d ts_inverted=%d reassembly_gap_flushed=%d] "+
 			"discarded[req=%d resp=%d other=%d] "+
 			"chain[resp_no_request=%d] "+
 			"pair[ok=%d req_only=%d resp_only=%d same_dir_merge=%d] "+
@@ -106,6 +106,11 @@ func LogCaptureDiagnostics(clientID, podName, serviceID string, prefilter, postf
 		atomic.LoadUint64(&pcap.CountNilAssemblerContextAfterParse),
 		atomic.LoadUint64(&pcap.CountZeroValuePacketTimestamp),
 		atomic.LoadUint64(&pcap.CountLastPacketBeforeFirstPacket),
+
+		// TCP streams the reassembler force-flushed because a sequence-number
+		// gap sat unfilled past its timeout -- the local counterpart of the
+		// capture_gap_truncated_flushed telemetry event.
+		atomic.LoadUint64(&pcap.CountReassemblyGapFlushed),
 
 		// The same failures as nil_ctx and bad_ctx, but split by which half we
 		// threw away. This is the pair to read for the "response starts in a

--- a/apidump/diagnostics.go
+++ b/apidump/diagnostics.go
@@ -1,0 +1,154 @@
+package apidump
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync/atomic"
+
+	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/akitasoftware/akita-libs/tags"
+	"github.com/postmanlabs/postman-insights-agent/pcap"
+	"github.com/postmanlabs/postman-insights-agent/printer"
+	"github.com/postmanlabs/postman-insights-agent/trace"
+)
+
+// Set POSTMAN_INSIGHTS_AGENT_CAPTURE_DIAGNOSTICS=false to suppress the capture
+// diagnostics line. It is on by default: one line per telemetry interval, which
+// defaults to five minutes, so twelve lines an hour per monitored pod.
+const captureDiagnosticsEnvVar = "POSTMAN_INSIGHTS_AGENT_CAPTURE_DIAGNOSTICS"
+
+func captureDiagnosticsEnabled() bool {
+	v, present := os.LookupEnv(captureDiagnosticsEnvVar)
+	if !present {
+		return true
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		printer.Warningf("Could not parse %s value %q, defaulting to enabled: %v\n",
+			captureDiagnosticsEnvVar, v, err)
+		return true
+	}
+	return enabled
+}
+
+// logCaptureDiagnostics reports this session's capture counters. Called on each
+// telemetry tick.
+//
+// The line is prefixed with the client ID and the monitored pod name so it can
+// be attributed. That matters because the agent runs as a DaemonSet with one
+// apidump process per monitored pod, so a node's logs interleave several
+// processes, and because client_id is the only pod-level identifier that reaches
+// the back end -- the pod name is sent once at startup and then discarded there.
+// Without this prefix there is no way to tell which pod a counter belongs to.
+func (a *apidump) logCaptureDiagnostics() {
+	if a.dumpSummary == nil || !captureDiagnosticsEnabled() {
+		return
+	}
+
+	pod := a.Args.Tags[tags.XAkitaKubernetesPod]
+	if pod == "" {
+		pod = "unknown"
+	}
+
+	LogCaptureDiagnostics(
+		akid.String(a.ClientID),
+		pod,
+		akid.String(a.backendSvc),
+		a.dumpSummary.PrefilterSummary,
+		a.dumpSummary.FilterSummary,
+	)
+}
+
+// LogCaptureDiagnostics writes the capture counters that we maintain but do not
+// send to the back end.
+//
+// Every counter here sits on a path that can silently lose one half of a
+// request/response pair. Because we upload a witness for the request either
+// way, that loss surfaces only at the back end, as a missing_status_code drop,
+// with no way to tell from there which layer lost it. Printing these
+// periodically makes the layer visible in `kubectl logs` for a running agent.
+//
+// PrintWarnings covers some of the same ground, but it only runs when a capture
+// ends, which for a long-lived DaemonSet is never.
+//
+// prefilter and postfilter are the request/response counts from either side of
+// the collector chain's filtering and rate limiting. They are the pair that
+// matters most: if prefilter responses roughly match prefilter requests but
+// postfilter responses do not, the response reached us and something in the
+// chain discarded it. If neither matches, we never parsed the response at all.
+func LogCaptureDiagnostics(clientID, podName, serviceID string, prefilter, postfilter *trace.PacketCounter) {
+	printer.Stderr.Infof(
+		"Capture diagnostics: client=%s pod=%s service=%s "+
+			"kernel[recv=%d drop=%d ifdrop=%d] "+
+			"parse[nil_ctx=%d bad_ctx=%d nil_ctx_after=%d zero_ts=%d ts_inverted=%d] "+
+			"discarded[req=%d resp=%d other=%d] "+
+			"chain[resp_no_request=%d] "+
+			"pair[ok=%d req_only=%d resp_only=%d same_dir_merge=%d] "+
+			"neg_latency[sub_ms=%d sub_s=%d over_s=%d]%s\n",
+
+		// Identify which apidump process this line came from. A node runs one
+		// per monitored pod, so the logs interleave.
+		clientID, podName, serviceID,
+
+		// Packets the kernel gave us, and packets it threw away because we could
+		// not keep up. A drop in the middle of a response usually costs us the
+		// whole response while sparing the request.
+		atomic.LoadUint64(&pcap.CountPcapPacketsReceived),
+		atomic.LoadUint64(&pcap.CountPcapPacketsDropped),
+		atomic.LoadUint64(&pcap.CountPcapPacketsIfDropped),
+
+		// Messages we refused to parse. nil_ctx and bad_ctx are the cases where
+		// the first byte carried no TCP sequence number, so we discarded the
+		// message rather than parsing it.
+		atomic.LoadUint64(&pcap.CountNilAssemblerContext),
+		atomic.LoadUint64(&pcap.CountBadAssemblerContextType),
+		atomic.LoadUint64(&pcap.CountNilAssemblerContextAfterParse),
+		atomic.LoadUint64(&pcap.CountZeroValuePacketTimestamp),
+		atomic.LoadUint64(&pcap.CountLastPacketBeforeFirstPacket),
+
+		// The same failures as nil_ctx and bad_ctx, but split by which half we
+		// threw away. This is the pair to read for the "response starts in a
+		// later reassembly page" theory.
+		atomic.LoadUint64(&pcap.CountDiscardedRequests),
+		atomic.LoadUint64(&pcap.CountDiscardedResponses),
+		atomic.LoadUint64(&pcap.CountDiscardedOther),
+
+		// Responses we parsed and then dropped for want of a matching request.
+		atomic.LoadUint64(&trace.CountResponsesDroppedNoMatchingRequest),
+
+		// How witnesses left the pair cache.
+		atomic.LoadUint64(&trace.CountWitnessesPaired),
+		atomic.LoadUint64(&trace.CountUnpairedRequestsFlushed),
+		atomic.LoadUint64(&trace.CountUnpairedResponsesFlushed),
+		atomic.LoadUint64(&trace.CountSameDirectionMerges),
+
+		// Negative processing latency, bucketed by size. Small values can be
+		// genuine (a server answering before the request body finished); large
+		// ones mean we paired a response with the wrong request.
+		atomic.LoadUint64(&trace.CountNegativeLatencyUnder1ms),
+		atomic.LoadUint64(&trace.CountNegativeLatencyUnder1s),
+		atomic.LoadUint64(&trace.CountNegativeLatencyOver1s),
+
+		formatFilterCounts(prefilter, postfilter),
+	)
+}
+
+// formatFilterCounts renders the request and response counts from both ends of
+// the collector chain, so the gap between them attributes response loss to the
+// chain rather than to parsing.
+func formatFilterCounts(prefilter, postfilter *trace.PacketCounter) string {
+	if prefilter == nil || postfilter == nil {
+		return ""
+	}
+
+	pre := prefilter.Total()
+	post := postfilter.Total()
+	return fmt.Sprintf(
+		" prefilter[req=%d resp=%d] postfilter[req=%d resp=%d]",
+		pre.HTTPRequests+pre.HTTPSRequests,
+		pre.HTTPResponses+pre.HTTPSResponses,
+		post.HTTPRequests+post.HTTPSRequests,
+		post.HTTPResponses+post.HTTPSResponses,
+	)
+}

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -145,9 +145,13 @@ func (s *Summary) printPortHighlights(top *client_telemetry.PacketCountSummary) 
 			continue
 		}
 
-		// If we saw HTTP traffic but it was filtered, give the pre-filter statistics
+		// If we saw HTTP traffic but it was filtered, give the pre-filter statistics.
+		//
+		// Gated on NumUserFilters because the pre-filter counters are now always
+		// collected, for capture diagnostics. This message talks about "the
+		// filters you gave", so it must not appear when the user gave none.
 		preFilter := s.PrefilterSummary.TotalOnPort(p)
-		if preFilter.HTTPRequests+preFilter.HTTPResponses > 0 {
+		if s.NumUserFilters > 0 && preFilter.HTTPRequests+preFilter.HTTPResponses > 0 {
 			printer.Stderr.Infof("TCP port %5d: %5d packets (%d%% of total), no HTTP requests or responses satisfied all the filters you gave, but %d HTTP requests and %d HTTP responses were seen before your path and host filters were applied.\n",
 				p, thisPort.TCPPackets, pct, preFilter.HTTPRequests, preFilter.HTTPResponses)
 			continue
@@ -245,9 +249,11 @@ func (s *Summary) printHostHighlights(top *client_telemetry.PacketCountSummary) 
 			continue
 		}
 
-		// If we saw HTTP traffic but it was filtered, give the pre-filter statistics.
+		// If we saw HTTP traffic but it was filtered, give the pre-filter
+		// statistics. Gated on NumUserFilters for the same reason as the
+		// per-port message above.
 		preFilter := s.PrefilterSummary.TotalOnHost(h)
-		if preFilter.HTTPRequests+preFilter.HTTPResponses > 0 {
+		if s.NumUserFilters > 0 && preFilter.HTTPRequests+preFilter.HTTPResponses > 0 {
 			printer.Stderr.Infof("%s no HTTP requests satisfied all the filters you gave, but %d HTTP requests were seen before your path and host filters were applied.\n",
 				label, preFilter.HTTPRequests)
 			continue

--- a/pcap/capture_stats.go
+++ b/pcap/capture_stats.go
@@ -103,6 +103,14 @@ var (
 	CountDiscardedOther     uint64
 )
 
+// CountReassemblyGapFlushed counts TCP streams the reassembler force-flushed
+// because a sequence-number gap sat unfilled past its timeout -- i.e. bytes we
+// expected never arrived and we gave up waiting for them. Whatever the stream
+// was mid-message when this happens gets truncated, which is the same event
+// telemetry reports upstream as capture_gap_truncated_flushed; this is the
+// local, always-on counterpart surfaced in the capture diagnostics log.
+var CountReassemblyGapFlushed uint64
+
 // Names reported by the akinet HTTP parser factories.
 const (
 	httpRequestParserFactoryName  = "HTTP/1.x Request Parser Factory"

--- a/pcap/capture_stats.go
+++ b/pcap/capture_stats.go
@@ -1,0 +1,125 @@
+package pcap
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/google/gopacket/pcap"
+	"github.com/postmanlabs/postman-insights-agent/printer"
+)
+
+// Capture counters reported by libpcap itself, summed over every handle opened
+// during a capture session.
+//
+// These come from pcap_stats(3): packets the kernel handed us, packets it
+// discarded because our userspace buffer was full, and packets the interface
+// dropped before the capture filter ran. Nothing else in the agent notices a
+// dropped packet; the TCP reassembler just sees a hole in the stream.
+//
+// The asymmetry is what makes these worth reporting. A request usually fits in
+// one packet, while a response spans many, so losing a single packet is much
+// more likely to destroy a response than the request it belongs to. A response
+// we cannot parse leaves a witness with no response half, which the back end
+// then drops as missing_status_code.
+var (
+	CountPcapPacketsReceived  uint64
+	CountPcapPacketsDropped   uint64
+	CountPcapPacketsIfDropped uint64
+)
+
+// How often we read libpcap's counters.
+const pcapStatsPollInterval = 15 * time.Second
+
+// pollPcapStats accumulates libpcap's capture counters until done is closed.
+//
+// pcap_stats reports totals for the lifetime of one handle, and a session opens
+// a handle per interface, so we accumulate deltas rather than absolute values.
+//
+// The caller must not close handle until this function has returned: pcap_stats
+// dereferences the handle without taking a lock.
+func pollPcapStats(handle *pcap.Handle, interfaceName string, done <-chan struct{}) {
+	ticker := time.NewTicker(pcapStatsPollInterval)
+	defer ticker.Stop()
+
+	var prev pcap.Stats
+
+	sample := func() {
+		stats, err := handle.Stats()
+		if err != nil {
+			// Expected while the handle is being torn down.
+			printer.Debugf("Could not read pcap stats for %s: %v\n", interfaceName, err)
+			return
+		}
+
+		// Guard each delta separately: libpcap resets these counters on some
+		// platforms, and a reset must not underflow the exported total.
+		if stats.PacketsReceived >= prev.PacketsReceived {
+			atomic.AddUint64(&CountPcapPacketsReceived, uint64(stats.PacketsReceived-prev.PacketsReceived))
+		}
+		if stats.PacketsDropped >= prev.PacketsDropped {
+			atomic.AddUint64(&CountPcapPacketsDropped, uint64(stats.PacketsDropped-prev.PacketsDropped))
+		}
+		if stats.PacketsIfDropped >= prev.PacketsIfDropped {
+			atomic.AddUint64(&CountPcapPacketsIfDropped, uint64(stats.PacketsIfDropped-prev.PacketsIfDropped))
+		}
+		prev = *stats
+	}
+
+	for {
+		select {
+		case <-done:
+			// Take a final sample so the last interval is not lost.
+			sample()
+			return
+		case <-ticker.C:
+			sample()
+		}
+	}
+}
+
+// Messages discarded at parser-creation time, split by which half of the
+// exchange they were.
+//
+// These sit alongside CountNilAssemblerContext and CountBadAssemblerContextType,
+// which count the same failures but are shared across both directions of every
+// flow. The split matters because the two halves fail differently downstream:
+//
+//   - A discarded response leaves the request with nothing to pair with, so we
+//     upload a witness with a request and no response, which the back end drops
+//     as missing_status_code.
+//   - A discarded request produces no witness at all. Its response then arrives,
+//     fails to match any request in the rate limiter, and is dropped there too.
+//     Both halves vanish without appearing in any drop count.
+//
+// Two caveats when reading these. They count *events*, not messages: after one
+// of these the stream is desynced mid-message, so the following bytes are
+// discarded as unparseable until a new message boundary is found, and a single
+// event can therefore cost more than one message. And they only cover this one
+// failure path -- bytes that no parser would accept are counted as Unparsed
+// instead.
+var (
+	CountDiscardedRequests  uint64
+	CountDiscardedResponses uint64
+	CountDiscardedOther     uint64
+)
+
+// Names reported by the akinet HTTP parser factories.
+const (
+	httpRequestParserFactoryName  = "HTTP/1.x Request Parser Factory"
+	httpResponseParserFactoryName = "HTTP/1.x Response Parser Factory"
+)
+
+// countDiscardedByParserKind attributes a discarded message to the half of the
+// exchange it belonged to, using the name of the parser factory that had already
+// agreed to parse it.
+func countDiscardedByParserKind(factoryName string) {
+	switch factoryName {
+	case httpRequestParserFactoryName:
+		atomic.AddUint64(&CountDiscardedRequests, 1)
+	case httpResponseParserFactoryName:
+		atomic.AddUint64(&CountDiscardedResponses, 1)
+	default:
+		// TLS, HTTP/2 prefaces, and anything else with a parser factory.
+		atomic.AddUint64(&CountDiscardedOther, 1)
+	}
+}

--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"runtime/debug"
+	"sync/atomic"
 	"time"
 
 	"github.com/akitasoftware/akita-libs/akid"
@@ -212,6 +213,10 @@ func (p *NetworkTrafficParser) ParseFromInterface(
 
 				if flushed != 0 || closed != 0 {
 					printer.Debugf("%d flushed, %d closed\n", flushed, closed)
+				}
+				if flushed != 0 {
+					printer.Debugf("TCP reassembly gap: flushed %d stream(s) early because expected data never arrived\n", flushed)
+					atomic.AddUint64(&CountReassemblyGapFlushed, uint64(flushed))
 				}
 			}
 		}

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -48,6 +48,15 @@ func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter
 	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
 	pktChan := packetSource.Packets()
 
+	// Watch libpcap's own capture counters, which tell us whether the kernel is
+	// discarding packets before we ever see them. See capture_stats.go.
+	statsDone := make(chan struct{})
+	statsStopped := make(chan struct{})
+	go func() {
+		defer close(statsStopped)
+		pollPcapStats(handle, interfaceName, statsDone)
+	}()
+
 	// TODO: tune the packet channel buffer
 	wrappedChan := make(chan gopacket.Packet, 10)
 	go func() {
@@ -56,6 +65,13 @@ func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter
 		// wait for the handle to close in this goroutine.
 		defer func() {
 			close(wrappedChan)
+
+			// Wait for the stats poller to return before closing the handle:
+			// pcap_stats dereferences the handle without locking, so a sample in
+			// flight during Close is a use-after-free.
+			close(statsDone)
+			<-statsStopped
+
 			handle.Close()
 		}()
 

--- a/pcap/stream.go
+++ b/pcap/stream.go
@@ -139,6 +139,14 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 				} else {
 					atomic.AddUint64(&CountBadAssemblerContextType, 1)
 				}
+
+				// Also record which half of the exchange we just threw away. The
+				// counters above are shared by both directions, so on their own they
+				// cannot tell us whether we are losing requests or responses --
+				// which is the question, since a lost response leaves a witness with
+				// no response half while a lost request leaves no witness at all.
+				countDiscardedByParserKind(fact.Name())
+
 				f.handleUnparseable(sg.CaptureInfo(ignoreCount).Timestamp, pktData.Len())
 				return
 			}

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
@@ -28,6 +29,61 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/rest"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
+
+// Pairing outcomes for witnesses leaving the pair cache. Together these account
+// for every witness we upload, so they reconcile directly against the back end's
+// witness_pipeline drop reasons without a cross-system join.
+var (
+	// Witnesses uploaded with both halves.
+	CountWitnessesPaired uint64
+
+	// Witnesses uploaded with only a request, because no response ever arrived
+	// before pairCacheExpiration. The back end drops these as
+	// missing_status_code.
+	CountUnpairedRequestsFlushed uint64
+
+	// Witnesses uploaded with only a response, because no request ever arrived.
+	// The back end drops these as missing_latency.
+	CountUnpairedResponsesFlushed uint64
+
+	// Times two requests, or two responses, collided on the same pair key and we
+	// merged them into one witness. The result has two request halves and no
+	// response, so it is also dropped as missing_status_code. A non-zero value
+	// here means pair keys are colliding, which happens when more than one
+	// request is in flight on a connection.
+	CountSameDirectionMerges uint64
+)
+
+// Negative processing latency means we computed a response that started before
+// its request finished. Bucketing by magnitude separates the causes, which is
+// why we count rather than silently clamp:
+//
+//   - Under 1ms: the two halves are effectively simultaneous. Timestamp
+//     granularity or a response that overlaps the tail of the request.
+//   - 1ms to 1s: plausibly real. A server may answer before the client has
+//     finished uploading (an early 4xx, or a 100-continue flow), in which case
+//     the response genuinely starts first and processing latency is not a
+//     meaningful quantity.
+//   - Over 1s: almost certainly a mispairing. We attached a response to a
+//     request it does not belong to, so the timestamps come from unrelated
+//     exchanges. Expect this to move together with CountSameDirectionMerges.
+var (
+	CountNegativeLatencyUnder1ms uint64
+	CountNegativeLatencyUnder1s  uint64
+	CountNegativeLatencyOver1s   uint64
+)
+
+// recordNegativeLatency buckets a negative processing latency, in milliseconds.
+func recordNegativeLatency(latency_ms float32) {
+	switch {
+	case latency_ms > -1.0:
+		atomic.AddUint64(&CountNegativeLatencyUnder1ms, 1)
+	case latency_ms > -1000.0:
+		atomic.AddUint64(&CountNegativeLatencyUnder1s, 1)
+	default:
+		atomic.AddUint64(&CountNegativeLatencyOver1s, 1)
+	}
+}
 
 const (
 	// We stop trying to pair partial witnesses older than pairCacheExpiration.
@@ -104,6 +160,7 @@ func (r *witnessWithInfo) toReport() (*kgxapi.WitnessReport, error) {
 
 func (w *witnessWithInfo) computeProcessingLatency(isRequest bool, t akinet.ParsedNetworkTraffic) {
 	if w.isRequest == isRequest {
+		atomic.AddUint64(&CountSameDirectionMerges, 1)
 		if isRequest {
 			printer.Debugln("Skipping latency calculation. Matched 2 requests together.")
 		} else {
@@ -131,6 +188,7 @@ func (w *witnessWithInfo) computeProcessingLatency(isRequest bool, t akinet.Pars
 
 	latency := float32(responseStart.Sub(requestEnd).Microseconds()) / 1000.0
 	if latency < 0.0 {
+		recordNegativeLatency(latency)
 		printer.Debugf("Negative latency calculation: %v\n", latency)
 	}
 
@@ -287,6 +345,7 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 				pair.srcPort, pair.dstPort = pair.dstPort, pair.srcPort
 			}
 
+			atomic.AddUint64(&CountWitnessesPaired, 1)
 			c.queueUpload(pair)
 			printer.Debugf("Completed witness %v direction=%s at %v -- %v\n",
 				partial.PairKey, pair.direction, t.ObservationTime, t.FinalPacketTime)
@@ -462,6 +521,17 @@ func (c *BackendCollector) flushPairCache(cutoffTime time.Time) {
 			e.witnessMutex.Lock()
 			defer e.witnessMutex.Unlock()
 
+			// This witness never found its other half, and we are about to upload
+			// it anyway. Record which half is missing: the back end will drop a
+			// request-only witness as missing_status_code and a response-only one
+			// as missing_latency, so these two counters are the agent-side
+			// equivalents of those drop reasons.
+			if e.isRequest {
+				atomic.AddUint64(&CountUnpairedRequestsFlushed, 1)
+			} else {
+				atomic.AddUint64(&CountUnpairedResponsesFlushed, 1)
+			}
+
 			c.queueUpload(e)
 			c.pairCache.Delete(k)
 
@@ -470,4 +540,9 @@ func (c *BackendCollector) flushPairCache(cutoffTime time.Time) {
 		totalWitnesses += 1
 		return true
 	})
+
+	if flushedWitnesses > 0 {
+		printer.Debugf("Flushed %d unpaired witnesses, %d still waiting for a pair\n",
+			flushedWitnesses, totalWitnesses-flushedWitnesses)
+	}
 }

--- a/trace/rate_limit.go
+++ b/trace/rate_limit.go
@@ -3,6 +3,7 @@ package trace
 import (
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/akitasoftware/akita-libs/akinet"
@@ -10,6 +11,13 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/spf13/viper"
 )
+
+// Number of HTTP responses we parsed successfully and then discarded because we
+// could not match them to a request. Every one of these leaves a witness with a
+// request and no response, so this counter distinguishes "the response was never
+// parsed" from "the response was parsed and then thrown away here" -- which have
+// completely different fixes.
+var CountResponsesDroppedNoMatchingRequest uint64
 
 const (
 	// One sample is collected per epoch
@@ -260,6 +268,23 @@ func (r *rateLimitCollector) Process(pnt akinet.ParsedNetworkTraffic) error {
 		if _, ok := r.RequestArrivalTimes[key]; ok {
 			delete(r.RequestArrivalTimes, key)
 			r.NextCollector.Process(pnt)
+		} else {
+			// We parsed this response but are throwing it away, because we cannot
+			// match it to a request we admitted. Its request has already gone
+			// downstream, so this becomes a witness with no response half, which
+			// the back end drops as missing_status_code.
+			//
+			// Three ways to get here:
+			//   - The request was rate limited, so we never recorded its key. Also
+			//     counted as HTTPRequestsRateLimited.
+			//   - expireRequests dropped the key on an epoch boundary before the
+			//     response arrived.
+			//   - The response's key does not match its request's key at all. Both
+			//     keys come from TCP numbers -- the request uses the ack of its
+			//     first segment, the response uses the seq of its first segment --
+			//     which are only equal if nothing else was in flight on the
+			//     connection. See akinet/http/parser.go.
+			atomic.AddUint64(&CountResponsesDroppedNoMatchingRequest, 1)
 		}
 	default:
 		if r.RateLimit.AllowOther() {


### PR DESCRIPTION
## Why

The back end drops **13% of identity-service witnesses in prod and 33% in lower** as `missing_status_code` — the witness arrived with a request and no response. Two other services show the same reason at much smaller volumes.

`client_capture_stats` already tells us where this happens. Requests are fine: the agent parses **113% of New Relic's transaction count** in prod. Responses are not — `window_http_responses` is 86% of `window_http_requests` in prod and 67% in lower, and that gap accounts for 93% of the back end's `missing_status_code` drops. So the loss is entirely upstream of the pair cache, and `rate_limited` and `oversized` are `0` on all 278 pods, which rules those out.

What we cannot tell from the existing data is **which layer** loses the response. Every candidate is uninstrumented:

| Layer | Could lose a response | Instrumented before this PR |
| --- | --- | --- |
| Kernel / libpcap buffer | Packet dropped mid-response | No — `handle.Stats()` never called anywhere |
| TCP reassembly | First byte carries no TCP seq number, message discarded | Counters exist, but shared across both directions, and only printed when a capture *ends* |
| Rate limiter | Response's key not found, discarded | No — the branch did nothing at all |
| Pair cache | Unpaired half uploaded after 60s | No — the two local counters were computed and thrown away |

This PR adds counters at each layer and reports them from a running agent. It is diagnostic only.

## What changed

**`pcap/capture_stats.go`** (new) — polls `handle.Stats()` for `ps_recv` / `ps_drop` / `ps_ifdrop`. Kernel loss is the classic cause of exactly this asymmetry: a request usually fits in one packet, a response spans many, so losing one packet destroys the response and spares the request. Accumulates deltas because a session opens one handle per interface. The poller is stopped and joined before `handle.Close()` — `pcap_stats` dereferences the handle without locking, so a sample in flight during `Close` would be a use-after-free.

Also splits the discard counters by direction. `CountNilAssemblerContext` and `CountBadAssemblerContextType` already fire when a message's first byte has no TCP sequence number and we discard the message instead of parsing it — the case the code comment attributes to "the HTTP response is in the second (or later) page of a reassembly buffer" — but they are package-level globals shared by both directions, so they could not say which half was lost.

**`trace/rate_limit.go`** — counts responses discarded because their key is not in `RequestArrivalTimes`. Worth knowing: this gate runs on every response whether or not throttling is active, and the request and response keys come from different TCP numbers (the request's ack, the response's seq), which are equal only if nothing else was in flight on the connection. So `rate_limited = 0` does **not** rule this path out. This is the counter that separates "never parsed" from "parsed then dropped here".

**`trace/backend_collector.go`** — counts how each witness left the pair cache (paired / request-only / response-only / merged same-direction). These account for every witness uploaded, so they reconcile against the back end's drop reasons directly: request-only maps to `missing_status_code`, response-only to `missing_latency`, and the same-direction counter is the test for pair-key collisions.

Negative processing latency is **bucketed by magnitude rather than clamped**, because magnitude is what identifies the cause: under 1ms is timestamp granularity; 1ms–1s is plausibly a server answering before the request body finished uploading, where processing latency is genuinely undefined rather than wrong; over 1s means we paired a response with the wrong request.

**`apidump/apidump.go`, `apidump/summary.go`** — the `prefilterSummary` counter now always runs, so there is visibility above the rate limiter. Two existing summary messages read those counters and say "the filters you gave", so they are now gated on `NumUserFilters` — without that, a user who configured no filters could see them.

**`apidump/diagnostics.go`** (new) — prints everything above plus the five existing `pcap.Count*` counters, once per telemetry interval. Those five existed but were only rendered by `Summary.PrintWarnings()`, which runs when a capture *ends* — never, for a DaemonSet.

## Output

```
Capture diagnostics: client=cli_xxx pod=identity-abc-123 service=svc_xxx
  kernel[recv=N drop=N ifdrop=N]
  parse[nil_ctx=N bad_ctx=N nil_ctx_after=N zero_ts=N ts_inverted=N]
  discarded[req=N resp=N other=N]
  chain[resp_no_request=N]
  pair[ok=N req_only=N resp_only=N same_dir_merge=N]
  neg_latency[sub_ms=N sub_s=N over_s=N]
  prefilter[req=N resp=N] postfilter[req=N resp=N]
```

Every line carries `client_id`, monitored pod name and `service_id`. This matters for two reasons: a node runs one apidump process per monitored pod, so logs interleave; and `client_id` is the only pod-level identifier that reaches the back end today — the pod name is sent once in `PostInitialClientTelemetry` and then discarded, so there is currently no way to map a `client_id` to a pod. This line closes that gap.

## How to read it

| Reading | Conclusion |
| --- | --- |
| `discarded[resp]` large, `chain[resp_no_request]` ~0 | Reassembly page boundary. Fix: let the parser start when a message begins mid-buffer. |
| `discarded[resp]` ~0, `chain[resp_no_request]` large | Response parsed, rate limiter's key lookup dropped it. Fix: replace ack/seq matching with the eBPF path's ordered index (`ebpf/events/adapter.go:131`). |
| `kernel[drop]` high on specific pods only | Capacity, not correctness. `SetBufferSize` is never called today. |
| `discarded[req]` non-zero | Requests are vanishing too — those produce no witness and no drop count, so real loss exceeds what the dashboard shows. |
| `neg_latency[over_s]` tracks `same_dir_merge` | Mispairing, not clock skew. |