### PR TITLE
[INS-145] Add opt-in synthetic TCP pairing for pcap HTTP/1.x capture

### DIFF
--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -60,23 +60,25 @@ func (ctx *assemblerCtxWithSeq) GetCaptureInfo() gopacket.CaptureInfo {
 
 // tcpStreamFactory implements reassembly.StreamFactory.
 type tcpStreamFactory struct {
-	clock   clockWrapper
-	fs      akinet.TCPParserFactorySelector
-	outChan chan<- akinet.ParsedNetworkTraffic
-	stats   *capturestats.Stats
+	clock               clockWrapper
+	fs                  akinet.TCPParserFactorySelector
+	outChan             chan<- akinet.ParsedNetworkTraffic
+	stats               *capturestats.Stats
+	useSyntheticPairing bool
 }
 
-func newTCPStreamFactory(clock clockWrapper, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats) *tcpStreamFactory {
+func newTCPStreamFactory(clock clockWrapper, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats, useSyntheticPairing bool) *tcpStreamFactory {
 	return &tcpStreamFactory{
-		clock:   clock,
-		fs:      fs,
-		outChan: outChan,
-		stats:   stats,
+		clock:               clock,
+		fs:                  fs,
+		outChan:             outChan,
+		stats:               stats,
+		useSyntheticPairing: useSyntheticPairing,
 	}
 }
 
 func (fact *tcpStreamFactory) New(netFlow, tcpFlow gopacket.Flow, _ *layers.TCP, _ reassembly.AssemblerContext) reassembly.Stream {
-	return newTCPStream(fact.clock, netFlow, fact.outChan, fact.fs, fact.stats)
+	return newTCPStream(fact.clock, netFlow, fact.outChan, fact.fs, fact.stats, fact.useSyntheticPairing)
 }
 
 // NetworkTrafficObserver is the callback function type for observing
@@ -98,6 +100,11 @@ type NetworkTrafficParser struct {
 	// numbers scoped to the one pod that session is monitoring -- see
 	// capturestats.Stats for why that distinction matters.
 	stats *capturestats.Stats
+
+	// See syntheticTCPPairingEnabled (pairing.go). Defaults to false (the
+	// existing seq/ack pairing); Collect sets this from the env var, tests may
+	// set it directly.
+	useSyntheticPairing bool
 }
 
 func NewNetworkTrafficParser(serviceID akid.ServiceID, traceTags map[tags.Key]string, bufferShare float32, telemetry telemetry.Tracker, stats *capturestats.Stats) *NetworkTrafficParser {
@@ -139,7 +146,7 @@ func (p *NetworkTrafficParser) ParseFromInterface(
 
 	// Set up assembly
 	out := make(chan akinet.ParsedNetworkTraffic, 100)
-	streamFactory := newTCPStreamFactory(p.clock, out, akinet.TCPParserFactorySelector(fs), p.stats)
+	streamFactory := newTCPStreamFactory(p.clock, out, akinet.TCPParserFactorySelector(fs), p.stats, p.useSyntheticPairing)
 	streamPool := reassembly.NewStreamPool(streamFactory)
 	assembler := reassembly.NewAssembler(streamPool)
 

--- a/pcap/packet_util.go
+++ b/pcap/packet_util.go
@@ -62,6 +62,24 @@ func CreatePacketWithSeq(src, dst net.IP, srcPort, dstPort int, payload []byte, 
 	return gopacket.NewPacket(buffer.Bytes(), layers.LayerTypeEthernet, gopacket.Default)
 }
 
+// CreatePacketWithSeqAndAck is like CreatePacketWithSeq but also sets the
+// ACK number explicitly, needed to construct packets that exercise TCP
+// seq/ack-based HTTP pairing (see pairing_test.go).
+func CreatePacketWithSeqAndAck(src, dst net.IP, srcPort, dstPort int, payload []byte, seq, ack uint32) gopacket.Packet {
+	ethernetLayer, ipLayer, tcpLayer := createPacketLayers(src, dst, srcPort, dstPort, seq)
+	tcpLayer.ACK = true
+	tcpLayer.Ack = ack
+	buffer := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true}
+	gopacket.SerializeLayers(buffer, opts,
+		ethernetLayer,
+		ipLayer,
+		tcpLayer,
+		gopacket.Payload(payload),
+	)
+	return gopacket.NewPacket(buffer.Bytes(), layers.LayerTypeEthernet, gopacket.Default)
+}
+
 func CreateUDPPacket(src, dst net.IP, srcPort, dstPort int, payload []byte) gopacket.Packet {
 	ethernetLayer := &layers.Ethernet{
 		EthernetType: layers.EthernetTypeIPv4,

--- a/pcap/pairing.go
+++ b/pcap/pairing.go
@@ -1,0 +1,96 @@
+package pcap
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/akitasoftware/akita-libs/akinet"
+	"github.com/google/gopacket/reassembly"
+	"github.com/postmanlabs/postman-insights-agent/printer"
+)
+
+// Set POSTMAN_INSIGHTS_AGENT_SYNTHETIC_TCP_PAIRING=true to pair HTTP/1.x
+// requests and responses using a synthetic per-connection FIFO ordinal
+// instead of their real TCP seq/ack numbers. Off by default.
+//
+// The existing pairing (tcpFlow.reassembled's fact.CreateParser(f.bidiID,
+// ctx.seq, ctx.ack)) relies on the ACK on a request's first segment being
+// equal to the SEQ of its response's first segment, which akita-libs'
+// http.newHTTPParser uses as the pairing key (request.Seq = ack,
+// response.Seq = seq -- see akinet/http/parser.go). That equality only holds
+// if nothing else was in flight on the connection; see the requestKey
+// comment in trace/rate_limit.go for the failure mode this causes
+// (responses dropped as ResponsesDroppedNoMatchingRequest, which surfaces at
+// the back end as a missing_status_code witness).
+//
+// This flag switches to the fix already proven on the eBPF capture path
+// (ebpf/events/adapter.go's tlsConnState.pairSeqForFactory): track message
+// arrival order per connection instead of TCP byte offsets. It is a flag
+// rather than the default so it can be validated against real traffic
+// first; once confirmed, remove the flag and the old seq/ack path rather
+// than keeping both as permanent configuration.
+const syntheticTCPPairingEnvVar = "POSTMAN_INSIGHTS_AGENT_SYNTHETIC_TCP_PAIRING"
+
+func syntheticTCPPairingEnabled() bool {
+	v, present := os.LookupEnv(syntheticTCPPairingEnvVar)
+	if !present {
+		return false
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		printer.Warningf("Could not parse %s value %q, defaulting to disabled: %v\n",
+			syntheticTCPPairingEnvVar, v, err)
+		return false
+	}
+	return enabled
+}
+
+// pairSequencer generates synthetic pairing sequence numbers shared by both
+// directions of one TCP connection (see tcpStream.pairSeq), used in place of
+// real TCP seq/ack numbers when synthetic TCP pairing is enabled.
+//
+// Mirrors ebpf/events/adapter.go's tlsConnState.pairSeqForFactory: HTTP
+// requests push their index onto a FIFO queue, responses pop the oldest
+// unmatched index, so pipelined or overlapping HTTP/1.1 exchanges on the
+// same connection still pair correctly regardless of what TCP acked when.
+//
+// Not synchronized: like the rest of tcpFlow/tcpStream, a pairSequencer is
+// only ever touched by the single goroutine that drives TCP reassembly for
+// the interface owning this connection (see NetworkTrafficParser.ParseFromInterface).
+//
+// Non-HTTP-request factories (HTTP response, TLS handshake, HTTP/2 preface)
+// all fall into the "pop" branch below. That's harmless for TLS and HTTP/2
+// preface: pcap never extracts HTTP witnesses from those (TLS-encrypted
+// traffic is opaque to pcap, and the HTTP/2 preface parser is a one-time
+// sink), so the one counter value they consume is never compared against
+// anything.
+type pairSequencer struct {
+	nextPairIdx       int
+	unmatchedRequests []int
+}
+
+func newPairSequencer() *pairSequencer {
+	return &pairSequencer{}
+}
+
+func (p *pairSequencer) pairSeqForFactory(factory akinet.TCPParserFactory) reassembly.Sequence {
+	if isHTTPRequestParserFactory(factory) {
+		idx := p.nextPairIdx
+		p.nextPairIdx++
+		p.unmatchedRequests = append(p.unmatchedRequests, idx)
+		return reassembly.Sequence(idx)
+	}
+
+	idx := p.nextPairIdx
+	if len(p.unmatchedRequests) > 0 {
+		idx = p.unmatchedRequests[0]
+		p.unmatchedRequests = p.unmatchedRequests[1:]
+	} else {
+		p.nextPairIdx++
+	}
+	return reassembly.Sequence(idx)
+}
+
+func isHTTPRequestParserFactory(factory akinet.TCPParserFactory) bool {
+	return factory.Name() == "HTTP/1.x Request Parser Factory"
+}

--- a/pcap/pairing.go
+++ b/pcap/pairing.go
@@ -58,12 +58,12 @@ func syntheticTCPPairingEnabled() bool {
 // only ever touched by the single goroutine that drives TCP reassembly for
 // the interface owning this connection (see NetworkTrafficParser.ParseFromInterface).
 //
-// Non-HTTP-request factories (HTTP response, TLS handshake, HTTP/2 preface)
-// all fall into the "pop" branch below. That's harmless for TLS and HTTP/2
-// preface: pcap never extracts HTTP witnesses from those (TLS-encrypted
-// traffic is opaque to pcap, and the HTTP/2 preface parser is a one-time
-// sink), so the one counter value they consume is never compared against
-// anything.
+// Only reached for HTTP/1.x request/response factories -- see
+// isHTTPParserFactory and its call site in tcpFlow.reassembled. TLS,
+// HTTP/2-preface, and any other factory keep the real ctx.seq/ctx.ack
+// unconditionally, even when synthetic pairing is enabled, since this fix
+// only concerns HTTP/1.x pairing and those factories' CreateParser
+// implementations don't use their seq/ack params at all today.
 type pairSequencer struct {
 	nextPairIdx       int
 	unmatchedRequests []int
@@ -93,4 +93,14 @@ func (p *pairSequencer) pairSeqForFactory(factory akinet.TCPParserFactory) reass
 
 func isHTTPRequestParserFactory(factory akinet.TCPParserFactory) bool {
 	return factory.Name() == httpRequestParserFactoryName
+}
+
+// isHTTPParserFactory reports whether factory is the HTTP/1.x request or
+// response parser factory -- the only two whose pairing key
+// (akinet/http/parser.go's newHTTPParser) is derived from seq/ack. This
+// gates which factories get the synthetic ordinal substituted in for
+// ctx.seq/ctx.ack at pairSequencer's call site in tcpFlow.reassembled.
+func isHTTPParserFactory(factory akinet.TCPParserFactory) bool {
+	name := factory.Name()
+	return name == httpRequestParserFactoryName || name == httpResponseParserFactoryName
 }

--- a/pcap/pairing.go
+++ b/pcap/pairing.go
@@ -92,5 +92,5 @@ func (p *pairSequencer) pairSeqForFactory(factory akinet.TCPParserFactory) reass
 }
 
 func isHTTPRequestParserFactory(factory akinet.TCPParserFactory) bool {
-	return factory.Name() == "HTTP/1.x Request Parser Factory"
+	return factory.Name() == httpRequestParserFactoryName
 }

--- a/pcap/pairing_test.go
+++ b/pcap/pairing_test.go
@@ -1,0 +1,192 @@
+package pcap
+
+import (
+	"testing"
+
+	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/akitasoftware/akita-libs/akinet"
+	akihttp "github.com/akitasoftware/akita-libs/akinet/http"
+	"github.com/akitasoftware/akita-libs/buffer_pool"
+	"github.com/akitasoftware/akita-libs/memview"
+	"github.com/akitasoftware/akita-libs/tags"
+	"github.com/akitasoftware/go-utils/optionals"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/reassembly"
+	"github.com/postmanlabs/postman-insights-agent/capturestats"
+	"github.com/postmanlabs/postman-insights-agent/telemetry"
+)
+
+// fakeHTTPRequestFactory has the same Name() as akinet/http's real HTTP
+// request parser factory, without needing a buffer pool, so pairSeqForFactory
+// can be tested in isolation from real HTTP parsing.
+type fakeHTTPRequestFactory struct{}
+
+func (fakeHTTPRequestFactory) Name() string { return "HTTP/1.x Request Parser Factory" }
+
+func (fakeHTTPRequestFactory) Accepts(input memview.MemView, isEnd bool) (akinet.AcceptDecision, int64) {
+	return akinet.Reject, 0
+}
+
+func (fakeHTTPRequestFactory) CreateParser(id akinet.TCPBidiID, seq, ack reassembly.Sequence) akinet.TCPParser {
+	return nil
+}
+
+// TestPairSequencer exercises the FIFO pairing queue directly: requests push
+// an index, responses pop the oldest unmatched one, in order -- including
+// the pipelined case where two requests arrive before either response.
+func TestPairSequencer(t *testing.T) {
+	p := newPairSequencer()
+	req := fakeHTTPRequestFactory{}
+	notReq := princeParserFactory{} // any factory whose Name() isn't the HTTP request factory's
+
+	// Simple case: request then its response.
+	r0 := p.pairSeqForFactory(req)
+	s0 := p.pairSeqForFactory(notReq)
+	if r0 != s0 {
+		t.Errorf("expected first response to pair with first request: req=%v resp=%v", r0, s0)
+	}
+
+	// Pipelined case: two requests arrive before either response. FIFO
+	// ordering must still pair them correctly.
+	r1 := p.pairSeqForFactory(req)
+	r2 := p.pairSeqForFactory(req)
+	s1 := p.pairSeqForFactory(notReq)
+	s2 := p.pairSeqForFactory(notReq)
+
+	if r1 != s1 {
+		t.Errorf("expected second request to pair with first of the two pending responses: req=%v resp=%v", r1, s1)
+	}
+	if r2 != s2 {
+		t.Errorf("expected third request to pair with second of the two pending responses: req=%v resp=%v", r2, s2)
+	}
+	if r1 == r2 {
+		t.Errorf("expected the two pipelined requests to get distinct indices, both got %v", r1)
+	}
+}
+
+// setupPairingTestParser wires up a NetworkTrafficParser with real HTTP/1.x
+// parser factories (not the fake prince/pineapple protocols used elsewhere
+// in this package), and filters its output down to just the parsed HTTP
+// requests and responses.
+func setupPairingTestParser(useSyntheticPairing bool, pkts []gopacket.Packet, signalClose <-chan struct{}, pool buffer_pool.BufferPool) (<-chan akinet.ParsedNetworkTraffic, error) {
+	p := NewNetworkTrafficParser(akid.GenerateServiceID(), map[tags.Key]string{}, 1.0, telemetry.Default(), capturestats.New())
+	p.pcap = fakePcap(pkts)
+	p.clock = &fakeClock{testTime}
+	p.useSyntheticPairing = useSyntheticPairing
+
+	rawOut, err := p.ParseFromInterface("dummy0", "", optionals.None[string](), signalClose,
+		akihttp.NewHTTPRequestParserFactory(pool),
+		akihttp.NewHTTPResponseParserFactory(pool),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(chan akinet.ParsedNetworkTraffic)
+	go func() {
+		defer close(out)
+		for pkt := range rawOut {
+			switch pkt.Content.(type) {
+			case akinet.HTTPRequest, akinet.HTTPResponse:
+				out <- pkt
+			}
+		}
+	}()
+	return out, nil
+}
+
+// TestSyntheticTCPPairingFixesKeepAliveMismatch reproduces the pairing bug
+// end to end (real TCP packets, real HTTP/1.x parsing, no live traffic
+// capture needed) and shows the fix resolves it.
+//
+// Two HTTP request/response exchanges happen on one keep-alive connection.
+// The second request's ACK is deliberately a few bytes short of fully
+// acknowledging the first response -- a client that fires its next request
+// slightly before its TCP stack has acked all of the previous response,
+// which is what breaks the real seq/ack pairing on a busy connection (see
+// the requestKey comment in trace/rate_limit.go, and pairing.go).
+//
+// The first exchange pairs correctly either way, since nothing preceded it.
+// The second exchange is where the two pairing strategies diverge: with the
+// existing seq/ack pairing it MUST mismatch (reproducing the drop), and with
+// synthetic pairing enabled it MUST match (the fix).
+func TestSyntheticTCPPairingFixesKeepAliveMismatch(t *testing.T) {
+	pool, err := buffer_pool.MakeBufferPool(1024*1024, 4*1024)
+	if err != nil {
+		t.Fatalf("failed to create buffer pool: %v", err)
+	}
+
+	const (
+		clientSeq0   = 1000
+		serverSeq0   = 2000
+		ackShortfall = 3 // bytes of resp1 that req2's ACK fails to cover
+	)
+	req1 := []byte("GET /a HTTP/1.1\r\nHost: x.com\r\nContent-Length: 0\r\n\r\n")
+	resp1 := []byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+	req2 := []byte("GET /b HTTP/1.1\r\nHost: x.com\r\nContent-Length: 0\r\n\r\n")
+	resp2 := []byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+
+	clientSeqAfterReq1 := uint32(clientSeq0 + len(req1))
+	serverSeqAfterResp1 := uint32(serverSeq0 + len(resp1))
+
+	makePackets := func() []gopacket.Packet {
+		return []gopacket.Packet{
+			// Exchange 1: req1's ACK (serverSeq0) equals resp1's SEQ -- the
+			// "nothing else in flight yet" case that always pairs.
+			CreatePacketWithSeqAndAck(ip1, ip2, port1, port2, req1, clientSeq0, serverSeq0),
+			CreatePacketWithSeqAndAck(ip2, ip1, port2, port1, resp1, serverSeq0, clientSeqAfterReq1),
+
+			// Exchange 2: req2's ACK is short of resp2's SEQ by ackShortfall
+			// bytes, reproducing the keep-alive skew.
+			CreatePacketWithSeqAndAck(ip1, ip2, port1, port2, req2, clientSeqAfterReq1, serverSeqAfterResp1-ackShortfall),
+			CreatePacketWithSeqAndAck(ip2, ip1, port2, port1, resp2, serverSeqAfterResp1, clientSeqAfterReq1+uint32(len(req2))),
+		}
+	}
+
+	collect := func(useSyntheticPairing bool) (reqs []akinet.HTTPRequest, resps []akinet.HTTPResponse) {
+		closeChan := make(chan struct{})
+		defer close(closeChan)
+
+		out, err := setupPairingTestParser(useSyntheticPairing, makePackets(), closeChan, pool)
+		if err != nil {
+			t.Fatalf("failed to set up parser: %v", err)
+		}
+
+		for pkt := range out {
+			switch c := pkt.Content.(type) {
+			case akinet.HTTPRequest:
+				reqs = append(reqs, c)
+			case akinet.HTTPResponse:
+				resps = append(resps, c)
+			}
+			pkt.Content.ReleaseBuffers()
+		}
+		return reqs, resps
+	}
+
+	t.Run("existing seq/ack pairing: second exchange mismatches", func(t *testing.T) {
+		reqs, resps := collect(false)
+		if len(reqs) != 2 || len(resps) != 2 {
+			t.Fatalf("expected 2 requests and 2 responses, got %d requests and %d responses", len(reqs), len(resps))
+		}
+		if reqs[0].Seq != resps[0].Seq {
+			t.Errorf("expected first exchange to pair (nothing preceded it): request.Seq=%d response.Seq=%d", reqs[0].Seq, resps[0].Seq)
+		}
+		if reqs[1].Seq == resps[1].Seq {
+			t.Errorf("expected second exchange to MISMATCH under existing seq/ack pairing (this is the bug we're fixing), but request.Seq=%d == response.Seq=%d", reqs[1].Seq, resps[1].Seq)
+		}
+	})
+
+	t.Run("synthetic pairing: both exchanges match", func(t *testing.T) {
+		reqs, resps := collect(true)
+		if len(reqs) != 2 || len(resps) != 2 {
+			t.Fatalf("expected 2 requests and 2 responses, got %d requests and %d responses", len(reqs), len(resps))
+		}
+		if reqs[0].Seq != resps[0].Seq {
+			t.Errorf("expected first exchange to pair: request.Seq=%d response.Seq=%d", reqs[0].Seq, resps[0].Seq)
+		}
+		if reqs[1].Seq != resps[1].Seq {
+			t.Errorf("expected second exchange to MATCH under synthetic pairing (this is the fix), but request.Seq=%d != response.Seq=%d", reqs[1].Seq, resps[1].Seq)
+		}
+	})
+}

--- a/pcap/pairing_test.go
+++ b/pcap/pairing_test.go
@@ -148,6 +148,13 @@ func TestSyntheticTCPPairingFixesKeepAliveMismatch(t *testing.T) {
 		}
 	}
 
+	// collect does not release buffers itself: HTTPRequest/HTTPResponse's
+	// buffer field is an interface (buffer_pool.Buffer), so releasing it
+	// affects every copy of the struct that shares it, including the ones
+	// returned here. Releasing before the caller's assertions run would make
+	// any field beyond Seq (an independent int, unaffected by the buffer
+	// pool) unsafe to read. Callers must release via releasePairingTestTraffic
+	// once they're done with the returned values.
 	collect := func(useSyntheticPairing bool) (reqs []akinet.HTTPRequest, resps []akinet.HTTPResponse) {
 		closeChan := make(chan struct{})
 		defer close(closeChan)
@@ -164,13 +171,14 @@ func TestSyntheticTCPPairingFixesKeepAliveMismatch(t *testing.T) {
 			case akinet.HTTPResponse:
 				resps = append(resps, c)
 			}
-			pkt.Content.ReleaseBuffers()
 		}
 		return reqs, resps
 	}
 
 	t.Run("existing seq/ack pairing: second exchange mismatches", func(t *testing.T) {
 		reqs, resps := collect(false)
+		defer releasePairingTestTraffic(reqs, resps)
+
 		if len(reqs) != 2 || len(resps) != 2 {
 			t.Fatalf("expected 2 requests and 2 responses, got %d requests and %d responses", len(reqs), len(resps))
 		}
@@ -184,6 +192,8 @@ func TestSyntheticTCPPairingFixesKeepAliveMismatch(t *testing.T) {
 
 	t.Run("synthetic pairing: both exchanges match", func(t *testing.T) {
 		reqs, resps := collect(true)
+		defer releasePairingTestTraffic(reqs, resps)
+
 		if len(reqs) != 2 || len(resps) != 2 {
 			t.Fatalf("expected 2 requests and 2 responses, got %d requests and %d responses", len(reqs), len(resps))
 		}
@@ -194,4 +204,13 @@ func TestSyntheticTCPPairingFixesKeepAliveMismatch(t *testing.T) {
 			t.Errorf("expected second exchange to MATCH under synthetic pairing (this is the fix), but request.Seq=%d != response.Seq=%d", reqs[1].Seq, resps[1].Seq)
 		}
 	})
+}
+
+func releasePairingTestTraffic(reqs []akinet.HTTPRequest, resps []akinet.HTTPResponse) {
+	for _, r := range reqs {
+		r.ReleaseBuffers()
+	}
+	for _, r := range resps {
+		r.ReleaseBuffers()
+	}
 }

--- a/pcap/pairing_test.go
+++ b/pcap/pairing_test.go
@@ -21,7 +21,7 @@ import (
 // can be tested in isolation from real HTTP parsing.
 type fakeHTTPRequestFactory struct{}
 
-func (fakeHTTPRequestFactory) Name() string { return "HTTP/1.x Request Parser Factory" }
+func (fakeHTTPRequestFactory) Name() string { return httpRequestParserFactoryName }
 
 func (fakeHTTPRequestFactory) Accepts(input memview.MemView, isEnd bool) (akinet.AcceptDecision, int64) {
 	return akinet.Reject, 0
@@ -89,6 +89,11 @@ func setupPairingTestParser(useSyntheticPairing bool, pkts []gopacket.Packet, si
 			switch pkt.Content.(type) {
 			case akinet.HTTPRequest, akinet.HTTPResponse:
 				out <- pkt
+			default:
+				// e.g. TCPPacketMetadata today; release on principle so this
+				// doesn't start leaking if a content type that does hold a
+				// buffer gets added to the filter's default case later.
+				pkt.Content.ReleaseBuffers()
 			}
 		}
 	}()

--- a/pcap/run.go
+++ b/pcap/run.go
@@ -57,6 +57,7 @@ func Collect(
 	}
 
 	parser := NewNetworkTrafficParser(serviceID, traceTags, bufferShare, telemetry, stats)
+	parser.useSyntheticPairing = syntheticTCPPairingEnabled()
 
 	if packetCount != nil {
 		parser.InstallObserver(CountTcpPackets(intf, packetCount))

--- a/pcap/run.go
+++ b/pcap/run.go
@@ -59,6 +59,16 @@ func Collect(
 	parser := NewNetworkTrafficParser(serviceID, traceTags, bufferShare, telemetry, stats)
 	parser.useSyntheticPairing = syntheticTCPPairingEnabled()
 
+	podName, ok := traceTags[tags.XAkitaKubernetesPod]
+	if !ok {
+		podName = "unknown"
+	}
+	if parser.useSyntheticPairing {
+		printer.Infof("HTTP/1.x request/response pairing: using synthetic per-connection FIFO ordinal (POSTMAN_INSIGHTS_AGENT_SYNTHETIC_TCP_PAIRING=true), interface=%s svc=%v pod=%v\n", intf, serviceID, podName)
+	} else {
+		printer.Infof("HTTP/1.x request/response pairing: using TCP seq/ack (default), interface=%s svc=%v pod=%v\n", intf, serviceID, podName)
+	}
+
 	if packetCount != nil {
 		parser.InstallObserver(CountTcpPackets(intf, packetCount))
 	}

--- a/pcap/stream.go
+++ b/pcap/stream.go
@@ -41,6 +41,12 @@ type tcpFlow struct {
 	// whole node -- see capturestats.Stats.
 	stats *capturestats.Stats
 
+	// Shared with the tcpFlow in the opposite direction of this flow (both
+	// flows of one tcpStream point at the same pairSequencer). Non-nil only
+	// when synthetic TCP pairing is enabled -- see syntheticTCPPairingEnabled
+	// in pairing.go. Nil means use the real TCP seq/ack numbers, as before.
+	pairSeq *pairSequencer
+
 	// Non-nil if there is an active parser for this flow.
 	currentParser akinet.TCPParser
 
@@ -55,7 +61,7 @@ type tcpFlow struct {
 	unusedAcceptBuf memview.MemView
 }
 
-func newTCPFlow(clock clockWrapper, bidiID akinet.TCPBidiID, nf, tf gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats) *tcpFlow {
+func newTCPFlow(clock clockWrapper, bidiID akinet.TCPBidiID, nf, tf gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats, pairSeq *pairSequencer) *tcpFlow {
 	return &tcpFlow{
 		clock:           clock,
 		netFlow:         nf,
@@ -64,6 +70,7 @@ func newTCPFlow(clock clockWrapper, bidiID akinet.TCPBidiID, nf, tf gopacket.Flo
 		outChan:         outChan,
 		factorySelector: fs,
 		stats:           stats,
+		pairSeq:         pairSeq,
 	}
 }
 
@@ -136,7 +143,16 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 				f.handleUnparseable(sg.CaptureInfo(ignoreCount).Timestamp, pktData.Len())
 				return
 			}
-			f.currentParser = fact.CreateParser(f.bidiID, ctx.seq, ctx.ack)
+			if f.pairSeq != nil {
+				// Synthetic pairing enabled: ignore the real TCP seq/ack and use a
+				// shared per-connection FIFO ordinal instead, mirroring
+				// ebpf/events/adapter.go's tlsConnState.pairSeqForFactory. See
+				// pairing.go for why the real numbers are unreliable here.
+				synthSeq := f.pairSeq.pairSeqForFactory(fact)
+				f.currentParser = fact.CreateParser(f.bidiID, synthSeq, synthSeq)
+			} else {
+				f.currentParser = fact.CreateParser(f.bidiID, ctx.seq, ctx.ack)
+			}
 			f.currentParserCtx = ctx
 		default:
 			printer.Errorf("unsupported decision type %s, treating data as raw bytes\n", decision)
@@ -306,9 +322,17 @@ type tcpStream struct {
 	factorySelector akinet.TCPParserFactorySelector
 	outChan         chan<- akinet.ParsedNetworkTraffic
 	stats           *capturestats.Stats
+
+	// Shared by both flows of this connection when synthetic TCP pairing is
+	// enabled; nil otherwise. See pairing.go.
+	pairSeq *pairSequencer
 }
 
-func newTCPStream(clock clockWrapper, netFlow gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats) *tcpStream {
+func newTCPStream(clock clockWrapper, netFlow gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats, useSyntheticPairing bool) *tcpStream {
+	var pairSeq *pairSequencer
+	if useSyntheticPairing {
+		pairSeq = newPairSequencer()
+	}
 	return &tcpStream{
 		clock:           clock,
 		bidiID:          akinet.TCPBidiID(uuid.New()),
@@ -316,6 +340,7 @@ func newTCPStream(clock clockWrapper, netFlow gopacket.Flow, outChan chan<- akin
 		factorySelector: fs,
 		outChan:         outChan,
 		stats:           stats,
+		pairSeq:         pairSeq,
 	}
 }
 
@@ -335,8 +360,8 @@ func (c *tcpStream) Accept(tcp *layers.TCP, _ gopacket.CaptureInfo, dir reassemb
 		// data from this tcpStream or it is garbage collected by the assembler
 		// after streamTimeout.
 		tf, _ := gopacket.FlowFromEndpoints(layers.NewTCPPortEndpoint(tcp.SrcPort), layers.NewTCPPortEndpoint(tcp.DstPort))
-		s1 := newTCPFlow(c.clock, c.bidiID, c.netFlow, tf, c.outChan, c.factorySelector, c.stats)
-		s2 := newTCPFlow(c.clock, c.bidiID, c.netFlow.Reverse(), tf.Reverse(), c.outChan, c.factorySelector, c.stats)
+		s1 := newTCPFlow(c.clock, c.bidiID, c.netFlow, tf, c.outChan, c.factorySelector, c.stats, c.pairSeq)
+		s2 := newTCPFlow(c.clock, c.bidiID, c.netFlow.Reverse(), tf.Reverse(), c.outChan, c.factorySelector, c.stats, c.pairSeq)
 		c.flows = map[reassembly.TCPFlowDirection]*tcpFlow{
 			dir:           s1,
 			dir.Reverse(): s2,

--- a/pcap/stream.go
+++ b/pcap/stream.go
@@ -143,11 +143,17 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 				f.handleUnparseable(sg.CaptureInfo(ignoreCount).Timestamp, pktData.Len())
 				return
 			}
-			if f.pairSeq != nil {
-				// Synthetic pairing enabled: ignore the real TCP seq/ack and use a
-				// shared per-connection FIFO ordinal instead, mirroring
+			if f.pairSeq != nil && isHTTPParserFactory(fact) {
+				// Synthetic pairing enabled, and this is an HTTP/1.x request or
+				// response: ignore the real TCP seq/ack and use a shared
+				// per-connection FIFO ordinal instead, mirroring
 				// ebpf/events/adapter.go's tlsConnState.pairSeqForFactory. See
 				// pairing.go for why the real numbers are unreliable here.
+				//
+				// Scoped to HTTP only -- TLS/HTTP2-preface/etc. keep the real
+				// seq/ack, even when the flag is on, since this fix only concerns
+				// HTTP/1.x pairing and other factories have no reason to see
+				// substituted values.
 				synthSeq := f.pairSeq.pairSeqForFactory(fact)
 				f.currentParser = fact.CreateParser(f.bidiID, synthSeq, synthSeq)
 			} else {

--- a/pcap/stream_test.go
+++ b/pcap/stream_test.go
@@ -85,7 +85,7 @@ func runTCPFlowTestCase(c tcpFlowTestCase) error {
 		princeParserFactory{},
 		pineappleParserFactory{},
 	})
-	f := newTCPFlow(&fakeClock{testTime}, dummyBidiID, dummyNetFlow, dummyTCPPacketFlow, out, fs, capturestats.New())
+	f := newTCPFlow(&fakeClock{testTime}, dummyBidiID, dummyNetFlow, dummyTCPPacketFlow, out, fs, capturestats.New(), nil)
 
 	for i, input := range c.inputs {
 		sg.data = memview.New([]byte(input))


### PR DESCRIPTION
### Summary

The pcap path pairs HTTP requests with responses using raw TCP seq/ack numbers, which only works if nothing else is in flight on the connection — a busy keep-alive connection breaks that assumption, and the orphaned response gets dropped (`missing_status_code` at the back end). This was confirmed as the dominant cause of the response loss we've been tracking on `identity-service`/`api-catalog-service`.

### Fix
Replace the raw seq/ack pairing key with a **per-connection FIFO queue**, gated behind a flag. Each HTTP request pushes an index onto the queue; each response pops the oldest un-matched index off it. Since requests and responses always arrive on a connection in the same relative order they were sent, popping in arrival order pairs them correctly regardless of what the TCP numbers say — pipelined or delayed exchanges included. This is the same technique the eBPF capture path already uses successfully (`ebpf/events/adapter.go`'s `pairSeqForFactory`), just ported to the pcap/TCP-reassembly layer.

### Changes

- `pcap/pairing.go` (new) — the FIFO queue + `POSTMAN_INSIGHTS_AGENT_SYNTHETIC_TCP_PAIRING` flag (default off)
- `pcap/stream.go` — uses the FIFO ordinal instead of `ctx.seq`/`ctx.ack` when the flag is on; unchanged path when off
- `pcap/net_parse.go`, `pcap/run.go` — thread the flag down
- `pcap/pairing_test.go` (new) — reproduces the bug with real packets and asserts old-path mismatch / new-path match

### Test plan

- `go build`, `go vet`, `gofmt`, full pcap suite + `-race` — all clean
- New tests confirm the fix
- Next: deploy with the flag on to one pod, compare against the diagnostics counters we've been using