### PR TITLE
[INS-145] Isolate capture-diagnostics counters per apidump session

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/postmanlabs/postman-insights-agent/apispec"
 	"github.com/postmanlabs/postman-insights-agent/architecture"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/ci"
 	"github.com/postmanlabs/postman-insights-agent/data_masks"
 	"github.com/postmanlabs/postman-insights-agent/deployment"
@@ -296,6 +297,17 @@ type apidump struct {
 	startTime        time.Time
 	dumpSummary      *Summary
 	successTelemetry *trace.SuccessTelemetry
+
+	// Capture-diagnostics counters for this session, created once at the top
+	// of Run(). See capturestats.Stats.
+	captureStats *capturestats.Stats
+
+	// The trace tags collectTraceTags produced for this session, including
+	// the monitored pod name merged in from DaemonsetArgs.TraceTags in the
+	// Kubernetes DaemonSet path. Args.Tags does not carry that merge -- only
+	// this field does -- so logCaptureDiagnostics must read from here, not
+	// Args.Tags, to report the pod a diagnostics line belongs to.
+	traceTags map[tags.Key]string
 }
 
 // Start a new apidump session based on the given arguments.
@@ -834,6 +846,10 @@ func (a *apidump) Run() error {
 	}
 
 	traceTags := collectTraceTags(args)
+	// Args.Tags does not receive the DaemonsetArgs.TraceTags merge above, so
+	// logCaptureDiagnostics needs its own reference to find the monitored pod
+	// name (tags.XAkitaKubernetesPod).
+	a.traceTags = traceTags
 
 	// Build path filters.
 	pathExclusions, err := compileRegexps(args.PathExclusions, "path exclusion")
@@ -922,10 +938,18 @@ func (a *apidump) Run() error {
 	numUserFilters := len(pathExclusions) + len(hostExclusions) + len(pathAllowlist) + len(hostAllowlist)
 	prefilterSummary := trace.NewPacketCounter()
 
+	// Capture-diagnostics counters for this session. Created once per Run()
+	// call and threaded into everything below that can lose a request or
+	// response, so its numbers describe exactly this pod -- see
+	// capturestats.Stats for why that must be a value passed in, not a
+	// package-level counter: the Kubernetes DaemonSet runs one Run() call per
+	// monitored pod, all as goroutines in a single process.
+	a.captureStats = capturestats.New()
+
 	// Initialized shared rate object, if we are configured with a rate limit
 	var rateLimit *trace.SharedRateLimit
 	if args.WitnessesPerMinute != 0.0 {
-		rateLimit = trace.NewRateLimit(args.WitnessesPerMinute)
+		rateLimit = trace.NewRateLimit(args.WitnessesPerMinute, a.captureStats)
 		defer rateLimit.Stop()
 	}
 
@@ -940,6 +964,7 @@ func (a *apidump) Run() error {
 		filterSummary,
 		prefilterSummary,
 		negationSummary,
+		a.captureStats,
 	)
 	a.dumpSummary.HTTPSCaptureEnabled = args.HTTPS.Enabled
 
@@ -1028,6 +1053,7 @@ func (a *apidump) Run() error {
 						args.Plugins,
 						args.MaxWitnessUploadBuffers,
 						apidumpTelemetry,
+						a.captureStats,
 					)
 
 					collector = backendCollector
@@ -1129,6 +1155,7 @@ func (a *apidump) Run() error {
 					summary,
 					pool,
 					apidumpTelemetry,
+					a.captureStats,
 				); err != nil {
 					errChan <- interfaceError{
 						interfaceName: interfaceName,
@@ -1161,6 +1188,7 @@ func (a *apidump) Run() error {
 			args.Plugins,
 			args.MaxWitnessUploadBuffers,
 			apidumpTelemetry,
+			a.captureStats,
 		)
 		if lsc, ok := httpsCollector.(trace.LearnSessionCollector); ok && lsc != nil {
 			toRotate = append(toRotate, lsc)

--- a/apidump/diagnostics.go
+++ b/apidump/diagnostics.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"sync/atomic"
 
 	"github.com/akitasoftware/akita-libs/akid"
 	"github.com/akitasoftware/akita-libs/tags"
-	"github.com/postmanlabs/postman-insights-agent/pcap"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/postmanlabs/postman-insights-agent/trace"
 )
@@ -32,21 +31,29 @@ func captureDiagnosticsEnabled() bool {
 	return enabled
 }
 
-// logCaptureDiagnostics reports this session's capture counters. Called on each
-// telemetry tick.
+// logCaptureDiagnostics reports this session's capture counters. Called on
+// each telemetry tick.
 //
-// The line is prefixed with the client ID and the monitored pod name so it can
-// be attributed. That matters because the agent runs as a DaemonSet with one
-// apidump process per monitored pod, so a node's logs interleave several
-// processes, and because client_id is the only pod-level identifier that reaches
-// the back end -- the pod name is sent once at startup and then discarded there.
-// Without this prefix there is no way to tell which pod a counter belongs to.
+// The line is prefixed with the client ID and the monitored pod name so it
+// can be attributed. That matters because the agent runs as a DaemonSet with
+// one apidump process per monitored pod, all as goroutines inside a single
+// OS process (see cmd/internal/kube/daemonset/apidump_process.go), so a
+// node's logs interleave several sessions -- and client_id is the only
+// pod-level identifier that reaches the back end, since the pod name is sent
+// once at startup and then discarded there. Without this prefix there would
+// be no way to tell which pod a line belongs to.
+//
+// The pod name comes from a.traceTags, not a.Args.Tags: in the Kubernetes
+// DaemonSet path, tags.XAkitaKubernetesPod only ever reaches the trace tags
+// that collectTraceTags merges from DaemonsetArgs.TraceTags (see Run()) --
+// Args.Tags is never updated with that merge, so reading it here always
+// misses and reports pod=unknown.
 func (a *apidump) logCaptureDiagnostics() {
 	if a.dumpSummary == nil || !captureDiagnosticsEnabled() {
 		return
 	}
 
-	pod := a.Args.Tags[tags.XAkitaKubernetesPod]
+	pod := a.traceTags[tags.XAkitaKubernetesPod]
 	if pod == "" {
 		pod = "unknown"
 	}
@@ -55,85 +62,101 @@ func (a *apidump) logCaptureDiagnostics() {
 		akid.String(a.ClientID),
 		pod,
 		akid.String(a.backendSvc),
+		a.captureStats,
 		a.dumpSummary.PrefilterSummary,
 		a.dumpSummary.FilterSummary,
 	)
 }
 
-// LogCaptureDiagnostics writes the capture counters that we maintain but do not
-// send to the back end.
+// LogCaptureDiagnostics writes the capture counters that we maintain but do
+// not send to the back end.
 //
 // Every counter here sits on a path that can silently lose one half of a
 // request/response pair. Because we upload a witness for the request either
-// way, that loss surfaces only at the back end, as a missing_status_code drop,
-// with no way to tell from there which layer lost it. Printing these
-// periodically makes the layer visible in `kubectl logs` for a running agent.
+// way, that loss surfaces only at the back end, as a missing_status_code
+// drop, with no way to tell from there which layer lost it. Printing these
+// periodically makes the layer visible in `kubectl logs` for a running
+// agent.
 //
-// PrintWarnings covers some of the same ground, but it only runs when a capture
-// ends, which for a long-lived DaemonSet is never.
+// PrintWarnings covers some of the same ground, but it only runs when a
+// capture ends, which for a long-lived DaemonSet is never.
 //
-// prefilter and postfilter are the request/response counts from either side of
-// the collector chain's filtering and rate limiting. They are the pair that
-// matters most: if prefilter responses roughly match prefilter requests but
-// postfilter responses do not, the response reached us and something in the
-// chain discarded it. If neither matches, we never parsed the response at all.
-func LogCaptureDiagnostics(clientID, podName, serviceID string, prefilter, postfilter *trace.PacketCounter) {
+// stats must be the same *capturestats.Stats passed to this session's
+// pcap.Collect, trace.NewRateLimit, and trace.NewBackendCollector calls --
+// see capturestats.Stats for why a shared, per-session value (rather than a
+// package-level counter) is what keeps every number below scoped to the one
+// pod this session is monitoring.
+//
+// prefilter and postfilter are the request/response counts from either side
+// of the collector chain's filtering and rate limiting. They are the pair
+// that matters most: if prefilter responses roughly match prefilter requests
+// but postfilter responses do not, the response reached us and something in
+// the chain discarded it. If neither matches, we never parsed the response
+// at all.
+func LogCaptureDiagnostics(clientID, podName, serviceID string, stats *capturestats.Stats, prefilter, postfilter *trace.PacketCounter) {
+	snap := stats.Snapshot()
+
 	printer.Stderr.Infof(
 		"Capture diagnostics: client=%s pod=%s service=%s "+
 			"kernel[recv=%d drop=%d ifdrop=%d] "+
 			"parse[nil_ctx=%d bad_ctx=%d nil_ctx_after=%d zero_ts=%d ts_inverted=%d reassembly_gap_flushed=%d] "+
 			"discarded[req=%d resp=%d other=%d] "+
 			"chain[resp_no_request=%d] "+
-			"pair[ok=%d req_only=%d resp_only=%d same_dir_merge=%d] "+
+			"pair[ok=%d req_only=%d resp_only=%d same_dir_merge=%d parse_failed=%d] "+
 			"neg_latency[sub_ms=%d sub_s=%d over_s=%d]%s\n",
 
-		// Identify which apidump process this line came from. A node runs one
+		// Identify which apidump session this line came from. A node runs one
 		// per monitored pod, so the logs interleave.
 		clientID, podName, serviceID,
 
 		// Packets the kernel gave us, and packets it threw away because we could
 		// not keep up. A drop in the middle of a response usually costs us the
 		// whole response while sparing the request.
-		atomic.LoadUint64(&pcap.CountPcapPacketsReceived),
-		atomic.LoadUint64(&pcap.CountPcapPacketsDropped),
-		atomic.LoadUint64(&pcap.CountPcapPacketsIfDropped),
+		snap.PcapPacketsReceived,
+		snap.PcapPacketsDropped,
+		snap.PcapPacketsIfDropped,
 
 		// Messages we refused to parse. nil_ctx and bad_ctx are the cases where
 		// the first byte carried no TCP sequence number, so we discarded the
-		// message rather than parsing it.
-		atomic.LoadUint64(&pcap.CountNilAssemblerContext),
-		atomic.LoadUint64(&pcap.CountBadAssemblerContextType),
-		atomic.LoadUint64(&pcap.CountNilAssemblerContextAfterParse),
-		atomic.LoadUint64(&pcap.CountZeroValuePacketTimestamp),
-		atomic.LoadUint64(&pcap.CountLastPacketBeforeFirstPacket),
+		// message rather than parsing it. reassembly_gap_flushed counts TCP
+		// streams the reassembler force-flushed because a sequence-number gap
+		// sat unfilled past its timeout -- usually the downstream consequence
+		// of a kernel packet drop.
+		snap.NilAssemblerContext,
+		snap.BadAssemblerContextType,
+		snap.NilAssemblerContextAfterParse,
+		snap.ZeroValuePacketTimestamp,
+		snap.LastPacketBeforeFirstPacket,
+		snap.ReassemblyGapFlushed,
 
-		// TCP streams the reassembler force-flushed because a sequence-number
-		// gap sat unfilled past its timeout -- the local counterpart of the
-		// capture_gap_truncated_flushed telemetry event.
-		atomic.LoadUint64(&pcap.CountReassemblyGapFlushed),
-
-		// The same failures as nil_ctx and bad_ctx, but split by which half we
-		// threw away. This is the pair to read for the "response starts in a
-		// later reassembly page" theory.
-		atomic.LoadUint64(&pcap.CountDiscardedRequests),
-		atomic.LoadUint64(&pcap.CountDiscardedResponses),
-		atomic.LoadUint64(&pcap.CountDiscardedOther),
+		// The same nil_ctx/bad_ctx failures, but split by which half we threw
+		// away. This is the pair to read for the "response starts in a later
+		// reassembly page" theory.
+		snap.DiscardedRequests,
+		snap.DiscardedResponses,
+		snap.DiscardedOther,
 
 		// Responses we parsed and then dropped for want of a matching request.
-		atomic.LoadUint64(&trace.CountResponsesDroppedNoMatchingRequest),
+		snap.ResponsesDroppedNoMatchingRequest,
 
-		// How witnesses left the pair cache.
-		atomic.LoadUint64(&trace.CountWitnessesPaired),
-		atomic.LoadUint64(&trace.CountUnpairedRequestsFlushed),
-		atomic.LoadUint64(&trace.CountUnpairedResponsesFlushed),
-		atomic.LoadUint64(&trace.CountSameDirectionMerges),
+		// How witnesses left the pair cache, plus parse_failed: a request or
+		// response that reached the backend collector -- so it already passed
+		// prefilter, filters, rate limiting, and sampling, and postfilter
+		// already counted it -- but failed to parse into a witness. That
+		// failure is invisible to the prefilter/postfilter comparison, since
+		// postfilter counted it before the parse was attempted.
+		snap.WitnessesPaired,
+		snap.UnpairedRequestsFlushed,
+		snap.UnpairedResponsesFlushed,
+		snap.SameDirectionMerges,
+		snap.WitnessParseFailed,
 
 		// Negative processing latency, bucketed by size. Small values can be
 		// genuine (a server answering before the request body finished); large
 		// ones mean we paired a response with the wrong request.
-		atomic.LoadUint64(&trace.CountNegativeLatencyUnder1ms),
-		atomic.LoadUint64(&trace.CountNegativeLatencyUnder1s),
-		atomic.LoadUint64(&trace.CountNegativeLatencyOver1s),
+		snap.NegativeLatencyUnder1ms,
+		snap.NegativeLatencyUnder1s,
+		snap.NegativeLatencyOver1s,
 
 		formatFilterCounts(prefilter, postfilter),
 	)

--- a/apidump/diagnostics.go
+++ b/apidump/diagnostics.go
@@ -36,8 +36,8 @@ func captureDiagnosticsEnabled() bool {
 //
 // The line is prefixed with the client ID and the monitored pod name so it
 // can be attributed. That matters because the agent runs as a DaemonSet with
-// one apidump process per monitored pod, all as goroutines inside a single
-// OS process (see cmd/internal/kube/daemonset/apidump_process.go), so a
+// one apidump session (one apidump.Run() goroutine) per monitored pod inside a
+// single OS process (see cmd/internal/kube/daemonset/apidump_process.go), so a
 // node's logs interleave several sessions -- and client_id is the only
 // pod-level identifier that reaches the back end, since the pod name is sent
 // once at startup and then discarded there. Without this prefix there would

--- a/apidump/summary.go
+++ b/apidump/summary.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/akitasoftware/akita-libs/client_telemetry"
 	"github.com/akitasoftware/go-utils/math"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/env"
-	"github.com/postmanlabs/postman-insights-agent/pcap"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/postmanlabs/postman-insights-agent/trace"
 	"github.com/spf13/viper"
@@ -32,6 +32,12 @@ type Summary struct {
 	// HTTPSCaptureEnabled is true when --enable-https-capture is in effect,
 	// which changes the end-of-trace warning for detected HTTPS traffic.
 	HTTPSCaptureEnabled bool
+
+	// Capture-diagnostics counters for this session, shared with the same
+	// *capturestats.Stats passed to the collectors below PrintWarnings reads
+	// from it instead of a package-level counter, so a value read here
+	// belongs to this session alone. See capturestats.Stats.
+	stats *capturestats.Stats
 }
 
 func NewSummary(
@@ -42,6 +48,7 @@ func NewSummary(
 	filterSummary *trace.PacketCounter,
 	prefilterSummary *trace.PacketCounter,
 	negationSummary *trace.PacketCounter,
+	stats *capturestats.Stats,
 ) *Summary {
 	return &Summary{
 		CapturingNegation: capturingNegation,
@@ -51,6 +58,7 @@ func NewSummary(
 		FilterSummary:     filterSummary,
 		PrefilterSummary:  prefilterSummary,
 		NegationSummary:   negationSummary,
+		stats:             stats,
 	}
 }
 
@@ -276,17 +284,18 @@ func (s *Summary) printHostHighlights(top *client_telemetry.PacketCountSummary) 
 // any packets, capturing packets but failing to parse them, etc.
 func (s *Summary) PrintWarnings() {
 	// Report on recoverable error counts during trace
-	if pcap.CountNilAssemblerContext > 0 ||
-		pcap.CountNilAssemblerContextAfterParse > 0 ||
-		pcap.CountBadAssemblerContextType > 0 ||
-		pcap.CountZeroValuePacketTimestamp > 0 ||
-		pcap.CountLastPacketBeforeFirstPacket > 0 {
+	snap := s.stats.Snapshot()
+	if snap.NilAssemblerContext > 0 ||
+		snap.NilAssemblerContextAfterParse > 0 ||
+		snap.BadAssemblerContextType > 0 ||
+		snap.ZeroValuePacketTimestamp > 0 ||
+		snap.LastPacketBeforeFirstPacket > 0 {
 		printer.Stderr.Infof("Detected packet assembly context problems during capture: %v empty, %v bad type, %v empty after parse, %v zero timestamp, %v last before first timestamp. ",
-			pcap.CountNilAssemblerContext,
-			pcap.CountBadAssemblerContextType,
-			pcap.CountNilAssemblerContextAfterParse,
-			pcap.CountZeroValuePacketTimestamp,
-			pcap.CountLastPacketBeforeFirstPacket)
+			snap.NilAssemblerContext,
+			snap.BadAssemblerContextType,
+			snap.NilAssemblerContextAfterParse,
+			snap.ZeroValuePacketTimestamp,
+			snap.LastPacketBeforeFirstPacket)
 		printer.Stderr.Infof("These errors may cause some packets to be missing from the trace.\n")
 	}
 

--- a/capturestats/capturestats.go
+++ b/capturestats/capturestats.go
@@ -1,0 +1,312 @@
+// Package capturestats holds the capture-diagnostics counters for a single
+// apidump session.
+//
+// These started out as package-level counters in pcap and trace. That is
+// wrong for this agent: the Kubernetes DaemonSet runs one apidump.Run() call
+// per monitored pod, all as goroutines inside a single OS process (see
+// cmd/internal/kube/daemonset/apidump_process.go, StartApiDumpProcess). A
+// package-level `var Count... uint64` is shared by every one of those
+// goroutines, so a counter printed alongside one pod's client_id would
+// actually be the sum across every pod that node happens to monitor --
+// discovered by comparing a "Capture diagnostics" log line's pair[ok=...]
+// against that same line's prefilter[req=...] for one client_id and finding
+// the former many times larger than the latter could possibly be for one
+// pod's own traffic.
+//
+// Stats fixes that by being an ordinary value, created once per apidump.Run()
+// call and threaded through the pieces that increment it, the same way
+// trace.PacketCounter (prefilter/postfilter) already was. One Stats instance
+// per session means its numbers describe exactly the pod that session is
+// capturing.
+package capturestats
+
+import "sync/atomic"
+
+// Stats holds every capture-diagnostics counter for one apidump session.
+// Fields are incremented with sync/atomic from whichever goroutine observes
+// the event (packet capture, TCP reassembly, rate limiting, and witness
+// pairing all run concurrently within one session), and read the same way
+// when a diagnostics line is logged.
+type Stats struct {
+	// Reported by libpcap itself, polled from the capture handle. A drop here
+	// happens before any parsing, so it costs us data we never had a chance to
+	// see -- and it costs a multi-packet response far more often than a
+	// single-packet request.
+	PcapPacketsReceived  uint64
+	PcapPacketsDropped   uint64
+	PcapPacketsIfDropped uint64
+
+	// TCP reassembly failures. NilAssemblerContext and BadAssemblerContextType
+	// fire when a message's first byte carries no TCP sequence number, so the
+	// parser is never created and the message is discarded outright.
+	// ReassemblyGapFlushed counts TCP streams force-flushed because an
+	// expected-but-missing segment sat unfilled past the reassembler's
+	// timeout -- usually the downstream consequence of a kernel packet drop.
+	NilAssemblerContext           uint64
+	BadAssemblerContextType       uint64
+	NilAssemblerContextAfterParse uint64
+	ZeroValuePacketTimestamp      uint64
+	LastPacketBeforeFirstPacket   uint64
+	ReassemblyGapFlushed          uint64
+
+	// The same NilAssemblerContext/BadAssemblerContextType failures, split by
+	// which half of the exchange was discarded. A discarded response leaves a
+	// witness with no response half; a discarded request produces no witness
+	// at all, and its eventual response is later dropped by the rate limiter
+	// with nothing to match against -- see ResponsesDroppedNoMatchingRequest.
+	DiscardedRequests  uint64
+	DiscardedResponses uint64
+	DiscardedOther     uint64
+
+	// A response we parsed successfully and then discarded because its
+	// pairing key -- derived from TCP ack/seq numbers -- did not match any
+	// request we were still tracking. The request, if any, has already gone
+	// out as an unpaired witness by the time this fires.
+	ResponsesDroppedNoMatchingRequest uint64
+
+	// How witnesses left the pair cache: both halves present, request only
+	// (missing_status_code at the back end), response only (missing_latency),
+	// or two messages of the same direction merged into one malformed witness
+	// because they collided on the same pairing key.
+	WitnessesPaired          uint64
+	UnpairedRequestsFlushed  uint64
+	UnpairedResponsesFlushed uint64
+	SameDirectionMerges      uint64
+
+	// A response and request paired, but produced a negative processing
+	// latency, bucketed by magnitude: sub-millisecond is timestamp noise,
+	// sub-second is plausibly a server answering before the request body
+	// finished uploading, and anything over a second is almost certainly a
+	// mispairing (see SameDirectionMerges).
+	NegativeLatencyUnder1ms uint64
+	NegativeLatencyUnder1s  uint64
+	NegativeLatencyOver1s   uint64
+
+	// A request or response reached the backend collector -- so it already
+	// passed prefilter, filters, rate limiting, and sampling -- but
+	// learn.ParseHTTP then failed on it, so it was silently dropped with no
+	// witness produced. This sits strictly after postfilter, so a shortfall
+	// here does not show up as a postfilter-vs-prefilter gap; it can only be
+	// seen here.
+	WitnessParseFailed uint64
+}
+
+// New returns a zeroed Stats for one apidump session.
+func New() *Stats {
+	return &Stats{}
+}
+
+// Add* helpers keep call sites free of repeated &s.Field, atomic.AddUint64
+// boilerplate and make each increment site read as "what happened", not "how
+// it's counted".
+
+// Every method below is a no-op on a nil receiver. A capture session should
+// always have a real Stats -- see apidump.Run() -- but nil-safety here means
+// a missing one (an uninitialized test fixture, a code path that forgot to
+// thread it through) fails silently instead of panicking the capture
+// pipeline.
+
+func (s *Stats) AddPcapPacketsReceived(n uint64) {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.PcapPacketsReceived, n)
+}
+func (s *Stats) AddPcapPacketsDropped(n uint64) {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.PcapPacketsDropped, n)
+}
+func (s *Stats) AddPcapPacketsIfDropped(n uint64) {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.PcapPacketsIfDropped, n)
+}
+
+func (s *Stats) IncrNilAssemblerContext() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.NilAssemblerContext, 1)
+}
+func (s *Stats) IncrBadAssemblerContextType() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.BadAssemblerContextType, 1)
+}
+func (s *Stats) IncrNilAssemblerContextAfterParse() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.NilAssemblerContextAfterParse, 1)
+}
+func (s *Stats) IncrZeroValuePacketTimestamp() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.ZeroValuePacketTimestamp, 1)
+}
+func (s *Stats) IncrLastPacketBeforeFirstPacket() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.LastPacketBeforeFirstPacket, 1)
+}
+func (s *Stats) AddReassemblyGapFlushed(n uint64) {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.ReassemblyGapFlushed, n)
+}
+
+func (s *Stats) IncrDiscardedRequests() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.DiscardedRequests, 1)
+}
+func (s *Stats) IncrDiscardedResponses() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.DiscardedResponses, 1)
+}
+func (s *Stats) IncrDiscardedOther() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.DiscardedOther, 1)
+}
+
+func (s *Stats) IncrResponsesDroppedNoMatchingRequest() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.ResponsesDroppedNoMatchingRequest, 1)
+}
+
+func (s *Stats) IncrWitnessesPaired() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.WitnessesPaired, 1)
+}
+func (s *Stats) IncrUnpairedRequestsFlushed() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.UnpairedRequestsFlushed, 1)
+}
+func (s *Stats) IncrUnpairedResponsesFlushed() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.UnpairedResponsesFlushed, 1)
+}
+func (s *Stats) IncrSameDirectionMerges() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.SameDirectionMerges, 1)
+}
+
+func (s *Stats) IncrNegativeLatencyUnder1ms() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.NegativeLatencyUnder1ms, 1)
+}
+func (s *Stats) IncrNegativeLatencyUnder1s() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.NegativeLatencyUnder1s, 1)
+}
+func (s *Stats) IncrNegativeLatencyOver1s() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.NegativeLatencyOver1s, 1)
+}
+
+func (s *Stats) IncrWitnessParseFailed() {
+	if s == nil {
+		return
+	}
+	atomic.AddUint64(&s.WitnessParseFailed, 1)
+}
+
+// RecordNegativeLatency buckets a negative processing latency, in
+// milliseconds, into the appropriate counter.
+func (s *Stats) RecordNegativeLatency(latencyMs float32) {
+	if s == nil {
+		return
+	}
+	switch {
+	case latencyMs > -1.0:
+		s.IncrNegativeLatencyUnder1ms()
+	case latencyMs > -1000.0:
+		s.IncrNegativeLatencyUnder1s()
+	default:
+		s.IncrNegativeLatencyOver1s()
+	}
+}
+
+// Snapshot is a plain-value copy of Stats for safe, consistent reading (avoids
+// reading fields one at a time while they are still being incremented).
+type Snapshot struct {
+	PcapPacketsReceived, PcapPacketsDropped, PcapPacketsIfDropped uint64
+
+	NilAssemblerContext, BadAssemblerContextType, NilAssemblerContextAfterParse,
+	ZeroValuePacketTimestamp, LastPacketBeforeFirstPacket, ReassemblyGapFlushed uint64
+
+	DiscardedRequests, DiscardedResponses, DiscardedOther uint64
+
+	ResponsesDroppedNoMatchingRequest uint64
+
+	WitnessesPaired, UnpairedRequestsFlushed, UnpairedResponsesFlushed, SameDirectionMerges uint64
+
+	NegativeLatencyUnder1ms, NegativeLatencyUnder1s, NegativeLatencyOver1s uint64
+
+	WitnessParseFailed uint64
+}
+
+// Snapshot reads every counter with atomic.LoadUint64 and returns the result
+// as plain values, safe to format without further synchronization.
+func (s *Stats) Snapshot() Snapshot {
+	if s == nil {
+		return Snapshot{}
+	}
+	return Snapshot{
+		PcapPacketsReceived:  atomic.LoadUint64(&s.PcapPacketsReceived),
+		PcapPacketsDropped:   atomic.LoadUint64(&s.PcapPacketsDropped),
+		PcapPacketsIfDropped: atomic.LoadUint64(&s.PcapPacketsIfDropped),
+
+		NilAssemblerContext:           atomic.LoadUint64(&s.NilAssemblerContext),
+		BadAssemblerContextType:       atomic.LoadUint64(&s.BadAssemblerContextType),
+		NilAssemblerContextAfterParse: atomic.LoadUint64(&s.NilAssemblerContextAfterParse),
+		ZeroValuePacketTimestamp:      atomic.LoadUint64(&s.ZeroValuePacketTimestamp),
+		LastPacketBeforeFirstPacket:   atomic.LoadUint64(&s.LastPacketBeforeFirstPacket),
+		ReassemblyGapFlushed:          atomic.LoadUint64(&s.ReassemblyGapFlushed),
+
+		DiscardedRequests:  atomic.LoadUint64(&s.DiscardedRequests),
+		DiscardedResponses: atomic.LoadUint64(&s.DiscardedResponses),
+		DiscardedOther:     atomic.LoadUint64(&s.DiscardedOther),
+
+		ResponsesDroppedNoMatchingRequest: atomic.LoadUint64(&s.ResponsesDroppedNoMatchingRequest),
+
+		WitnessesPaired:          atomic.LoadUint64(&s.WitnessesPaired),
+		UnpairedRequestsFlushed:  atomic.LoadUint64(&s.UnpairedRequestsFlushed),
+		UnpairedResponsesFlushed: atomic.LoadUint64(&s.UnpairedResponsesFlushed),
+		SameDirectionMerges:      atomic.LoadUint64(&s.SameDirectionMerges),
+
+		NegativeLatencyUnder1ms: atomic.LoadUint64(&s.NegativeLatencyUnder1ms),
+		NegativeLatencyUnder1s:  atomic.LoadUint64(&s.NegativeLatencyUnder1s),
+		NegativeLatencyOver1s:   atomic.LoadUint64(&s.NegativeLatencyOver1s),
+
+		WitnessParseFailed: atomic.LoadUint64(&s.WitnessParseFailed),
+	}
+}

--- a/capturestats/capturestats.go
+++ b/capturestats/capturestats.go
@@ -255,8 +255,8 @@ func (s *Stats) RecordNegativeLatency(latencyMs float32) {
 	}
 }
 
-// Snapshot is a plain-value copy of Stats for safe, consistent reading (avoids
-// reading fields one at a time while they are still being incremented).
+// Snapshot is a plain-value copy of Stats for safe reading/formatting.
+// It loads each counter atomically to avoid data races with concurrent increments.
 type Snapshot struct {
 	PcapPacketsReceived, PcapPacketsDropped, PcapPacketsIfDropped uint64
 

--- a/capturestats/capturestats_test.go
+++ b/capturestats/capturestats_test.go
@@ -1,0 +1,112 @@
+package capturestats
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// This is the regression test for the bug this package exists to fix: two
+// independent capture sessions (e.g. two apidump.Run() goroutines on the same
+// DaemonSet node, monitoring two different pods) must not observe each
+// other's counters. A package-level `var Count... uint64`, which is what
+// these counters used to be, would fail this test -- every increment on
+// either Stats instance would land in the same global variable.
+func TestStatsAreIsolatedPerSession(t *testing.T) {
+	podA := New()
+	podB := New()
+
+	podA.IncrWitnessesPaired()
+	podA.IncrWitnessesPaired()
+	podA.IncrUnpairedRequestsFlushed()
+	podA.AddPcapPacketsDropped(5)
+
+	podB.IncrWitnessesPaired()
+	podB.IncrResponsesDroppedNoMatchingRequest()
+
+	snapA := podA.Snapshot()
+	snapB := podB.Snapshot()
+
+	assert.Equal(t, uint64(2), snapA.WitnessesPaired, "pod A's own pairs")
+	assert.Equal(t, uint64(1), snapA.UnpairedRequestsFlushed)
+	assert.Equal(t, uint64(5), snapA.PcapPacketsDropped)
+	assert.Equal(t, uint64(0), snapA.ResponsesDroppedNoMatchingRequest, "must not see pod B's counters")
+
+	assert.Equal(t, uint64(1), snapB.WitnessesPaired, "pod B's own pairs, not pod A's 2")
+	assert.Equal(t, uint64(1), snapB.ResponsesDroppedNoMatchingRequest)
+	assert.Equal(t, uint64(0), snapB.UnpairedRequestsFlushed, "must not see pod A's counters")
+	assert.Equal(t, uint64(0), snapB.PcapPacketsDropped, "must not see pod A's counters")
+}
+
+// Every increment method, plus Snapshot and RecordNegativeLatency, must
+// tolerate a nil *Stats without panicking -- callers thread this pointer
+// through many layers (pcap, trace, apidump), and a nil one should be a
+// silent no-op, not a crash of the capture pipeline.
+func TestNilStatsIsSafe(t *testing.T) {
+	var s *Stats
+
+	assert.NotPanics(t, func() {
+		s.AddPcapPacketsReceived(1)
+		s.AddPcapPacketsDropped(1)
+		s.AddPcapPacketsIfDropped(1)
+		s.IncrNilAssemblerContext()
+		s.IncrBadAssemblerContextType()
+		s.IncrNilAssemblerContextAfterParse()
+		s.IncrZeroValuePacketTimestamp()
+		s.IncrLastPacketBeforeFirstPacket()
+		s.AddReassemblyGapFlushed(1)
+		s.IncrDiscardedRequests()
+		s.IncrDiscardedResponses()
+		s.IncrDiscardedOther()
+		s.IncrResponsesDroppedNoMatchingRequest()
+		s.IncrWitnessesPaired()
+		s.IncrUnpairedRequestsFlushed()
+		s.IncrUnpairedResponsesFlushed()
+		s.IncrSameDirectionMerges()
+		s.IncrNegativeLatencyUnder1ms()
+		s.IncrNegativeLatencyUnder1s()
+		s.IncrNegativeLatencyOver1s()
+		s.IncrWitnessParseFailed()
+		s.RecordNegativeLatency(-5000)
+	})
+
+	assert.Equal(t, Snapshot{}, s.Snapshot(), "nil Stats snapshots as all zeros")
+}
+
+// Increments from many goroutines must not race or lose updates -- every
+// counter here is incremented from a different goroutine than the one that
+// eventually reads it via Snapshot (e.g. pcap's reassembly goroutines vs. the
+// apidump telemetry ticker).
+func TestStatsConcurrentIncrements(t *testing.T) {
+	s := New()
+	const goroutines = 50
+	const perGoroutine = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range perGoroutine {
+				s.IncrWitnessesPaired()
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, uint64(goroutines*perGoroutine), s.Snapshot().WitnessesPaired)
+}
+
+func TestRecordNegativeLatencyBuckets(t *testing.T) {
+	s := New()
+	s.RecordNegativeLatency(-0.5)   // under 1ms
+	s.RecordNegativeLatency(-500)   // under 1s
+	s.RecordNegativeLatency(-5000)  // over 1s
+	s.RecordNegativeLatency(-999.9) // still under 1s
+
+	snap := s.Snapshot()
+	assert.Equal(t, uint64(1), snap.NegativeLatencyUnder1ms)
+	assert.Equal(t, uint64(2), snap.NegativeLatencyUnder1s)
+	assert.Equal(t, uint64(1), snap.NegativeLatencyOver1s)
+}

--- a/integrations/nginx/backend.go
+++ b/integrations/nginx/backend.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/postmanlabs/postman-insights-agent/apispec"
 	"github.com/postmanlabs/postman-insights-agent/architecture"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/data_masks"
 	"github.com/postmanlabs/postman-insights-agent/env"
 	"github.com/postmanlabs/postman-insights-agent/plugin"
@@ -197,6 +198,7 @@ func NewNginxBackend(args *Args) (*NginxBackend, error) {
 		args.Plugins,
 		apispec.DefaultMaxWintessUploadBuffers,
 		telemetry.Default(),
+		capturestats.New(),
 	)
 
 	// TODO: rate-limit

--- a/pcap/capture_stats.go
+++ b/pcap/capture_stats.go
@@ -1,50 +1,42 @@
 package pcap
 
 import (
-	"sync/atomic"
 	"time"
 
 	"github.com/google/gopacket/pcap"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/printer"
-)
-
-// Capture counters reported by libpcap itself, summed over every handle opened
-// during a capture session.
-//
-// These come from pcap_stats(3): packets the kernel handed us, packets it
-// discarded because our userspace buffer was full, and packets the interface
-// dropped before the capture filter ran. Nothing else in the agent notices a
-// dropped packet; the TCP reassembler just sees a hole in the stream.
-//
-// The asymmetry is what makes these worth reporting. A request usually fits in
-// one packet, while a response spans many, so losing a single packet is much
-// more likely to destroy a response than the request it belongs to. A response
-// we cannot parse leaves a witness with no response half, which the back end
-// then drops as missing_status_code.
-var (
-	CountPcapPacketsReceived  uint64
-	CountPcapPacketsDropped   uint64
-	CountPcapPacketsIfDropped uint64
 )
 
 // How often we read libpcap's counters.
 const pcapStatsPollInterval = 15 * time.Second
 
-// pollPcapStats accumulates libpcap's capture counters until done is closed.
+// pollPcapStats accumulates libpcap's capture counters into stats until done
+// is closed.
 //
-// pcap_stats reports totals for the lifetime of one handle, and a session opens
-// a handle per interface, so we accumulate deltas rather than absolute values.
+// pcap_stats(3) reports packets the kernel handed us, packets it discarded
+// because our userspace buffer was full, and packets the interface dropped
+// before the capture filter ran. Nothing else in the agent notices a dropped
+// packet; the TCP reassembler just sees a hole in the stream. A request
+// usually fits in one packet, while a response spans many, so losing a single
+// packet is much more likely to destroy a response than the request it
+// belongs to -- a response we cannot parse leaves a witness with no response
+// half, which the back end then drops as missing_status_code.
+//
+// pcap_stats reports totals for the lifetime of one handle, and a session
+// opens a handle per interface, so we accumulate deltas rather than absolute
+// values.
 //
 // The caller must not close handle until this function has returned: pcap_stats
 // dereferences the handle without taking a lock.
-func pollPcapStats(handle *pcap.Handle, interfaceName string, done <-chan struct{}) {
+func pollPcapStats(handle *pcap.Handle, interfaceName string, stats *capturestats.Stats, done <-chan struct{}) {
 	ticker := time.NewTicker(pcapStatsPollInterval)
 	defer ticker.Stop()
 
 	var prev pcap.Stats
 
 	sample := func() {
-		stats, err := handle.Stats()
+		s, err := handle.Stats()
 		if err != nil {
 			// Expected while the handle is being torn down.
 			printer.Debugf("Could not read pcap stats for %s: %v\n", interfaceName, err)
@@ -53,16 +45,16 @@ func pollPcapStats(handle *pcap.Handle, interfaceName string, done <-chan struct
 
 		// Guard each delta separately: libpcap resets these counters on some
 		// platforms, and a reset must not underflow the exported total.
-		if stats.PacketsReceived >= prev.PacketsReceived {
-			atomic.AddUint64(&CountPcapPacketsReceived, uint64(stats.PacketsReceived-prev.PacketsReceived))
+		if s.PacketsReceived >= prev.PacketsReceived {
+			stats.AddPcapPacketsReceived(uint64(s.PacketsReceived - prev.PacketsReceived))
 		}
-		if stats.PacketsDropped >= prev.PacketsDropped {
-			atomic.AddUint64(&CountPcapPacketsDropped, uint64(stats.PacketsDropped-prev.PacketsDropped))
+		if s.PacketsDropped >= prev.PacketsDropped {
+			stats.AddPcapPacketsDropped(uint64(s.PacketsDropped - prev.PacketsDropped))
 		}
-		if stats.PacketsIfDropped >= prev.PacketsIfDropped {
-			atomic.AddUint64(&CountPcapPacketsIfDropped, uint64(stats.PacketsIfDropped-prev.PacketsIfDropped))
+		if s.PacketsIfDropped >= prev.PacketsIfDropped {
+			stats.AddPcapPacketsIfDropped(uint64(s.PacketsIfDropped - prev.PacketsIfDropped))
 		}
-		prev = *stats
+		prev = *s
 	}
 
 	for {
@@ -77,57 +69,43 @@ func pollPcapStats(handle *pcap.Handle, interfaceName string, done <-chan struct
 	}
 }
 
-// Messages discarded at parser-creation time, split by which half of the
-// exchange they were.
-//
-// These sit alongside CountNilAssemblerContext and CountBadAssemblerContextType,
-// which count the same failures but are shared across both directions of every
-// flow. The split matters because the two halves fail differently downstream:
-//
-//   - A discarded response leaves the request with nothing to pair with, so we
-//     upload a witness with a request and no response, which the back end drops
-//     as missing_status_code.
-//   - A discarded request produces no witness at all. Its response then arrives,
-//     fails to match any request in the rate limiter, and is dropped there too.
-//     Both halves vanish without appearing in any drop count.
-//
-// Two caveats when reading these. They count *events*, not messages: after one
-// of these the stream is desynced mid-message, so the following bytes are
-// discarded as unparseable until a new message boundary is found, and a single
-// event can therefore cost more than one message. And they only cover this one
-// failure path -- bytes that no parser would accept are counted as Unparsed
-// instead.
-var (
-	CountDiscardedRequests  uint64
-	CountDiscardedResponses uint64
-	CountDiscardedOther     uint64
-)
-
-// CountReassemblyGapFlushed counts TCP streams the reassembler force-flushed
-// because a sequence-number gap sat unfilled past its timeout -- i.e. bytes we
-// expected never arrived and we gave up waiting for them. Whatever the stream
-// was mid-message when this happens gets truncated, which is the same event
-// telemetry reports upstream as capture_gap_truncated_flushed; this is the
-// local, always-on counterpart surfaced in the capture diagnostics log.
-var CountReassemblyGapFlushed uint64
-
 // Names reported by the akinet HTTP parser factories.
 const (
 	httpRequestParserFactoryName  = "HTTP/1.x Request Parser Factory"
 	httpResponseParserFactoryName = "HTTP/1.x Response Parser Factory"
 )
 
-// countDiscardedByParserKind attributes a discarded message to the half of the
-// exchange it belonged to, using the name of the parser factory that had already
-// agreed to parse it.
-func countDiscardedByParserKind(factoryName string) {
+// countDiscardedByParserKind attributes a discarded message to the half of
+// the exchange it belonged to, using the name of the parser factory that had
+// already agreed to parse it, and records it on stats.
+//
+// This sits alongside stats.NilAssemblerContext/BadAssemblerContextType,
+// which count the same failures but are shared across both directions of
+// every flow. The split matters because the two halves fail differently
+// downstream:
+//
+//   - A discarded response leaves the request with nothing to pair with, so
+//     we upload a witness with a request and no response, which the back end
+//     drops as missing_status_code.
+//   - A discarded request produces no witness at all. Its response then
+//     arrives, fails to match any request in the rate limiter, and is
+//     dropped there too. Both halves vanish without appearing in any drop
+//     count.
+//
+// Two caveats when reading these. They count *events*, not messages: after
+// one of these the stream is desynced mid-message, so the following bytes
+// are discarded as unparseable until a new message boundary is found, and a
+// single event can therefore cost more than one message. And they only
+// cover this one failure path -- bytes that no parser would accept are
+// counted as Unparsed instead.
+func countDiscardedByParserKind(stats *capturestats.Stats, factoryName string) {
 	switch factoryName {
 	case httpRequestParserFactoryName:
-		atomic.AddUint64(&CountDiscardedRequests, 1)
+		stats.IncrDiscardedRequests()
 	case httpResponseParserFactoryName:
-		atomic.AddUint64(&CountDiscardedResponses, 1)
+		stats.IncrDiscardedResponses()
 	default:
 		// TLS, HTTP/2 prefaces, and anything else with a parser factory.
-		atomic.AddUint64(&CountDiscardedOther, 1)
+		stats.IncrDiscardedOther()
 	}
 }

--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"runtime/debug"
-	"sync/atomic"
 	"time"
 
 	"github.com/akitasoftware/akita-libs/akid"
@@ -15,6 +14,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/reassembly"
 	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
@@ -63,18 +63,20 @@ type tcpStreamFactory struct {
 	clock   clockWrapper
 	fs      akinet.TCPParserFactorySelector
 	outChan chan<- akinet.ParsedNetworkTraffic
+	stats   *capturestats.Stats
 }
 
-func newTCPStreamFactory(clock clockWrapper, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector) *tcpStreamFactory {
+func newTCPStreamFactory(clock clockWrapper, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats) *tcpStreamFactory {
 	return &tcpStreamFactory{
 		clock:   clock,
 		fs:      fs,
 		outChan: outChan,
+		stats:   stats,
 	}
 }
 
 func (fact *tcpStreamFactory) New(netFlow, tcpFlow gopacket.Flow, _ *layers.TCP, _ reassembly.AssemblerContext) reassembly.Stream {
-	return newTCPStream(fact.clock, netFlow, fact.outChan, fact.fs)
+	return newTCPStream(fact.clock, netFlow, fact.outChan, fact.fs, fact.stats)
 }
 
 // NetworkTrafficObserver is the callback function type for observing
@@ -89,9 +91,16 @@ type NetworkTrafficParser struct {
 	observer    NetworkTrafficObserver // This function is called for every packet.
 	bufferShare float32
 	telemetry   telemetry.Tracker
+
+	// Capture-diagnostics counters for this parser's session. One
+	// NetworkTrafficParser is created per apidump.Run() call, so stats being a
+	// field here (rather than a package-level counter) is what keeps its
+	// numbers scoped to the one pod that session is monitoring -- see
+	// capturestats.Stats for why that distinction matters.
+	stats *capturestats.Stats
 }
 
-func NewNetworkTrafficParser(serviceID akid.ServiceID, traceTags map[tags.Key]string, bufferShare float32, telemetry telemetry.Tracker) *NetworkTrafficParser {
+func NewNetworkTrafficParser(serviceID akid.ServiceID, traceTags map[tags.Key]string, bufferShare float32, telemetry telemetry.Tracker, stats *capturestats.Stats) *NetworkTrafficParser {
 	return &NetworkTrafficParser{
 		serviceID:   serviceID,
 		traceTags:   traceTags,
@@ -100,6 +109,7 @@ func NewNetworkTrafficParser(serviceID akid.ServiceID, traceTags map[tags.Key]st
 		observer:    func(gopacket.Packet) {},
 		bufferShare: bufferShare,
 		telemetry:   telemetry,
+		stats:       stats,
 	}
 }
 
@@ -122,14 +132,14 @@ func (p *NetworkTrafficParser) ParseFromInterface(
 	fs ...akinet.TCPParserFactory,
 ) (<-chan akinet.ParsedNetworkTraffic, error) {
 	// Read in packets, pass to assembler
-	packets, err := p.pcap.capturePackets(signalClose, interfaceName, bpfFilter, targetNetworkNamespaceOpt)
+	packets, err := p.pcap.capturePackets(signalClose, interfaceName, bpfFilter, targetNetworkNamespaceOpt, p.stats)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed begin capturing packets from %s", interfaceName)
 	}
 
 	// Set up assembly
 	out := make(chan akinet.ParsedNetworkTraffic, 100)
-	streamFactory := newTCPStreamFactory(p.clock, out, akinet.TCPParserFactorySelector(fs))
+	streamFactory := newTCPStreamFactory(p.clock, out, akinet.TCPParserFactorySelector(fs), p.stats)
 	streamPool := reassembly.NewStreamPool(streamFactory)
 	assembler := reassembly.NewAssembler(streamPool)
 
@@ -216,7 +226,7 @@ func (p *NetworkTrafficParser) ParseFromInterface(
 				}
 				if flushed != 0 {
 					printer.Debugf("TCP reassembly gap: flushed %d stream(s) early because expected data never arrived\n", flushed)
-					atomic.AddUint64(&CountReassemblyGapFlushed, uint64(flushed))
+					p.stats.AddReassemblyGapFlushed(uint64(flushed))
 				}
 			}
 		}

--- a/pcap/net_parse_test.go
+++ b/pcap/net_parse_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/gopacket"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
 
@@ -98,7 +99,7 @@ func makeUDPPackets(split int, ms ...*testMessage) []gopacket.Packet {
 }
 
 func setupParseFromInterface(pcap pcapWrapper, signalClose <-chan struct{}, facts ...akinet.TCPParserFactory) (<-chan akinet.ParsedNetworkTraffic, error) {
-	p := NewNetworkTrafficParser(akid.GenerateServiceID(), map[tags.Key]string{}, 1.0, telemetry.Default())
+	p := NewNetworkTrafficParser(akid.GenerateServiceID(), map[tags.Key]string{}, 1.0, telemetry.Default(), capturestats.New())
 	p.pcap = pcap
 	p.clock = &fakeClock{testTime}
 	rawOut, err := p.ParseFromInterface("dummy0", "", optionals.None[string](), signalClose, facts...)

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 )
 
@@ -21,7 +22,7 @@ const (
 )
 
 type pcapWrapper interface {
-	capturePackets(done <-chan struct{}, interfaceName, bpfFilter string, targetNetworkNamespaceOpt optionals.Optional[string]) (<-chan gopacket.Packet, error)
+	capturePackets(done <-chan struct{}, interfaceName, bpfFilter string, targetNetworkNamespaceOpt optionals.Optional[string], stats *capturestats.Stats) (<-chan gopacket.Packet, error)
 	getInterfaceAddrs(interfaceName string) ([]net.IP, error)
 }
 
@@ -30,7 +31,7 @@ type pcapImpl struct {
 	TraceTags map[tags.Key]string
 }
 
-func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter string, targetNetworkNamespaceOpt optionals.Optional[string]) (<-chan gopacket.Packet, error) {
+func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter string, targetNetworkNamespaceOpt optionals.Optional[string], stats *capturestats.Stats) (<-chan gopacket.Packet, error) {
 	handle, err := GetPcapHandle(interfaceName, defaultSnapLen, true, BlockForever, targetNetworkNamespaceOpt)
 	if err != nil {
 		return nil, err
@@ -54,7 +55,7 @@ func (p *pcapImpl) capturePackets(done <-chan struct{}, interfaceName, bpfFilter
 	statsStopped := make(chan struct{})
 	go func() {
 		defer close(statsStopped)
-		pollPcapStats(handle, interfaceName, statsDone)
+		pollPcapStats(handle, interfaceName, stats, statsDone)
 	}()
 
 	// TODO: tune the packet channel buffer

--- a/pcap/pcap_replay_test.go
+++ b/pcap/pcap_replay_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/gopacket/pcap"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
 
@@ -150,7 +151,7 @@ func removeNonDeterministicField(p *akinet.ParsedNetworkTraffic) {
 // pcapWrapper backed by a pcap file.
 type filePcapWrapper string
 
-func (f filePcapWrapper) capturePackets(done <-chan struct{}, _, _ string, _ optionals.Optional[string]) (<-chan gopacket.Packet, error) {
+func (f filePcapWrapper) capturePackets(done <-chan struct{}, _, _ string, _ optionals.Optional[string], _ *capturestats.Stats) (<-chan gopacket.Packet, error) {
 	handle, err := pcap.OpenOffline(string(f))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open %s", f)
@@ -179,7 +180,7 @@ func (filePcapWrapper) getInterfaceAddrs(interfaceName string) ([]net.IP, error)
 }
 
 func readFromPcapFile(file string, pool buffer_pool.BufferPool) ([]akinet.ParsedNetworkTraffic, error) {
-	p := NewNetworkTrafficParser(akid.GenerateServiceID(), map[tags.Key]string{}, 1.0, telemetry.Default())
+	p := NewNetworkTrafficParser(akid.GenerateServiceID(), map[tags.Key]string{}, 1.0, telemetry.Default(), capturestats.New())
 	p.pcap = filePcapWrapper(file)
 
 	done := make(chan struct{})

--- a/pcap/run.go
+++ b/pcap/run.go
@@ -15,11 +15,18 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 	"github.com/postmanlabs/postman-insights-agent/trace"
 )
 
+// Collect captures and parses traffic from one interface. It is called once
+// per interface within a single apidump.Run() call, so stats should be the
+// same *capturestats.Stats shared across all of those calls -- see
+// capturestats.Stats for why a shared, per-session instance (rather than a
+// package-level counter) is what keeps its numbers scoped to one monitored
+// pod.
 func Collect(
 	serviceID akid.ServiceID,
 	traceTags map[tags.Key]string,
@@ -33,6 +40,7 @@ func Collect(
 	packetCount trace.PacketCountConsumer,
 	pool buffer_pool.BufferPool,
 	telemetry telemetry.Tracker,
+	stats *capturestats.Stats,
 ) error {
 	defer proc.Close()
 
@@ -48,7 +56,7 @@ func Collect(
 		)
 	}
 
-	parser := NewNetworkTrafficParser(serviceID, traceTags, bufferShare, telemetry)
+	parser := NewNetworkTrafficParser(serviceID, traceTags, bufferShare, telemetry, stats)
 
 	if packetCount != nil {
 		parser.InstallObserver(CountTcpPackets(intf, packetCount))

--- a/pcap/stream.go
+++ b/pcap/stream.go
@@ -3,7 +3,6 @@ package pcap
 import (
 	"encoding/binary"
 	"net"
-	"sync/atomic"
 	"time"
 
 	"github.com/akitasoftware/akita-libs/akid"
@@ -13,31 +12,10 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/reassembly"
 	"github.com/google/uuid"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
-
-// These error counters don't seem to have a comfortable home, can we somehow get them back up to the
-// normal packet counter?  They can't go in tcpFlow because that's ephemeral.
-
-// Nunmber of times we got a nil assembler context; this can happen when the payload
-// resides in a page other than the first in the reassembly buffer.
-var CountNilAssemblerContext uint64
-
-// or when we flush old data?
-var CountNilAssemblerContextAfterParse uint64
-
-// Number of times we got an assembler context of the wrong type; this probably shouldn't
-// happen at all.
-var CountBadAssemblerContextType uint64
-
-// Number of times we got parsed network traffic where either the firstPacket or lastPacket
-// timestamp is the default zero value.
-var CountZeroValuePacketTimestamp uint64
-
-// Number of times we got parsed network traffic where the firstPacket timestamp
-// is before the lastPacket timestamp.
-var CountLastPacketBeforeFirstPacket uint64
 
 // tcpFlow represents a uni-directional flow of TCP segments along with a
 // bidirectional ID that identifies the tcpFlow in the opposite direction.
@@ -56,6 +34,13 @@ type tcpFlow struct {
 
 	factorySelector akinet.TCPParserFactorySelector
 
+	// Capture-diagnostics counters for the apidump session this flow belongs
+	// to. Shared across every flow in that session (there is one NewCollector
+	// call, and so one capturestats.Stats, per apidump.Run() call), which is
+	// what keeps these numbers scoped to one monitored pod instead of the
+	// whole node -- see capturestats.Stats.
+	stats *capturestats.Stats
+
 	// Non-nil if there is an active parser for this flow.
 	currentParser akinet.TCPParser
 
@@ -70,7 +55,7 @@ type tcpFlow struct {
 	unusedAcceptBuf memview.MemView
 }
 
-func newTCPFlow(clock clockWrapper, bidiID akinet.TCPBidiID, nf, tf gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector) *tcpFlow {
+func newTCPFlow(clock clockWrapper, bidiID akinet.TCPBidiID, nf, tf gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats) *tcpFlow {
 	return &tcpFlow{
 		clock:           clock,
 		netFlow:         nf,
@@ -78,6 +63,7 @@ func newTCPFlow(clock clockWrapper, bidiID akinet.TCPBidiID, nf, tf gopacket.Flo
 		bidiID:          bidiID,
 		outChan:         outChan,
 		factorySelector: fs,
+		stats:           stats,
 	}
 }
 
@@ -135,9 +121,9 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 				// that we don't yet understand.
 				// So, track the error count but don't spam the log.
 				if acForFirstByte == nil {
-					atomic.AddUint64(&CountNilAssemblerContext, 1)
+					f.stats.IncrNilAssemblerContext()
 				} else {
-					atomic.AddUint64(&CountBadAssemblerContextType, 1)
+					f.stats.IncrBadAssemblerContextType()
 				}
 
 				// Also record which half of the exchange we just threw away. The
@@ -145,7 +131,7 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 				// cannot tell us whether we are losing requests or responses --
 				// which is the question, since a lost response leaves a witness with
 				// no response half while a lost request leaves no witness at all.
-				countDiscardedByParserKind(fact.Name())
+				countDiscardedByParserKind(f.stats, fact.Name())
 
 				f.handleUnparseable(sg.CaptureInfo(ignoreCount).Timestamp, pktData.Len())
 				return
@@ -182,7 +168,7 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 			// probably be misleading.
 			// TODO: what else can we log here to help identify what's going on?
 			printer.V(6).Infof("AssemblerContext is nil for packet started at %v\n", parseStart)
-			atomic.AddUint64(&CountNilAssemblerContextAfterParse, 1)
+			f.stats.IncrNilAssemblerContextAfterParse()
 			parseEnd = parseStart
 		}
 		f.outChan <- f.toPNT(parseStart, parseEnd, pnc)
@@ -253,7 +239,7 @@ func (f *tcpFlow) toPNT(firstPacketTime time.Time, lastPacketTime time.Time,
 	if firstPacketTime.IsZero() || lastPacketTime.IsZero() {
 		now := f.clock.Now()
 		printer.V(6).Infof("ParsedNetworkTraffic with zero value packet timestamps. type: %v first: %v last: %v now: %v", pncType(), firstPacketTime, lastPacketTime, now)
-		atomic.AddUint64(&CountZeroValuePacketTimestamp, 1)
+		f.stats.IncrZeroValuePacketTimestamp()
 
 		if firstPacketTime.IsZero() {
 			firstPacketTime = now
@@ -264,7 +250,7 @@ func (f *tcpFlow) toPNT(firstPacketTime time.Time, lastPacketTime time.Time,
 	}
 	if lastPacketTime.Before(firstPacketTime) {
 		printer.V(6).Infof("ParsedNetworkTraffic with last packet before first packet. type: %v first: %v last: %v", pncType(), firstPacketTime, lastPacketTime)
-		atomic.AddUint64(&CountLastPacketBeforeFirstPacket, 1)
+		f.stats.IncrLastPacketBeforeFirstPacket()
 
 		lastPacketTime = firstPacketTime
 	}
@@ -319,15 +305,17 @@ type tcpStream struct {
 
 	factorySelector akinet.TCPParserFactorySelector
 	outChan         chan<- akinet.ParsedNetworkTraffic
+	stats           *capturestats.Stats
 }
 
-func newTCPStream(clock clockWrapper, netFlow gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector) *tcpStream {
+func newTCPStream(clock clockWrapper, netFlow gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats) *tcpStream {
 	return &tcpStream{
 		clock:           clock,
 		bidiID:          akinet.TCPBidiID(uuid.New()),
 		netFlow:         netFlow,
 		factorySelector: fs,
 		outChan:         outChan,
+		stats:           stats,
 	}
 }
 
@@ -347,8 +335,8 @@ func (c *tcpStream) Accept(tcp *layers.TCP, _ gopacket.CaptureInfo, dir reassemb
 		// data from this tcpStream or it is garbage collected by the assembler
 		// after streamTimeout.
 		tf, _ := gopacket.FlowFromEndpoints(layers.NewTCPPortEndpoint(tcp.SrcPort), layers.NewTCPPortEndpoint(tcp.DstPort))
-		s1 := newTCPFlow(c.clock, c.bidiID, c.netFlow, tf, c.outChan, c.factorySelector)
-		s2 := newTCPFlow(c.clock, c.bidiID, c.netFlow.Reverse(), tf.Reverse(), c.outChan, c.factorySelector)
+		s1 := newTCPFlow(c.clock, c.bidiID, c.netFlow, tf, c.outChan, c.factorySelector, c.stats)
+		s2 := newTCPFlow(c.clock, c.bidiID, c.netFlow.Reverse(), tf.Reverse(), c.outChan, c.factorySelector, c.stats)
 		c.flows = map[reassembly.TCPFlowDirection]*tcpFlow{
 			dir:           s1,
 			dir.Reverse(): s2,

--- a/pcap/stream_test.go
+++ b/pcap/stream_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/reassembly"
 	"github.com/google/uuid"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 )
 
 var (
@@ -84,7 +85,7 @@ func runTCPFlowTestCase(c tcpFlowTestCase) error {
 		princeParserFactory{},
 		pineappleParserFactory{},
 	})
-	f := newTCPFlow(&fakeClock{testTime}, dummyBidiID, dummyNetFlow, dummyTCPPacketFlow, out, fs)
+	f := newTCPFlow(&fakeClock{testTime}, dummyBidiID, dummyNetFlow, dummyTCPPacketFlow, out, fs, capturestats.New())
 
 	for i, input := range c.inputs {
 		sg.data = memview.New([]byte(input))

--- a/pcap/util_test.go
+++ b/pcap/util_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/reassembly"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 )
 
 var (
@@ -26,7 +27,7 @@ var (
 
 type fakePcap []gopacket.Packet
 
-func (f fakePcap) capturePackets(done <-chan struct{}, interfaceName, bpfFilter string, targetNetworkNamespaceOpt optionals.Optional[string]) (<-chan gopacket.Packet, error) {
+func (f fakePcap) capturePackets(done <-chan struct{}, interfaceName, bpfFilter string, targetNetworkNamespaceOpt optionals.Optional[string], stats *capturestats.Stats) (<-chan gopacket.Packet, error) {
 	outChan := make(chan gopacket.Packet)
 	go func() {
 		defer close(outChan)
@@ -49,7 +50,7 @@ func (f fakePcap) getInterfaceAddrs(interfaceName string) ([]net.IP, error) {
 // cancelled.
 type forceCancelPcap []gopacket.Packet
 
-func (f forceCancelPcap) capturePackets(done <-chan struct{}, interfaceName, bpfFilter string, targetNetworkNamespaceOpt optionals.Optional[string]) (<-chan gopacket.Packet, error) {
+func (f forceCancelPcap) capturePackets(done <-chan struct{}, interfaceName, bpfFilter string, targetNetworkNamespaceOpt optionals.Optional[string], stats *capturestats.Stats) (<-chan gopacket.Packet, error) {
 	outChan := make(chan gopacket.Packet)
 	go func() {
 		defer close(outChan)

--- a/trace/backend_collector.go
+++ b/trace/backend_collector.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	pb "github.com/akitasoftware/akita-ir/go/api_spec"
@@ -22,6 +21,7 @@ import (
 	"github.com/akitasoftware/go-utils/sets"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/data_masks"
 	"github.com/postmanlabs/postman-insights-agent/learn"
 	"github.com/postmanlabs/postman-insights-agent/plugin"
@@ -29,61 +29,6 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/rest"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
-
-// Pairing outcomes for witnesses leaving the pair cache. Together these account
-// for every witness we upload, so they reconcile directly against the back end's
-// witness_pipeline drop reasons without a cross-system join.
-var (
-	// Witnesses uploaded with both halves.
-	CountWitnessesPaired uint64
-
-	// Witnesses uploaded with only a request, because no response ever arrived
-	// before pairCacheExpiration. The back end drops these as
-	// missing_status_code.
-	CountUnpairedRequestsFlushed uint64
-
-	// Witnesses uploaded with only a response, because no request ever arrived.
-	// The back end drops these as missing_latency.
-	CountUnpairedResponsesFlushed uint64
-
-	// Times two requests, or two responses, collided on the same pair key and we
-	// merged them into one witness. The result has two request halves and no
-	// response, so it is also dropped as missing_status_code. A non-zero value
-	// here means pair keys are colliding, which happens when more than one
-	// request is in flight on a connection.
-	CountSameDirectionMerges uint64
-)
-
-// Negative processing latency means we computed a response that started before
-// its request finished. Bucketing by magnitude separates the causes, which is
-// why we count rather than silently clamp:
-//
-//   - Under 1ms: the two halves are effectively simultaneous. Timestamp
-//     granularity or a response that overlaps the tail of the request.
-//   - 1ms to 1s: plausibly real. A server may answer before the client has
-//     finished uploading (an early 4xx, or a 100-continue flow), in which case
-//     the response genuinely starts first and processing latency is not a
-//     meaningful quantity.
-//   - Over 1s: almost certainly a mispairing. We attached a response to a
-//     request it does not belong to, so the timestamps come from unrelated
-//     exchanges. Expect this to move together with CountSameDirectionMerges.
-var (
-	CountNegativeLatencyUnder1ms uint64
-	CountNegativeLatencyUnder1s  uint64
-	CountNegativeLatencyOver1s   uint64
-)
-
-// recordNegativeLatency buckets a negative processing latency, in milliseconds.
-func recordNegativeLatency(latency_ms float32) {
-	switch {
-	case latency_ms > -1.0:
-		atomic.AddUint64(&CountNegativeLatencyUnder1ms, 1)
-	case latency_ms > -1000.0:
-		atomic.AddUint64(&CountNegativeLatencyUnder1s, 1)
-	default:
-		atomic.AddUint64(&CountNegativeLatencyOver1s, 1)
-	}
-}
 
 const (
 	// We stop trying to pair partial witnesses older than pairCacheExpiration.
@@ -158,9 +103,9 @@ func (r *witnessWithInfo) toReport() (*kgxapi.WitnessReport, error) {
 	}, nil
 }
 
-func (w *witnessWithInfo) computeProcessingLatency(isRequest bool, t akinet.ParsedNetworkTraffic) {
+func (w *witnessWithInfo) computeProcessingLatency(stats *capturestats.Stats, isRequest bool, t akinet.ParsedNetworkTraffic) {
 	if w.isRequest == isRequest {
-		atomic.AddUint64(&CountSameDirectionMerges, 1)
+		stats.IncrSameDirectionMerges()
 		if isRequest {
 			printer.Debugln("Skipping latency calculation. Matched 2 requests together.")
 		} else {
@@ -188,7 +133,7 @@ func (w *witnessWithInfo) computeProcessingLatency(isRequest bool, t akinet.Pars
 
 	latency := float32(responseStart.Sub(requestEnd).Microseconds()) / 1000.0
 	if latency < 0.0 {
-		recordNegativeLatency(latency)
+		stats.RecordNegativeLatency(latency)
 		printer.Debugf("Negative latency calculation: %v\n", latency)
 	}
 
@@ -238,6 +183,14 @@ type BackendCollector struct {
 	redactor *data_masks.Redactor
 
 	telemetry telemetry.Tracker
+
+	// Capture-diagnostics counters for the apidump session this collector
+	// belongs to. One BackendCollector is created per apidump.Run() call (two
+	// if HTTPS capture is also enabled), so stats being a field here -- rather
+	// than a package-level counter -- is what keeps pairing outcomes and
+	// negative-latency counts scoped to the pod this collector is uploading
+	// witnesses for, instead of every pod the node happens to monitor.
+	stats *capturestats.Stats
 }
 
 var _ LearnSessionCollector = (*BackendCollector)(nil)
@@ -255,6 +208,7 @@ func NewBackendCollector(
 	plugins []plugin.AkitaPlugin,
 	uploadReportBuffers int,
 	telemetry telemetry.Tracker,
+	stats *capturestats.Stats,
 ) Collector {
 	// Compile the regexps for the always capture payloads.
 	alwaysCapturePayloadsPathsRegex := []*regexp.Regexp{}
@@ -280,6 +234,7 @@ func NewBackendCollector(
 		alwaysCapturePayloadsPathsRegex: alwaysCapturePayloadsPathsRegex,
 		redactor:                        redactor,
 		telemetry:                       telemetry,
+		stats:                           stats,
 	}
 
 	col.uploadReportBatch = batcher.NewInMemory(
@@ -312,6 +267,14 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 	}
 
 	if parseHTTPErr != nil {
+		// This message already passed prefilter, filters, rate limiting, and
+		// sampling -- postfilter's PacketCountCollector counted it as a
+		// request or response before we ever got here -- so this failure is
+		// invisible to the prefilter/postfilter comparison. It is the other
+		// half of the request or response we are about to silently drop:
+		// whichever side of the pair this was, no witness will be produced
+		// for it.
+		c.stats.IncrWitnessParseFailed()
 		c.telemetry.RateLimitError("parse HTTP", parseHTTPErr)
 		printer.Debugf("Failed to parse HTTP, skipping: %v\n", parseHTTPErr)
 		return nil
@@ -329,7 +292,7 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 			// Combine the pair, merging the result into the existing item
 			// rather than the new partial.
 			learn.MergeWitness(pair.witness, partial.Witness)
-			pair.computeProcessingLatency(isRequest, t)
+			pair.computeProcessingLatency(c.stats, isRequest, t)
 
 			// Backfill direction if the first-seen half didn't carry one. Both
 			// halves of an eBPF pair report the same direction, so this is a
@@ -345,7 +308,7 @@ func (c *BackendCollector) Process(t akinet.ParsedNetworkTraffic) error {
 				pair.srcPort, pair.dstPort = pair.dstPort, pair.srcPort
 			}
 
-			atomic.AddUint64(&CountWitnessesPaired, 1)
+			c.stats.IncrWitnessesPaired()
 			c.queueUpload(pair)
 			printer.Debugf("Completed witness %v direction=%s at %v -- %v\n",
 				partial.PairKey, pair.direction, t.ObservationTime, t.FinalPacketTime)
@@ -527,9 +490,9 @@ func (c *BackendCollector) flushPairCache(cutoffTime time.Time) {
 			// as missing_latency, so these two counters are the agent-side
 			// equivalents of those drop reasons.
 			if e.isRequest {
-				atomic.AddUint64(&CountUnpairedRequestsFlushed, 1)
+				c.stats.IncrUnpairedRequestsFlushed()
 			} else {
-				atomic.AddUint64(&CountUnpairedResponsesFlushed, 1)
+				c.stats.IncrUnpairedResponsesFlushed()
 			}
 
 			c.queueUpload(e)

--- a/trace/backend_collector_test.go
+++ b/trace/backend_collector_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/postmanlabs/postman-insights-agent/apispec"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/data_masks"
 	mockrest "github.com/postmanlabs/postman-insights-agent/rest"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
@@ -150,6 +151,7 @@ func TestRedact(t *testing.T) {
 		nil,
 		apispec.DefaultMaxWintessUploadBuffers,
 		telemetry.Default(),
+		capturestats.New(),
 	)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
@@ -501,6 +503,7 @@ func TestTiming(t *testing.T) {
 				nil,
 				apispec.DefaultMaxWintessUploadBuffers,
 				telemetry.Default(),
+				capturestats.New(),
 			)
 			for _, pnt := range test.PNTs {
 				assert.NoError(t, col.Process(pnt))
@@ -543,6 +546,7 @@ func TestMultipleInterfaces(t *testing.T) {
 		nil,
 		apispec.DefaultMaxWintessUploadBuffers,
 		telemetry.Default(),
+		capturestats.New(),
 	)
 
 	var wg sync.WaitGroup
@@ -695,6 +699,7 @@ func TestOnlyRedactNonErrorResponses(t *testing.T) {
 		nil,
 		apispec.DefaultMaxWintessUploadBuffers,
 		telemetry.Default(),
+		capturestats.New(),
 	)
 	assert.NoError(t, col.Process(req))
 	assert.NoError(t, col.Process(resp))
@@ -866,6 +871,7 @@ func TestAlwaysCapturePayloads(t *testing.T) {
 		nil,
 		apispec.DefaultMaxWintessUploadBuffers,
 		telemetry.Default(),
+		capturestats.New(),
 	)
 	assert.NoError(t, col.Process(reqWithCapturePayloadPath))
 	assert.NoError(t, col.Process(respWithCapturePayloadPath))
@@ -1687,6 +1693,7 @@ func TestRedactionConfigs(t *testing.T) {
 			nil,
 			apispec.DefaultMaxWintessUploadBuffers,
 			telemetry.Default(),
+			capturestats.New(),
 		)
 		assert.NoError(t, col.Process(req))
 		assert.NoError(t, col.Process(resp))

--- a/trace/rate_limit.go
+++ b/trace/rate_limit.go
@@ -3,21 +3,14 @@ package trace
 import (
 	"math/rand"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/akitasoftware/akita-libs/akinet"
 	"github.com/akitasoftware/akita-libs/client_telemetry"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	"github.com/spf13/viper"
 )
-
-// Number of HTTP responses we parsed successfully and then discarded because we
-// could not match them to a request. Every one of these leaves a witness with a
-// request and no response, so this counter distinguishes "the response was never
-// parsed" from "the response was parsed and then thrown away here" -- which have
-// completely different fixes.
-var CountResponsesDroppedNoMatchingRequest uint64
 
 const (
 	// One sample is collected per epoch
@@ -66,6 +59,13 @@ type SharedRateLimit struct {
 	children []*rateLimitCollector
 
 	lock sync.Mutex
+
+	// Capture-diagnostics counters for the apidump session that owns this
+	// rate limit. One SharedRateLimit is created per apidump.Run() call, so
+	// stats being a field here (rather than a package-level counter) is what
+	// keeps a response we drop -- see the else branch in Process below --
+	// attributed to the pod it actually belongs to.
+	stats *capturestats.Stats
 }
 
 func (r *SharedRateLimit) startInterval(start time.Time) {
@@ -284,7 +284,7 @@ func (r *rateLimitCollector) Process(pnt akinet.ParsedNetworkTraffic) error {
 			//     first segment, the response uses the seq of its first segment --
 			//     which are only equal if nothing else was in flight on the
 			//     connection. See akinet/http/parser.go.
-			atomic.AddUint64(&CountResponsesDroppedNoMatchingRequest, 1)
+			r.RateLimit.stats.IncrResponsesDroppedNoMatchingRequest()
 		}
 	default:
 		if r.RateLimit.AllowOther() {
@@ -321,7 +321,7 @@ func (r *rateLimitCollector) expireRequests(threshold time.Time) {
 	printer.Debugf("Expired %v old requests\n", expired)
 }
 
-func NewRateLimit(witnessesPerMinute float64) *SharedRateLimit {
+func NewRateLimit(witnessesPerMinute float64, stats *capturestats.Stats) *SharedRateLimit {
 	witnessLimit := witnessesPerMinute * viper.GetDuration(RateLimitEpochTime).Minutes()
 	if witnessLimit < 1 {
 		printer.Warningln("Witnesses per minute rate is too low; rounding up to 1 per 5 minutes.")
@@ -332,6 +332,7 @@ func NewRateLimit(witnessesPerMinute float64) *SharedRateLimit {
 		WitnessesPerEpoch:  int(witnessLimit),
 		FirstEstimate:      true,
 		done:               make(chan struct{}),
+		stats:              stats,
 	}
 
 	// Start the first epoch.

--- a/trace/rate_limit_test.go
+++ b/trace/rate_limit_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/akitasoftware/akita-libs/akinet"
 	"github.com/akitasoftware/akita-libs/memview"
 	"github.com/google/uuid"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/spf13/viper"
 )
 
@@ -43,7 +44,7 @@ func TestRateLimit_FirstSample(t *testing.T) {
 
 	start := time.Now()
 	cc := &countingCollector{}
-	rl := NewRateLimit(1.0)
+	rl := NewRateLimit(1.0, capturestats.New())
 	pc := NewPacketCounter()
 	c := rl.NewCollector(cc, pc).(*rateLimitCollector)
 


### PR DESCRIPTION
This pull request refactors how capture diagnostics counters are tracked and reported, ensuring that all per-session statistics are properly scoped to individual capture sessions (such as one per monitored pod in a Kubernetes DaemonSet). The changes replace package-level counters with a `capturestats.Stats` instance that is passed throughout the code, improving attribution and accuracy of diagnostics, especially in multi-session environments.

**Capture diagnostics refactoring and scoping:**

* Introduced a `capturestats.Stats` struct that is created per `apidump` session and passed to all relevant components, replacing previous use of package-level counters. This ensures that diagnostics are correctly scoped to the session/pod being monitored.
* Updated the diagnostics logging (`logCaptureDiagnostics` and `LogCaptureDiagnostics`) to use the session's `capturestats.Stats` instead of global counters, and improved comments to clarify the importance of correct pod attribution. * Modified the `Summary` struct and its `PrintWarnings` method to use the session-specific stats object, so warnings are accurately reported per session.

**Plumbing and integration:**

* Threaded the `capturestats.Stats` instance through all collector and rate limiter initializations, ensuring all components update and report using the correct session-specific stats.
* Updated imports and removed unused package-level imports related to the old counter approach.

These changes collectively make diagnostics reporting more reliable and accurate in multi-session (especially Kubernetes) environments.