### PR TITLE
[INS-155] Fix pcap pairing via Accept-time FIFO, auto inbound-only capture, and outbound drop

### DIFF
--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -2,6 +2,7 @@ package apidump
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -947,6 +948,33 @@ func (a *apidump) Run() error {
 		a.SendErrorTelemetry(api_schema.ApidumpError_InvalidFilters, err)
 		return err
 	}
+
+	// When the user did not set --bpf-filter, auto-restrict to discovered
+	// application listen ports in the capture netns (inbound-only). This drops
+	// mesh outbound / Istio REDIRECT split halves without requiring --port.
+	var inboundEndpoints *InboundEndpoints
+	userFilters, inboundEndpoints = applyAutoInboundFilters(interfaces, userFilters, targetNetworkNamespace, args.Filter)
+	var directionHint *pcap.DirectionHint
+	if inboundEndpoints != nil {
+		directionHint = pcap.NewDirectionHint(inboundEndpoints.LocalIPs, inboundEndpoints.ListenPorts)
+	}
+	// If auto filter did not apply (user BPF or empty listen set), still try to
+	// discover endpoints for Direction tagging / outbound drop.
+	if directionHint == nil && args.Filter == "" {
+		if eps, err := DiscoverInboundEndpoints(targetNetworkNamespace); err == nil {
+			directionHint = pcap.NewDirectionHint(eps.LocalIPs, eps.ListenPorts)
+			inboundEndpoints = &eps
+		}
+	}
+	if capturingNegation {
+		// Rebuild negation from the (possibly auto) inbound filters.
+		negationFilters = make(map[string]string, len(userFilters))
+		for n, f := range userFilters {
+			if f != "" {
+				negationFilters[n] = fmt.Sprintf("not (%s)", f)
+			}
+		}
+	}
 	lastCheckpoint = "filter_setup"
 
 	// When HTTPS-via-eBPF capture is active, drop the TLS port from the cBPF
@@ -1266,6 +1294,8 @@ func (a *apidump) Run() error {
 			// collector chain (filters, rate limiting) rather than to parsing.
 			// Without both, the two are indistinguishable. See LogCaptureDiagnostics.
 			if filterState == matchedFilter {
+				// Drop outbound before rate-limit / pair cache (Direction from pcap).
+				collector = trace.NewDropOutboundCollector(collector, reportTelemetryEvent)
 				collector = &trace.PacketCountCollector{
 					PacketCounts: prefilterSummary,
 					Collector:    collector,
@@ -1305,6 +1335,7 @@ func (a *apidump) Run() error {
 					apidumpTelemetry,
 					a.captureStats,
 					reportTelemetryEvent,
+					directionHint,
 				); err != nil {
 					errChan <- interfaceError{
 						interfaceName: interfaceName,

--- a/apidump/inbound_endpoints.go
+++ b/apidump/inbound_endpoints.go
@@ -1,0 +1,233 @@
+package apidump
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/akitasoftware/go-utils/optionals"
+	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/printer"
+)
+
+// TCP state LISTEN in /proc/net/tcp{,6}.
+const tcpListenState = "0A"
+
+// Default ports excluded from auto inbound capture (mesh sidecars, admin).
+// Apps that listen only on these ports will not get an auto filter applied
+// for those ports; other listen ports in the same netns still apply.
+var defaultExcludedListenPorts = map[uint16]struct{}{
+	22: {}, // ssh
+}
+
+// InboundEndpoints are local addresses and listen ports discovered in a
+// capture network namespace for building an inbound-only BPF filter.
+type InboundEndpoints struct {
+	LocalIPs    []net.IP
+	ListenPorts []uint16
+}
+
+func discoverInboundEndpointsInCurrentNS() (InboundEndpoints, error) {
+	ips, err := listLocalIPs()
+	if err != nil {
+		return InboundEndpoints{}, err
+	}
+	ports, err := listListenPorts(defaultExcludedListenPorts)
+	if err != nil {
+		return InboundEndpoints{}, err
+	}
+	return InboundEndpoints{LocalIPs: ips, ListenPorts: ports}, nil
+}
+
+func listLocalIPs() ([]net.IP, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, errors.Wrap(err, "list interfaces")
+	}
+	seen := map[string]struct{}{}
+	var ips []net.IP
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			printer.Warningf("Skipping interface %s while discovering local IPs: %v\n", iface.Name, err)
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch a := addr.(type) {
+			case *net.IPNet:
+				ip = a.IP
+			case *net.IPAddr:
+				ip = a.IP
+			}
+			if ip == nil {
+				continue
+			}
+			if v4 := ip.To4(); v4 != nil {
+				ip = v4
+			}
+			key := ip.String()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			ips = append(ips, append(net.IP(nil), ip...))
+		}
+	}
+	return ips, nil
+}
+
+func listListenPorts(exclude map[uint16]struct{}) ([]uint16, error) {
+	seen := map[uint16]struct{}{}
+	var ports []uint16
+	for _, name := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		f, err := os.Open(name)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, errors.Wrapf(err, "open %s", name)
+		}
+		sc := bufio.NewScanner(f)
+		first := true
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if first {
+				first = false
+				continue // header
+			}
+			if line == "" {
+				continue
+			}
+			port, ok := parseListenPortFromProcNetTCPLine(line)
+			if !ok {
+				continue
+			}
+			if shouldExcludeListenPort(port, exclude) {
+				continue
+			}
+			if _, ok := seen[port]; ok {
+				continue
+			}
+			seen[port] = struct{}{}
+			ports = append(ports, port)
+		}
+		err = sc.Err()
+		_ = f.Close()
+		if err != nil {
+			return nil, errors.Wrapf(err, "scan %s", name)
+		}
+	}
+	return ports, nil
+}
+
+func shouldExcludeListenPort(port uint16, exclude map[uint16]struct{}) bool {
+	if _, ok := exclude[port]; ok {
+		return true
+	}
+	// Istio / Envoy sidecar control and data ports.
+	if port >= 15000 && port <= 15090 {
+		return true
+	}
+	return false
+}
+
+// parseListenPortFromProcNetTCPLine returns the local port when the row is in
+// LISTEN state. Format: sl local_address rem_address st ...
+func parseListenPortFromProcNetTCPLine(line string) (uint16, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 4 {
+		return 0, false
+	}
+	if fields[3] != tcpListenState {
+		return 0, false
+	}
+	local := fields[1]
+	colon := strings.LastIndexByte(local, ':')
+	if colon < 0 || colon+1 >= len(local) {
+		return 0, false
+	}
+	port64, err := strconv.ParseUint(local[colon+1:], 16, 16)
+	if err != nil || port64 == 0 {
+		return 0, false
+	}
+	return uint16(port64), true
+}
+
+// buildInboundBPFFilterForEndpoints builds a cBPF expression that keeps only
+// traffic to/from the given local IPs on the given listen ports (same shape as
+// getInboundBPFFilter's --port mode, but multi-port).
+func buildInboundBPFFilterForEndpoints(ips []net.IP, ports []uint16) string {
+	if len(ips) == 0 || len(ports) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, ip := range ips {
+		ipStr := ip.String()
+		for _, port := range ports {
+			p := strconv.FormatUint(uint64(port), 10)
+			parts = append(parts,
+				fmt.Sprintf("(src host %s and src port %s)", ipStr, p),
+				fmt.Sprintf("(dst host %s and dst port %s)", ipStr, p),
+			)
+		}
+	}
+	return strings.Join(parts, " or ")
+}
+
+// applyAutoInboundFilters fills empty per-interface filters with an inbound-only
+// expression derived from DiscoverInboundEndpoints. No-op when the user already
+// set a BPF filter, or when discovery finds no usable listen ports.
+func applyAutoInboundFilters(
+	interfaces map[string]interfaceInfo,
+	userFilters map[string]string,
+	targetNetworkNamespaceOpt optionals.Optional[string],
+	userBPFFilter string,
+) (map[string]string, *InboundEndpoints) {
+	if userBPFFilter != "" {
+		return userFilters, nil
+	}
+	// Only auto-apply when every interface currently has an empty filter.
+	for _, f := range userFilters {
+		if f != "" {
+			return userFilters, nil
+		}
+	}
+
+	eps, err := DiscoverInboundEndpoints(targetNetworkNamespaceOpt)
+	if err != nil {
+		printer.Warningf("Auto inbound filter: endpoint discovery failed, capturing all traffic: %v\n", err)
+		return userFilters, nil
+	}
+	if len(eps.ListenPorts) == 0 {
+		printer.Infof("Auto inbound filter: no application listen ports found yet; capturing all traffic\n")
+		return userFilters, &eps
+	}
+
+	expr := buildInboundBPFFilterForEndpoints(eps.LocalIPs, eps.ListenPorts)
+	if expr == "" {
+		printer.Warningf("Auto inbound filter: discovered ports %v but no local IPs; capturing all traffic\n", eps.ListenPorts)
+		return userFilters, &eps
+	}
+
+	out := make(map[string]string, len(userFilters))
+	for name := range interfaces {
+		out[name] = expr
+	}
+	printer.Infof("Auto inbound-only capture enabled: ports=%v ips=%v\n", eps.ListenPorts, formatIPs(eps.LocalIPs))
+	return out, &eps
+}
+
+func formatIPs(ips []net.IP) []string {
+	s := make([]string, len(ips))
+	for i, ip := range ips {
+		s[i] = ip.String()
+	}
+	return s
+}

--- a/apidump/inbound_endpoints.go
+++ b/apidump/inbound_endpoints.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/pkg/errors"
@@ -16,12 +19,23 @@ import (
 // TCP state LISTEN in /proc/net/tcp{,6}.
 const tcpListenState = "0A"
 
+// How long / how often to wait for application listen ports when discovery
+// initially finds none (app may bind after the container is Running).
+// Overridable in tests.
+var (
+	inboundDiscoveryRetryTotal    = 15 * time.Second
+	inboundDiscoveryRetryInterval = 500 * time.Millisecond
+)
+
 // Default ports excluded from auto inbound capture (mesh sidecars, admin).
 // Apps that listen only on these ports will not get an auto filter applied
 // for those ports; other listen ports in the same netns still apply.
 var defaultExcludedListenPorts = map[uint16]struct{}{
 	22: {}, // ssh
 }
+
+// Matches .../proc/<pid>/ns/net (DaemonSet uses /host/proc/<pid>/ns/net).
+var procNSPathRE = regexp.MustCompile(`^(.*)/proc/(\d+)/ns/net$`)
 
 // InboundEndpoints are local addresses and listen ports discovered in a
 // capture network namespace for building an inbound-only BPF filter.
@@ -30,16 +44,37 @@ type InboundEndpoints struct {
 	ListenPorts []uint16
 }
 
-func discoverInboundEndpointsInCurrentNS() (InboundEndpoints, error) {
-	ips, err := listLocalIPs()
-	if err != nil {
-		return InboundEndpoints{}, err
+// discoverListenPortsForNetNS lists LISTEN ports for the capture netns.
+// Prefer /proc/<pid>/net/tcp{,6} derived from a DaemonSet ns path so we do not
+// depend on /proc/net after setns (kernels have had stale /proc/net dcache
+// bugs after CLONE_NEWNET). When the ns path is not pid-scoped, the caller
+// must already be in the target netns and should pass nsPath="" to read
+// /proc/net/tcp{,6}.
+func discoverListenPortsForNetNS(nsPath string) (appPorts, rawPorts []uint16, err error) {
+	if procRoot, pid, ok := procRootAndPIDFromNSPath(nsPath); ok {
+		paths := []string{
+			filepath.Join(procRoot, strconv.Itoa(pid), "net", "tcp"),
+			filepath.Join(procRoot, strconv.Itoa(pid), "net", "tcp6"),
+		}
+		return listListenPortsFromProcFiles(paths, defaultExcludedListenPorts)
 	}
-	ports, err := listListenPorts(defaultExcludedListenPorts)
-	if err != nil {
-		return InboundEndpoints{}, err
+	return listListenPortsFromProcFiles(
+		[]string{"/proc/net/tcp", "/proc/net/tcp6"},
+		defaultExcludedListenPorts,
+	)
+}
+
+func procRootAndPIDFromNSPath(nsPath string) (procRoot string, pid int, ok bool) {
+	m := procNSPathRE.FindStringSubmatch(nsPath)
+	if m == nil {
+		return "", 0, false
 	}
-	return InboundEndpoints{LocalIPs: ips, ListenPorts: ports}, nil
+	pid64, err := strconv.ParseInt(m[2], 10, 32)
+	if err != nil || pid64 <= 0 {
+		return "", 0, false
+	}
+	procRoot = m[1] + "/proc"
+	return procRoot, int(pid64), true
 }
 
 func listLocalIPs() ([]net.IP, error) {
@@ -83,16 +118,16 @@ func listLocalIPs() ([]net.IP, error) {
 	return ips, nil
 }
 
-func listListenPorts(exclude map[uint16]struct{}) ([]uint16, error) {
-	seen := map[uint16]struct{}{}
-	var ports []uint16
-	for _, name := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
-		f, err := os.Open(name)
-		if err != nil {
-			if os.IsNotExist(err) {
+func listListenPortsFromProcFiles(paths []string, exclude map[uint16]struct{}) (appPorts, rawPorts []uint16, err error) {
+	seenRaw := map[uint16]struct{}{}
+	seenApp := map[uint16]struct{}{}
+	for _, name := range paths {
+		f, openErr := os.Open(name)
+		if openErr != nil {
+			if os.IsNotExist(openErr) {
 				continue
 			}
-			return nil, errors.Wrapf(err, "open %s", name)
+			return nil, nil, errors.Wrapf(openErr, "open %s", name)
 		}
 		sc := bufio.NewScanner(f)
 		first := true
@@ -109,22 +144,26 @@ func listListenPorts(exclude map[uint16]struct{}) ([]uint16, error) {
 			if !ok {
 				continue
 			}
+			if _, ok := seenRaw[port]; !ok {
+				seenRaw[port] = struct{}{}
+				rawPorts = append(rawPorts, port)
+			}
 			if shouldExcludeListenPort(port, exclude) {
 				continue
 			}
-			if _, ok := seen[port]; ok {
+			if _, ok := seenApp[port]; ok {
 				continue
 			}
-			seen[port] = struct{}{}
-			ports = append(ports, port)
+			seenApp[port] = struct{}{}
+			appPorts = append(appPorts, port)
 		}
-		err = sc.Err()
+		scanErr := sc.Err()
 		_ = f.Close()
-		if err != nil {
-			return nil, errors.Wrapf(err, "scan %s", name)
+		if scanErr != nil {
+			return nil, nil, errors.Wrapf(scanErr, "scan %s", name)
 		}
 	}
-	return ports, nil
+	return appPorts, rawPorts, nil
 }
 
 func shouldExcludeListenPort(port uint16, exclude map[uint16]struct{}) bool {
@@ -200,13 +239,21 @@ func applyAutoInboundFilters(
 		}
 	}
 
-	eps, err := DiscoverInboundEndpoints(targetNetworkNamespaceOpt)
+	eps, rawPorts, err := discoverInboundEndpointsWithRetry(targetNetworkNamespaceOpt)
 	if err != nil {
 		printer.Warningf("Auto inbound filter: endpoint discovery failed, capturing all traffic: %v\n", err)
 		return userFilters, nil
 	}
 	if len(eps.ListenPorts) == 0 {
-		printer.Infof("Auto inbound filter: no application listen ports found yet; capturing all traffic\n")
+		nsDesc := "current"
+		if nsPath, ok := targetNetworkNamespaceOpt.Get(); ok && nsPath != "" {
+			nsDesc = nsPath
+		}
+		if len(rawPorts) == 0 {
+			printer.Infof("Auto inbound filter: no TCP LISTEN sockets in netns %s; capturing all traffic\n", nsDesc)
+		} else {
+			printer.Infof("Auto inbound filter: only mesh/admin listen ports %v in netns %s (no application ports); capturing all traffic\n", rawPorts, nsDesc)
+		}
 		return userFilters, &eps
 	}
 
@@ -222,6 +269,31 @@ func applyAutoInboundFilters(
 	}
 	printer.Infof("Auto inbound-only capture enabled: ports=%v ips=%v\n", eps.ListenPorts, formatIPs(eps.LocalIPs))
 	return out, &eps
+}
+
+func discoverInboundEndpointsWithRetry(
+	targetNetworkNamespaceOpt optionals.Optional[string],
+) (eps InboundEndpoints, rawPorts []uint16, err error) {
+	deadline := time.Now().Add(inboundDiscoveryRetryTotal)
+	attempt := 0
+	for {
+		attempt++
+		eps, rawPorts, err = discoverInboundEndpointsDetailed(targetNetworkNamespaceOpt)
+		if err != nil {
+			return InboundEndpoints{}, nil, err
+		}
+		if len(eps.ListenPorts) > 0 {
+			if attempt > 1 {
+				printer.Infof("Auto inbound filter: found application listen ports %v after %d attempt(s)\n", eps.ListenPorts, attempt)
+			}
+			return eps, rawPorts, nil
+		}
+		if time.Now().After(deadline) {
+			return eps, rawPorts, nil
+		}
+		printer.Debugf("Auto inbound filter: no application listen ports yet (raw=%v), retrying...\n", rawPorts)
+		time.Sleep(inboundDiscoveryRetryInterval)
+	}
 }
 
 func formatIPs(ips []net.IP) []string {

--- a/apidump/inbound_endpoints.go
+++ b/apidump/inbound_endpoints.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/pkg/errors"
+	"github.com/postmanlabs/postman-insights-agent/pcap"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 )
 
@@ -27,8 +28,9 @@ var (
 	inboundDiscoveryRetryInterval = 500 * time.Millisecond
 )
 
-// Default ports excluded from auto inbound capture (mesh sidecars, admin).
-// Apps that listen only on these ports will not get an auto filter applied
+// Default ports excluded from auto inbound capture (admin / non-app).
+// Mesh proxy ports are excluded via pcap.IsMeshProxyPort (shared with Direction).
+// Apps that listen only on excluded ports will not get an auto filter applied
 // for those ports; other listen ports in the same netns still apply.
 var defaultExcludedListenPorts = map[uint16]struct{}{
 	22: {}, // ssh
@@ -170,11 +172,8 @@ func shouldExcludeListenPort(port uint16, exclude map[uint16]struct{}) bool {
 	if _, ok := exclude[port]; ok {
 		return true
 	}
-	// Istio / Envoy sidecar control and data ports.
-	if port >= 15000 && port <= 15090 {
-		return true
-	}
-	return false
+	// Shared with pcap Direction tie-break (see pcap.IsMeshProxyPort).
+	return pcap.IsMeshProxyPort(port)
 }
 
 // parseListenPortFromProcNetTCPLine returns the local port when the row is in

--- a/apidump/inbound_endpoints_linux.go
+++ b/apidump/inbound_endpoints_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package apidump
+
+import (
+	"github.com/akitasoftware/go-utils/optionals"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/pkg/errors"
+)
+
+// DiscoverInboundEndpoints finds UP interface IPs and TCP LISTEN ports in the
+// target network namespace (or the current process ns when none is set).
+// Mesh/admin listen ports (Istio 15000–15090, ssh) are omitted.
+func DiscoverInboundEndpoints(targetNetworkNamespaceOpt optionals.Optional[string]) (InboundEndpoints, error) {
+	if nsPath, ok := targetNetworkNamespaceOpt.Get(); ok && nsPath != "" {
+		targetNs, err := ns.GetNS(nsPath)
+		if err != nil {
+			return InboundEndpoints{}, errors.Wrapf(err, "can't get network namespace %s", nsPath)
+		}
+		defer targetNs.Close()
+		var out InboundEndpoints
+		if err := targetNs.Do(func(_ ns.NetNS) error {
+			var e error
+			out, e = discoverInboundEndpointsInCurrentNS()
+			return e
+		}); err != nil {
+			return InboundEndpoints{}, err
+		}
+		return out, nil
+	}
+	return discoverInboundEndpointsInCurrentNS()
+}

--- a/apidump/inbound_endpoints_linux.go
+++ b/apidump/inbound_endpoints_linux.go
@@ -3,6 +3,8 @@
 package apidump
 
 import (
+	"net"
+
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/pkg/errors"
@@ -12,21 +14,70 @@ import (
 // target network namespace (or the current process ns when none is set).
 // Mesh/admin listen ports (Istio 15000–15090, ssh) are omitted.
 func DiscoverInboundEndpoints(targetNetworkNamespaceOpt optionals.Optional[string]) (InboundEndpoints, error) {
-	if nsPath, ok := targetNetworkNamespaceOpt.Get(); ok && nsPath != "" {
-		targetNs, err := ns.GetNS(nsPath)
+	eps, _, err := discoverInboundEndpointsDetailed(targetNetworkNamespaceOpt)
+	return eps, err
+}
+
+func discoverInboundEndpointsDetailed(targetNetworkNamespaceOpt optionals.Optional[string]) (InboundEndpoints, []uint16, error) {
+	nsPath, hasNS := targetNetworkNamespaceOpt.Get()
+	if !hasNS || nsPath == "" {
+		return discoverInboundEndpointsDetailedCurrentNS()
+	}
+
+	targetNs, err := ns.GetNS(nsPath)
+	if err != nil {
+		return InboundEndpoints{}, nil, errors.Wrapf(err, "can't get network namespace %s", nsPath)
+	}
+	defer targetNs.Close()
+
+	var (
+		ips                []net.IP
+		appPorts, rawPorts []uint16
+	)
+
+	// Ports: prefer /proc/<pid>/net/tcp{,6} from the DaemonSet ns path (no
+	// setns). Fall back to /proc/net inside setns only when the path is not
+	// pid-scoped (e.g. a named netns file).
+	if _, _, ok := procRootAndPIDFromNSPath(nsPath); ok {
+		appPorts, rawPorts, err = discoverListenPortsForNetNS(nsPath)
 		if err != nil {
-			return InboundEndpoints{}, errors.Wrapf(err, "can't get network namespace %s", nsPath)
+			return InboundEndpoints{}, nil, err
 		}
-		defer targetNs.Close()
-		var out InboundEndpoints
 		if err := targetNs.Do(func(_ ns.NetNS) error {
 			var e error
-			out, e = discoverInboundEndpointsInCurrentNS()
+			ips, e = listLocalIPs()
 			return e
 		}); err != nil {
-			return InboundEndpoints{}, err
+			return InboundEndpoints{}, nil, err
 		}
-		return out, nil
+	} else {
+		if err := targetNs.Do(func(_ ns.NetNS) error {
+			var e error
+			ips, e = listLocalIPs()
+			if e != nil {
+				return e
+			}
+			appPorts, rawPorts, e = discoverListenPortsForNetNS("")
+			return e
+		}); err != nil {
+			return InboundEndpoints{}, nil, err
+		}
 	}
-	return discoverInboundEndpointsInCurrentNS()
+
+	return InboundEndpoints{LocalIPs: ips, ListenPorts: appPorts}, rawPorts, nil
+}
+
+func discoverInboundEndpointsDetailedCurrentNS() (InboundEndpoints, []uint16, error) {
+	ips, err := listLocalIPs()
+	if err != nil {
+		return InboundEndpoints{}, nil, err
+	}
+	appPorts, rawPorts, err := listListenPortsFromProcFiles(
+		[]string{"/proc/net/tcp", "/proc/net/tcp6"},
+		defaultExcludedListenPorts,
+	)
+	if err != nil {
+		return InboundEndpoints{}, nil, err
+	}
+	return InboundEndpoints{LocalIPs: ips, ListenPorts: appPorts}, rawPorts, nil
 }

--- a/apidump/inbound_endpoints_linux.go
+++ b/apidump/inbound_endpoints_linux.go
@@ -12,7 +12,7 @@ import (
 
 // DiscoverInboundEndpoints finds UP interface IPs and TCP LISTEN ports in the
 // target network namespace (or the current process ns when none is set).
-// Mesh/admin listen ports (Istio 15000–15090, ssh) are omitted.
+// Mesh/admin listen ports (pcap.IsMeshProxyPort, ssh) are omitted.
 func DiscoverInboundEndpoints(targetNetworkNamespaceOpt optionals.Optional[string]) (InboundEndpoints, error) {
 	eps, _, err := discoverInboundEndpointsDetailed(targetNetworkNamespaceOpt)
 	return eps, err

--- a/apidump/inbound_endpoints_other.go
+++ b/apidump/inbound_endpoints_other.go
@@ -9,7 +9,8 @@ import (
 
 // DiscoverInboundEndpoints finds UP interface IPs and TCP LISTEN ports in the
 // current process network namespace. On non-Linux platforms, targetNetworkNamespace
-// is ignored (setns is unavailable).
+// is ignored (setns is unavailable). Mesh/admin ports follow pcap.IsMeshProxyPort
+// and ssh exclusion in shared discovery helpers.
 func DiscoverInboundEndpoints(targetNetworkNamespaceOpt optionals.Optional[string]) (InboundEndpoints, error) {
 	eps, _, err := discoverInboundEndpointsDetailed(targetNetworkNamespaceOpt)
 	return eps, err

--- a/apidump/inbound_endpoints_other.go
+++ b/apidump/inbound_endpoints_other.go
@@ -11,8 +11,24 @@ import (
 // current process network namespace. On non-Linux platforms, targetNetworkNamespace
 // is ignored (setns is unavailable).
 func DiscoverInboundEndpoints(targetNetworkNamespaceOpt optionals.Optional[string]) (InboundEndpoints, error) {
+	eps, _, err := discoverInboundEndpointsDetailed(targetNetworkNamespaceOpt)
+	return eps, err
+}
+
+func discoverInboundEndpointsDetailed(targetNetworkNamespaceOpt optionals.Optional[string]) (InboundEndpoints, []uint16, error) {
 	if nsPath, ok := targetNetworkNamespaceOpt.Get(); ok && nsPath != "" {
 		printer.Warningf("Auto inbound filter: network namespace switching is unsupported on this OS; discovering endpoints in the agent namespace (requested %s)\n", nsPath)
 	}
-	return discoverInboundEndpointsInCurrentNS()
+	ips, err := listLocalIPs()
+	if err != nil {
+		return InboundEndpoints{}, nil, err
+	}
+	appPorts, rawPorts, err := listListenPortsFromProcFiles(
+		[]string{"/proc/net/tcp", "/proc/net/tcp6"},
+		defaultExcludedListenPorts,
+	)
+	if err != nil {
+		return InboundEndpoints{}, nil, err
+	}
+	return InboundEndpoints{LocalIPs: ips, ListenPorts: appPorts}, rawPorts, nil
 }

--- a/apidump/inbound_endpoints_other.go
+++ b/apidump/inbound_endpoints_other.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package apidump
+
+import (
+	"github.com/akitasoftware/go-utils/optionals"
+	"github.com/postmanlabs/postman-insights-agent/printer"
+)
+
+// DiscoverInboundEndpoints finds UP interface IPs and TCP LISTEN ports in the
+// current process network namespace. On non-Linux platforms, targetNetworkNamespace
+// is ignored (setns is unavailable).
+func DiscoverInboundEndpoints(targetNetworkNamespaceOpt optionals.Optional[string]) (InboundEndpoints, error) {
+	if nsPath, ok := targetNetworkNamespaceOpt.Get(); ok && nsPath != "" {
+		printer.Warningf("Auto inbound filter: network namespace switching is unsupported on this OS; discovering endpoints in the agent namespace (requested %s)\n", nsPath)
+	}
+	return discoverInboundEndpointsInCurrentNS()
+}

--- a/apidump/inbound_endpoints_test.go
+++ b/apidump/inbound_endpoints_test.go
@@ -1,0 +1,59 @@
+package apidump
+
+import (
+	"net"
+	"testing"
+)
+
+func TestParseListenPortFromProcNetTCPLine(t *testing.T) {
+	// Port 1337 = 0x539
+	line := "0: 00000000:0539 00000000:0000 0A 00000000:00000000 00:00000000 00000000 0 0 1 1"
+	port, ok := parseListenPortFromProcNetTCPLine(line)
+	if !ok || port != 1337 {
+		t.Fatalf("got port=%d ok=%v, want 1337 true", port, ok)
+	}
+
+	estab := "0: 0100007F:0539 0100007F:1F90 01 00000000:00000000 00:00000000 00000000 0 0 1 1"
+	if _, ok := parseListenPortFromProcNetTCPLine(estab); ok {
+		t.Fatal("established row should not parse as listen")
+	}
+}
+
+func TestBuildInboundBPFFilterForEndpoints(t *testing.T) {
+	ips := []net.IP{net.ParseIP("10.0.0.5").To4(), net.ParseIP("127.0.0.1").To4()}
+	ports := []uint16{1337, 8080}
+	expr := buildInboundBPFFilterForEndpoints(ips, ports)
+	for _, want := range []string{
+		"src host 10.0.0.5 and src port 1337",
+		"dst host 10.0.0.5 and dst port 1337",
+		"src host 127.0.0.1 and src port 8080",
+		"dst host 127.0.0.1 and dst port 8080",
+	} {
+		if !containsSubstring(expr, want) {
+			t.Fatalf("filter missing %q; got %q", want, expr)
+		}
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		(func() bool {
+			for i := 0; i+len(sub) <= len(s); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		})())
+}
+
+func TestDefaultExcludedListenPortsIncludeEnvoy(t *testing.T) {
+	for _, p := range []uint16{15001, 15006, 15021, 22} {
+		if !shouldExcludeListenPort(p, defaultExcludedListenPorts) {
+			t.Fatalf("expected port %d to be excluded", p)
+		}
+	}
+	if shouldExcludeListenPort(1337, defaultExcludedListenPorts) {
+		t.Fatal("app port 1337 must not be excluded")
+	}
+}

--- a/apidump/inbound_endpoints_test.go
+++ b/apidump/inbound_endpoints_test.go
@@ -3,6 +3,9 @@ package apidump
 import (
 	"net"
 	"testing"
+	"time"
+
+	"github.com/akitasoftware/go-utils/optionals"
 )
 
 func TestParseListenPortFromProcNetTCPLine(t *testing.T) {
@@ -55,5 +58,36 @@ func TestDefaultExcludedListenPortsIncludeEnvoy(t *testing.T) {
 	}
 	if shouldExcludeListenPort(1337, defaultExcludedListenPorts) {
 		t.Fatal("app port 1337 must not be excluded")
+	}
+}
+
+func TestProcRootAndPIDFromNSPath(t *testing.T) {
+	root, pid, ok := procRootAndPIDFromNSPath("/host/proc/12345/ns/net")
+	if !ok || root != "/host/proc" || pid != 12345 {
+		t.Fatalf("got root=%q pid=%d ok=%v", root, pid, ok)
+	}
+	root, pid, ok = procRootAndPIDFromNSPath("/proc/9/ns/net")
+	if !ok || root != "/proc" || pid != 9 {
+		t.Fatalf("got root=%q pid=%d ok=%v", root, pid, ok)
+	}
+	if _, _, ok := procRootAndPIDFromNSPath("/var/run/netns/foo"); ok {
+		t.Fatal("expected non-proc ns path to be rejected")
+	}
+}
+
+func TestApplyAutoInboundFiltersNoPortsDoesNotHang(t *testing.T) {
+	prevTotal, prevInterval := inboundDiscoveryRetryTotal, inboundDiscoveryRetryInterval
+	inboundDiscoveryRetryTotal = 0
+	inboundDiscoveryRetryInterval = time.Millisecond
+	defer func() {
+		inboundDiscoveryRetryTotal = prevTotal
+		inboundDiscoveryRetryInterval = prevInterval
+	}()
+
+	ifaces := map[string]interfaceInfo{"eth0": interfaceWrapper{}}
+	filters := map[string]string{"eth0": ""}
+	out, _ := applyAutoInboundFilters(ifaces, filters, optionals.None[string](), "")
+	if out["eth0"] != "" {
+		t.Fatalf("expected empty filter when no listen ports, got %q", out["eth0"])
 	}
 }

--- a/pcap/direction.go
+++ b/pcap/direction.go
@@ -55,12 +55,8 @@ func (h *DirectionHint) isListenPort(port int) bool {
 	return ok
 }
 
-func (h *DirectionHint) isEnvoyPort(port int) bool {
-	return port >= 15000 && port <= 15090
-}
-
 // classifyHTTPDirection mirrors eBPF directionForPair using packet IPs/ports.
-// Both-local (Istio REDIRECT on lo) uses listen/Envoy port tie-break.
+// Both-local (Istio REDIRECT on lo) uses listen/mesh-proxy port tie-break.
 func classifyHTTPDirection(content akinet.ParsedNetworkContent, srcIP, dstIP net.IP, srcPort, dstPort int, hint *DirectionHint) akinet.NetTrafficDirection {
 	if hint == nil {
 		return akinet.DirectionUnknown
@@ -86,11 +82,11 @@ func classifyRequestDirection(srcLocal, dstLocal bool, dstPort int, hint *Direct
 	case srcLocal && !dstLocal:
 		return akinet.DirectionOutbound
 	case srcLocal && dstLocal:
-		// Mesh / loopback: prefer listen-port as inbound server, Envoy as outbound.
+		// Mesh / loopback: prefer listen-port as inbound server, mesh proxy as outbound.
 		if hint.isListenPort(dstPort) {
 			return akinet.DirectionInbound
 		}
-		if hint.isEnvoyPort(dstPort) {
+		if IsMeshProxyPort(uint16(dstPort)) {
 			return akinet.DirectionOutbound
 		}
 		// Ephemeral client → local peer without known listen port: outbound.

--- a/pcap/direction.go
+++ b/pcap/direction.go
@@ -1,0 +1,101 @@
+package pcap
+
+import (
+	"net"
+
+	"github.com/akitasoftware/akita-libs/akinet"
+)
+
+// DirectionHint holds netns-wide locals used to classify pcap HTTP as inbound
+// or outbound. ListenPorts are application listen ports (mesh ports excluded).
+type DirectionHint struct {
+	LocalIPs    map[string]struct{} // IP.String() keys
+	ListenPorts map[uint16]struct{}
+}
+
+func NewDirectionHint(ips []net.IP, ports []uint16) *DirectionHint {
+	if len(ips) == 0 && len(ports) == 0 {
+		return nil
+	}
+	h := &DirectionHint{
+		LocalIPs:    make(map[string]struct{}, len(ips)),
+		ListenPorts: make(map[uint16]struct{}, len(ports)),
+	}
+	for _, ip := range ips {
+		if ip == nil {
+			continue
+		}
+		if v4 := ip.To4(); v4 != nil {
+			ip = v4
+		}
+		h.LocalIPs[ip.String()] = struct{}{}
+	}
+	for _, p := range ports {
+		h.ListenPorts[p] = struct{}{}
+	}
+	return h
+}
+
+func (h *DirectionHint) isLocal(ip net.IP) bool {
+	if h == nil || ip == nil {
+		return false
+	}
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	_, ok := h.LocalIPs[ip.String()]
+	return ok
+}
+
+func (h *DirectionHint) isListenPort(port int) bool {
+	if h == nil {
+		return false
+	}
+	_, ok := h.ListenPorts[uint16(port)]
+	return ok
+}
+
+func (h *DirectionHint) isEnvoyPort(port int) bool {
+	return port >= 15000 && port <= 15090
+}
+
+// classifyHTTPDirection mirrors eBPF directionForPair using packet IPs/ports.
+// Both-local (Istio REDIRECT on lo) uses listen/Envoy port tie-break.
+func classifyHTTPDirection(content akinet.ParsedNetworkContent, srcIP, dstIP net.IP, srcPort, dstPort int, hint *DirectionHint) akinet.NetTrafficDirection {
+	if hint == nil {
+		return akinet.DirectionUnknown
+	}
+	srcLocal := hint.isLocal(srcIP)
+	dstLocal := hint.isLocal(dstIP)
+
+	switch content.(type) {
+	case akinet.HTTPRequest:
+		return classifyRequestDirection(srcLocal, dstLocal, dstPort, hint)
+	case akinet.HTTPResponse:
+		// Invert request rule using the response's src as the "server" side.
+		return classifyRequestDirection(dstLocal, srcLocal, srcPort, hint)
+	default:
+		return akinet.DirectionUnknown
+	}
+}
+
+func classifyRequestDirection(srcLocal, dstLocal bool, dstPort int, hint *DirectionHint) akinet.NetTrafficDirection {
+	switch {
+	case dstLocal && !srcLocal:
+		return akinet.DirectionInbound
+	case srcLocal && !dstLocal:
+		return akinet.DirectionOutbound
+	case srcLocal && dstLocal:
+		// Mesh / loopback: prefer listen-port as inbound server, Envoy as outbound.
+		if hint.isListenPort(dstPort) {
+			return akinet.DirectionInbound
+		}
+		if hint.isEnvoyPort(dstPort) {
+			return akinet.DirectionOutbound
+		}
+		// Ephemeral client → local peer without known listen port: outbound.
+		return akinet.DirectionOutbound
+	default:
+		return akinet.DirectionUnknown
+	}
+}

--- a/pcap/direction_test.go
+++ b/pcap/direction_test.go
@@ -1,0 +1,63 @@
+package pcap
+
+import (
+	"net"
+	"testing"
+
+	"github.com/akitasoftware/akita-libs/akinet"
+)
+
+func TestClassifyHTTPDirection(t *testing.T) {
+	hint := NewDirectionHint(
+		[]net.IP{net.ParseIP("10.0.0.5").To4(), net.ParseIP("127.0.0.1").To4()},
+		[]uint16{1337},
+	)
+
+	cases := []struct {
+		name     string
+		content  akinet.ParsedNetworkContent
+		src, dst string
+		sp, dp   int
+		want     akinet.NetTrafficDirection
+	}{
+		{
+			name:    "inbound request to app port",
+			content: akinet.HTTPRequest{},
+			src:     "10.0.0.9", dst: "10.0.0.5", sp: 40000, dp: 1337,
+			want: akinet.DirectionInbound,
+		},
+		{
+			name:    "inbound response from app port",
+			content: akinet.HTTPResponse{},
+			src:     "10.0.0.5", dst: "10.0.0.9", sp: 1337, dp: 40000,
+			want: akinet.DirectionInbound,
+		},
+		{
+			name:    "outbound request to remote",
+			content: akinet.HTTPRequest{},
+			src:     "10.0.0.5", dst: "10.0.0.9", sp: 50400, dp: 1337,
+			want: akinet.DirectionOutbound,
+		},
+		{
+			name:    "mesh outbound to envoy on lo",
+			content: akinet.HTTPRequest{},
+			src:     "10.0.0.5", dst: "127.0.0.1", sp: 50400, dp: 15001,
+			want: akinet.DirectionOutbound,
+		},
+		{
+			name:    "mesh inbound hairpin to app listen",
+			content: akinet.HTTPRequest{},
+			src:     "127.0.0.6", dst: "10.0.0.5", sp: 12345, dp: 1337,
+			want: akinet.DirectionInbound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyHTTPDirection(tc.content, net.ParseIP(tc.src), net.ParseIP(tc.dst), tc.sp, tc.dp, hint)
+			if got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pcap/mesh_ports.go
+++ b/pcap/mesh_ports.go
@@ -1,0 +1,19 @@
+package pcap
+
+// Istio / Envoy sidecar listen and data-plane ports commonly used in-pod.
+// Kept as one shared definition for:
+//   - apidump listen-port discovery (exclude from auto inbound BPF)
+//   - pcap Direction tie-break (both-local → outbound when dest is mesh proxy)
+//
+// Extend carefully when adding other meshes (Linkerd, etc.); ranges are
+// best-effort and config-dependent.
+const (
+	istioEnvoyPortMin uint16 = 15000
+	istioEnvoyPortMax uint16 = 15090
+)
+
+// IsMeshProxyPort reports whether port is a known sidecar / mesh proxy port
+// that should not be treated as an application listen port.
+func IsMeshProxyPort(port uint16) bool {
+	return port >= istioEnvoyPortMin && port <= istioEnvoyPortMax
+}

--- a/pcap/mesh_ports_test.go
+++ b/pcap/mesh_ports_test.go
@@ -1,0 +1,16 @@
+package pcap
+
+import "testing"
+
+func TestIsMeshProxyPort(t *testing.T) {
+	for _, p := range []uint16{15000, 15001, 15006, 15090} {
+		if !IsMeshProxyPort(p) {
+			t.Fatalf("expected port %d to be a mesh proxy port", p)
+		}
+	}
+	for _, p := range []uint16{22, 80, 443, 1337, 14999, 15091} {
+		if IsMeshProxyPort(p) {
+			t.Fatalf("port %d must not be treated as a mesh proxy port", p)
+		}
+	}
+}

--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -65,20 +65,22 @@ type tcpStreamFactory struct {
 	outChan             chan<- akinet.ParsedNetworkTraffic
 	stats               *capturestats.Stats
 	useSyntheticPairing bool
+	directionHint       *DirectionHint
 }
 
-func newTCPStreamFactory(clock clockWrapper, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats, useSyntheticPairing bool) *tcpStreamFactory {
+func newTCPStreamFactory(clock clockWrapper, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats, useSyntheticPairing bool, directionHint *DirectionHint) *tcpStreamFactory {
 	return &tcpStreamFactory{
 		clock:               clock,
 		fs:                  fs,
 		outChan:             outChan,
 		stats:               stats,
 		useSyntheticPairing: useSyntheticPairing,
+		directionHint:       directionHint,
 	}
 }
 
 func (fact *tcpStreamFactory) New(netFlow, tcpFlow gopacket.Flow, _ *layers.TCP, _ reassembly.AssemblerContext) reassembly.Stream {
-	return newTCPStream(fact.clock, netFlow, fact.outChan, fact.fs, fact.stats, fact.useSyntheticPairing)
+	return newTCPStream(fact.clock, netFlow, fact.outChan, fact.fs, fact.stats, fact.useSyntheticPairing, fact.directionHint)
 }
 
 // NetworkTrafficObserver is the callback function type for observing
@@ -106,6 +108,9 @@ type NetworkTrafficParser struct {
 	// existing seq/ack pairing); Collect sets this from the env var, tests may
 	// set it directly.
 	useSyntheticPairing bool
+
+	// Optional netns-wide locals for Direction tagging. Nil leaves DirectionUnknown.
+	directionHint *DirectionHint
 }
 
 func NewNetworkTrafficParser(serviceID akid.ServiceID, traceTags map[tags.Key]string, bufferShare float32, telemetry telemetry.Tracker, stats *capturestats.Stats) *NetworkTrafficParser {
@@ -152,7 +157,7 @@ func (p *NetworkTrafficParser) ParseFromInterface(
 
 	// Set up assembly
 	out := make(chan akinet.ParsedNetworkTraffic, 100)
-	streamFactory := newTCPStreamFactory(p.clock, out, akinet.TCPParserFactorySelector(fs), p.stats, p.useSyntheticPairing)
+	streamFactory := newTCPStreamFactory(p.clock, out, akinet.TCPParserFactorySelector(fs), p.stats, p.useSyntheticPairing, p.directionHint)
 	streamPool := reassembly.NewStreamPool(streamFactory)
 	assembler := reassembly.NewAssembler(streamPool)
 

--- a/pcap/pairing.go
+++ b/pcap/pairing.go
@@ -23,12 +23,15 @@ import (
 // (responses dropped as ResponsesDroppedNoMatchingRequest, which surfaces at
 // the back end as a missing_status_code witness).
 //
-// This flag switches to the fix already proven on the eBPF capture path
-// (ebpf/events/adapter.go's tlsConnState.pairSeqForFactory): track message
-// arrival order per connection instead of TCP byte offsets. It is a flag
-// rather than the default so it can be validated against real traffic
+// This flag switches to tracking message emission order per connection
+// instead of TCP byte offsets (the eBPF path uses the same FIFO idea). It is
+// a flag rather than the default so it can be validated against real traffic
 // first; once confirmed, remove the flag and the old seq/ack path rather
 // than keeping both as permanent configuration.
+//
+// FIFO ordinals are stamped when a message is successfully emitted, not when
+// a parser Accepts the first bytes. Accept-time allocation used to leave the
+// queue permanently skewed after a failed/abandoned parse.
 const syntheticTCPPairingEnvVar = "POSTMAN_INSIGHTS_AGENT_SYNTHETIC_TCP_PAIRING"
 
 func syntheticTCPPairingEnabled() bool {
@@ -54,16 +57,18 @@ func syntheticTCPPairingEnabled() bool {
 // unmatched index, so pipelined or overlapping HTTP/1.1 exchanges on the
 // same connection still pair correctly regardless of what TCP acked when.
 //
+// Ordinals must be allocated only when a message is successfully emitted
+// (stampSyntheticPairSeq), not when a parser factory Accepts the first
+// bytes. Accept-time allocation permanently skews the FIFO if that parse
+// later fails or the message is discarded -- every subsequent exchange on
+// the keep-alive connection then mismatches at rate-limit / pairCache.
+//
 // Not synchronized: like the rest of tcpFlow/tcpStream, a pairSequencer is
 // only ever touched by the single goroutine that drives TCP reassembly for
 // the interface owning this connection (see NetworkTrafficParser.ParseFromInterface).
 //
-// Only reached for HTTP/1.x request/response factories -- see
-// isHTTPParserFactory and its call site in tcpFlow.reassembled. TLS,
-// HTTP/2-preface, and any other factory keep the real ctx.seq/ctx.ack
-// unconditionally, even when synthetic pairing is enabled, since this fix
-// only concerns HTTP/1.x pairing and those factories' CreateParser
-// implementations don't use their seq/ack params at all today.
+// Only reached for HTTP/1.x request/response messages. TLS, HTTP/2-preface,
+// and any other factory keep the real ctx.seq/ctx.ack unconditionally.
 type pairSequencer struct {
 	nextPairIdx       int
 	unmatchedRequests []int
@@ -73,14 +78,14 @@ func newPairSequencer() *pairSequencer {
 	return &pairSequencer{}
 }
 
-func (p *pairSequencer) pairSeqForFactory(factory akinet.TCPParserFactory) reassembly.Sequence {
-	if isHTTPRequestParserFactory(factory) {
-		idx := p.nextPairIdx
-		p.nextPairIdx++
-		p.unmatchedRequests = append(p.unmatchedRequests, idx)
-		return reassembly.Sequence(idx)
-	}
+func (p *pairSequencer) pairSeqForRequest() reassembly.Sequence {
+	idx := p.nextPairIdx
+	p.nextPairIdx++
+	p.unmatchedRequests = append(p.unmatchedRequests, idx)
+	return reassembly.Sequence(idx)
+}
 
+func (p *pairSequencer) pairSeqForResponse() reassembly.Sequence {
 	idx := p.nextPairIdx
 	if len(p.unmatchedRequests) > 0 {
 		idx = p.unmatchedRequests[0]
@@ -91,16 +96,20 @@ func (p *pairSequencer) pairSeqForFactory(factory akinet.TCPParserFactory) reass
 	return reassembly.Sequence(idx)
 }
 
-func isHTTPRequestParserFactory(factory akinet.TCPParserFactory) bool {
-	return factory.Name() == httpRequestParserFactoryName
-}
-
-// isHTTPParserFactory reports whether factory is the HTTP/1.x request or
-// response parser factory -- the only two whose pairing key
-// (akinet/http/parser.go's newHTTPParser) is derived from seq/ack. This
-// gates which factories get the synthetic ordinal substituted in for
-// ctx.seq/ctx.ack at pairSequencer's call site in tcpFlow.reassembled.
-func isHTTPParserFactory(factory akinet.TCPParserFactory) bool {
-	name := factory.Name()
-	return name == httpRequestParserFactoryName || name == httpResponseParserFactoryName
+// stampSyntheticPairSeq overwrites HTTP request/response Seq with a FIFO
+// ordinal at emit time. Non-HTTP content is returned unchanged.
+func (p *pairSequencer) stampSyntheticPairSeq(pnc akinet.ParsedNetworkContent) akinet.ParsedNetworkContent {
+	if p == nil {
+		return pnc
+	}
+	switch c := pnc.(type) {
+	case akinet.HTTPRequest:
+		c.Seq = int(p.pairSeqForRequest())
+		return c
+	case akinet.HTTPResponse:
+		c.Seq = int(p.pairSeqForResponse())
+		return c
+	default:
+		return pnc
+	}
 }

--- a/pcap/pairing.go
+++ b/pcap/pairing.go
@@ -23,15 +23,12 @@ import (
 // (responses dropped as ResponsesDroppedNoMatchingRequest, which surfaces at
 // the back end as a missing_status_code witness).
 //
-// This flag switches to tracking message emission order per connection
-// instead of TCP byte offsets (the eBPF path uses the same FIFO idea). It is
-// a flag rather than the default so it can be validated against real traffic
+// This flag switches to the fix already proven on the eBPF capture path
+// (ebpf/events/adapter.go's tlsConnState.pairSeqForFactory): track message
+// arrival order per connection instead of TCP byte offsets. It is a flag
+// rather than the default so it can be validated against real traffic
 // first; once confirmed, remove the flag and the old seq/ack path rather
 // than keeping both as permanent configuration.
-//
-// FIFO ordinals are stamped when a message is successfully emitted, not when
-// a parser Accepts the first bytes. Accept-time allocation used to leave the
-// queue permanently skewed after a failed/abandoned parse.
 const syntheticTCPPairingEnvVar = "POSTMAN_INSIGHTS_AGENT_SYNTHETIC_TCP_PAIRING"
 
 func syntheticTCPPairingEnabled() bool {
@@ -57,18 +54,20 @@ func syntheticTCPPairingEnabled() bool {
 // unmatched index, so pipelined or overlapping HTTP/1.1 exchanges on the
 // same connection still pair correctly regardless of what TCP acked when.
 //
-// Ordinals must be allocated only when a message is successfully emitted
-// (stampSyntheticPairSeq), not when a parser factory Accepts the first
-// bytes. Accept-time allocation permanently skews the FIFO if that parse
-// later fails or the message is discarded -- every subsequent exchange on
-// the keep-alive connection then mismatches at rate-limit / pairCache.
+// Ordinals are allocated when a parser factory Accepts the first bytes
+// (pairSeqForFactory). If that parse later fails or is abandoned, call
+// rollbackPairSeq so the FIFO does not stay permanently skewed.
 //
 // Not synchronized: like the rest of tcpFlow/tcpStream, a pairSequencer is
 // only ever touched by the single goroutine that drives TCP reassembly for
 // the interface owning this connection (see NetworkTrafficParser.ParseFromInterface).
 //
-// Only reached for HTTP/1.x request/response messages. TLS, HTTP/2-preface,
-// and any other factory keep the real ctx.seq/ctx.ack unconditionally.
+// Only reached for HTTP/1.x request/response factories -- see
+// isHTTPParserFactory and its call site in tcpFlow.reassembled. TLS,
+// HTTP/2-preface, and any other factory keep the real ctx.seq/ctx.ack
+// unconditionally, even when synthetic pairing is enabled, since this fix
+// only concerns HTTP/1.x pairing and those factories' CreateParser
+// implementations don't use their seq/ack params at all today.
 type pairSequencer struct {
 	nextPairIdx       int
 	unmatchedRequests []int
@@ -78,38 +77,79 @@ func newPairSequencer() *pairSequencer {
 	return &pairSequencer{}
 }
 
-func (p *pairSequencer) pairSeqForRequest() reassembly.Sequence {
+// pairAllocKind records how an Accept-time ordinal was taken from the FIFO so
+// rollbackPairSeq can undo it if the parse never emits.
+type pairAllocKind int
+
+const (
+	pairAllocNone pairAllocKind = iota
+	pairAllocRequestPush
+	pairAllocResponsePop
+	pairAllocResponseInvent
+)
+
+func (p *pairSequencer) pairSeqForFactory(factory akinet.TCPParserFactory) (reassembly.Sequence, pairAllocKind) {
+	if isHTTPRequestParserFactory(factory) {
+		idx := p.nextPairIdx
+		p.nextPairIdx++
+		p.unmatchedRequests = append(p.unmatchedRequests, idx)
+		return reassembly.Sequence(idx), pairAllocRequestPush
+	}
+
+	if len(p.unmatchedRequests) > 0 {
+		idx := p.unmatchedRequests[0]
+		p.unmatchedRequests = p.unmatchedRequests[1:]
+		return reassembly.Sequence(idx), pairAllocResponsePop
+	}
 	idx := p.nextPairIdx
 	p.nextPairIdx++
-	p.unmatchedRequests = append(p.unmatchedRequests, idx)
-	return reassembly.Sequence(idx)
+	return reassembly.Sequence(idx), pairAllocResponseInvent
 }
 
-func (p *pairSequencer) pairSeqForResponse() reassembly.Sequence {
-	idx := p.nextPairIdx
-	if len(p.unmatchedRequests) > 0 {
-		idx = p.unmatchedRequests[0]
-		p.unmatchedRequests = p.unmatchedRequests[1:]
-	} else {
-		p.nextPairIdx++
-	}
-	return reassembly.Sequence(idx)
-}
-
-// stampSyntheticPairSeq overwrites HTTP request/response Seq with a FIFO
-// ordinal at emit time. Non-HTTP content is returned unchanged.
-func (p *pairSequencer) stampSyntheticPairSeq(pnc akinet.ParsedNetworkContent) akinet.ParsedNetworkContent {
+// rollbackPairSeq undoes an Accept-time allocation when the parser fails or is
+// abandoned before a successful emit. Safe no-op for pairAllocNone.
+func (p *pairSequencer) rollbackPairSeq(seq reassembly.Sequence, kind pairAllocKind) {
 	if p == nil {
-		return pnc
+		return
 	}
-	switch c := pnc.(type) {
-	case akinet.HTTPRequest:
-		c.Seq = int(p.pairSeqForRequest())
-		return c
-	case akinet.HTTPResponse:
-		c.Seq = int(p.pairSeqForResponse())
-		return c
-	default:
-		return pnc
+	idx := int(seq)
+	switch kind {
+	case pairAllocRequestPush:
+		// Single-goroutine reassembly: the abandoned request is still the last
+		// unmatched entry if nothing else Accept'd on this connection since.
+		if n := len(p.unmatchedRequests); n > 0 && p.unmatchedRequests[n-1] == idx {
+			p.unmatchedRequests = p.unmatchedRequests[:n-1]
+		} else {
+			// Remove by value if ordering was disturbed (defensive).
+			for i, v := range p.unmatchedRequests {
+				if v == idx {
+					p.unmatchedRequests = append(p.unmatchedRequests[:i], p.unmatchedRequests[i+1:]...)
+					break
+				}
+			}
+		}
+		if p.nextPairIdx == idx+1 {
+			p.nextPairIdx = idx
+		}
+	case pairAllocResponsePop:
+		p.unmatchedRequests = append([]int{idx}, p.unmatchedRequests...)
+	case pairAllocResponseInvent:
+		if p.nextPairIdx == idx+1 {
+			p.nextPairIdx = idx
+		}
 	}
+}
+
+func isHTTPRequestParserFactory(factory akinet.TCPParserFactory) bool {
+	return factory.Name() == httpRequestParserFactoryName
+}
+
+// isHTTPParserFactory reports whether factory is the HTTP/1.x request or
+// response parser factory -- the only two whose pairing key
+// (akinet/http/parser.go's newHTTPParser) is derived from seq/ack. This
+// gates which factories get the synthetic ordinal substituted in for
+// ctx.seq/ctx.ack at pairSequencer's call site in tcpFlow.reassembled.
+func isHTTPParserFactory(factory akinet.TCPParserFactory) bool {
+	name := factory.Name()
+	return name == httpRequestParserFactoryName || name == httpResponseParserFactoryName
 }

--- a/pcap/pairing_test.go
+++ b/pcap/pairing_test.go
@@ -7,51 +7,32 @@ import (
 	"github.com/akitasoftware/akita-libs/akinet"
 	akihttp "github.com/akitasoftware/akita-libs/akinet/http"
 	"github.com/akitasoftware/akita-libs/buffer_pool"
-	"github.com/akitasoftware/akita-libs/memview"
 	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/google/gopacket"
-	"github.com/google/gopacket/reassembly"
 	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
-
-// fakeHTTPRequestFactory has the same Name() as akinet/http's real HTTP
-// request parser factory, without needing a buffer pool, so pairSeqForFactory
-// can be tested in isolation from real HTTP parsing.
-type fakeHTTPRequestFactory struct{}
-
-func (fakeHTTPRequestFactory) Name() string { return httpRequestParserFactoryName }
-
-func (fakeHTTPRequestFactory) Accepts(input memview.MemView, isEnd bool) (akinet.AcceptDecision, int64) {
-	return akinet.Reject, 0
-}
-
-func (fakeHTTPRequestFactory) CreateParser(id akinet.TCPBidiID, seq, ack reassembly.Sequence) akinet.TCPParser {
-	return nil
-}
 
 // TestPairSequencer exercises the FIFO pairing queue directly: requests push
 // an index, responses pop the oldest unmatched one, in order -- including
 // the pipelined case where two requests arrive before either response.
 func TestPairSequencer(t *testing.T) {
 	p := newPairSequencer()
-	req := fakeHTTPRequestFactory{}
-	notReq := princeParserFactory{} // any factory whose Name() isn't the HTTP request factory's
 
 	// Simple case: request then its response.
-	r0 := p.pairSeqForFactory(req)
-	s0 := p.pairSeqForFactory(notReq)
+	r0 := p.pairSeqForRequest()
+	s0 := p.pairSeqForResponse()
 	if r0 != s0 {
 		t.Errorf("expected first response to pair with first request: req=%v resp=%v", r0, s0)
 	}
 
 	// Pipelined case: two requests arrive before either response. FIFO
 	// ordering must still pair them correctly.
-	r1 := p.pairSeqForFactory(req)
-	r2 := p.pairSeqForFactory(req)
-	s1 := p.pairSeqForFactory(notReq)
-	s2 := p.pairSeqForFactory(notReq)
+	r1 := p.pairSeqForRequest()
+	r2 := p.pairSeqForRequest()
+	s1 := p.pairSeqForResponse()
+	s2 := p.pairSeqForResponse()
 
 	if r1 != s1 {
 		t.Errorf("expected second request to pair with first of the two pending responses: req=%v resp=%v", r1, s1)
@@ -212,5 +193,35 @@ func releasePairingTestTraffic(reqs []akinet.HTTPRequest, resps []akinet.HTTPRes
 	}
 	for _, r := range resps {
 		r.ReleaseBuffers()
+	}
+}
+
+// TestStampSyntheticPairSeq_OnlyEmittedMessagesConsumeFIFO guards the emit-time
+// contract: a request that is accepted but never emitted must not take a FIFO
+// slot. Skipping stamp models "Accept then fail"; the next real exchange must
+// still match.
+func TestStampSyntheticPairSeq_OnlyEmittedMessagesConsumeFIFO(t *testing.T) {
+	p := newPairSequencer()
+
+	req1, ok := p.stampSyntheticPairSeq(akinet.HTTPRequest{Seq: -1}).(akinet.HTTPRequest)
+	if !ok {
+		t.Fatalf("expected HTTPRequest")
+	}
+	resp1, ok := p.stampSyntheticPairSeq(akinet.HTTPResponse{Seq: -1}).(akinet.HTTPResponse)
+	if !ok {
+		t.Fatalf("expected HTTPResponse")
+	}
+	if req1.Seq != resp1.Seq {
+		t.Fatalf("first exchange: req.Seq=%d resp.Seq=%d, want equal", req1.Seq, resp1.Seq)
+	}
+
+	// No stamp here = failed/abandoned parse. Must not skew the next exchange.
+	req2, _ := p.stampSyntheticPairSeq(akinet.HTTPRequest{Seq: -1}).(akinet.HTTPRequest)
+	resp2, _ := p.stampSyntheticPairSeq(akinet.HTTPResponse{Seq: -1}).(akinet.HTTPResponse)
+	if req2.Seq != resp2.Seq {
+		t.Fatalf("second exchange after a non-emitted accept: req.Seq=%d resp.Seq=%d, want equal", req2.Seq, resp2.Seq)
+	}
+	if req2.Seq == req1.Seq {
+		t.Fatalf("expected distinct ordinals across exchanges, both %d", req2.Seq)
 	}
 }

--- a/pcap/pairing_test.go
+++ b/pcap/pairing_test.go
@@ -7,32 +7,51 @@ import (
 	"github.com/akitasoftware/akita-libs/akinet"
 	akihttp "github.com/akitasoftware/akita-libs/akinet/http"
 	"github.com/akitasoftware/akita-libs/buffer_pool"
+	"github.com/akitasoftware/akita-libs/memview"
 	"github.com/akitasoftware/akita-libs/tags"
 	"github.com/akitasoftware/go-utils/optionals"
 	"github.com/google/gopacket"
+	"github.com/google/gopacket/reassembly"
 	"github.com/postmanlabs/postman-insights-agent/capturestats"
 	"github.com/postmanlabs/postman-insights-agent/telemetry"
 )
+
+// fakeHTTPRequestFactory has the same Name() as akinet/http's real HTTP
+// request parser factory, without needing a buffer pool, so pairSeqForFactory
+// can be tested in isolation from real HTTP parsing.
+type fakeHTTPRequestFactory struct{}
+
+func (fakeHTTPRequestFactory) Name() string { return httpRequestParserFactoryName }
+
+func (fakeHTTPRequestFactory) Accepts(input memview.MemView, isEnd bool) (akinet.AcceptDecision, int64) {
+	return akinet.Reject, 0
+}
+
+func (fakeHTTPRequestFactory) CreateParser(id akinet.TCPBidiID, seq, ack reassembly.Sequence) akinet.TCPParser {
+	return nil
+}
 
 // TestPairSequencer exercises the FIFO pairing queue directly: requests push
 // an index, responses pop the oldest unmatched one, in order -- including
 // the pipelined case where two requests arrive before either response.
 func TestPairSequencer(t *testing.T) {
 	p := newPairSequencer()
+	req := fakeHTTPRequestFactory{}
+	notReq := princeParserFactory{} // any factory whose Name() isn't the HTTP request factory's
 
 	// Simple case: request then its response.
-	r0 := p.pairSeqForRequest()
-	s0 := p.pairSeqForResponse()
+	r0, _ := p.pairSeqForFactory(req)
+	s0, _ := p.pairSeqForFactory(notReq)
 	if r0 != s0 {
 		t.Errorf("expected first response to pair with first request: req=%v resp=%v", r0, s0)
 	}
 
 	// Pipelined case: two requests arrive before either response. FIFO
 	// ordering must still pair them correctly.
-	r1 := p.pairSeqForRequest()
-	r2 := p.pairSeqForRequest()
-	s1 := p.pairSeqForResponse()
-	s2 := p.pairSeqForResponse()
+	r1, _ := p.pairSeqForFactory(req)
+	r2, _ := p.pairSeqForFactory(req)
+	s1, _ := p.pairSeqForFactory(notReq)
+	s2, _ := p.pairSeqForFactory(notReq)
 
 	if r1 != s1 {
 		t.Errorf("expected second request to pair with first of the two pending responses: req=%v resp=%v", r1, s1)
@@ -42,6 +61,54 @@ func TestPairSequencer(t *testing.T) {
 	}
 	if r1 == r2 {
 		t.Errorf("expected the two pipelined requests to get distinct indices, both got %v", r1)
+	}
+}
+
+func TestPairSequencerRollbackAfterFailedAccept(t *testing.T) {
+	p := newPairSequencer()
+	req := fakeHTTPRequestFactory{}
+	notReq := princeParserFactory{}
+
+	r0, kind0 := p.pairSeqForFactory(req)
+	if kind0 != pairAllocRequestPush {
+		t.Fatalf("want request push, got %v", kind0)
+	}
+	// Simulate Accept then parse fail: roll back before the next exchange.
+	p.rollbackPairSeq(r0, kind0)
+
+	r1, _ := p.pairSeqForFactory(req)
+	s1, kindResp := p.pairSeqForFactory(notReq)
+	if kindResp != pairAllocResponsePop {
+		t.Fatalf("want response pop, got %v", kindResp)
+	}
+	if r1 != s1 {
+		t.Fatalf("after request rollback, next exchange must pair: req=%v resp=%v", r1, s1)
+	}
+	if r1 != 0 {
+		t.Fatalf("after rolling back the only allocation, next ordinal should reuse 0, got %v", r1)
+	}
+
+	// Response pop then fail: put the pending request back.
+	r2, _ := p.pairSeqForFactory(req)
+	s2, kind2 := p.pairSeqForFactory(notReq)
+	p.rollbackPairSeq(s2, kind2)
+	s2b, kind2b := p.pairSeqForFactory(notReq)
+	if kind2b != pairAllocResponsePop {
+		t.Fatalf("want response pop after rollback, got %v", kind2b)
+	}
+	if r2 != s2b {
+		t.Fatalf("after response rollback, pending request must still pair: req=%v resp=%v", r2, s2b)
+	}
+
+	// Empty-FIFO response invent then fail.
+	s3, kind3 := p.pairSeqForFactory(notReq)
+	if kind3 != pairAllocResponseInvent {
+		t.Fatalf("want invent, got %v", kind3)
+	}
+	p.rollbackPairSeq(s3, kind3)
+	s4, kind4 := p.pairSeqForFactory(notReq)
+	if kind4 != pairAllocResponseInvent || s4 != s3 {
+		t.Fatalf("after invent rollback, next invent should reuse seq: got seq=%v kind=%v want seq=%v invent", s4, kind4, s3)
 	}
 }
 
@@ -193,35 +260,5 @@ func releasePairingTestTraffic(reqs []akinet.HTTPRequest, resps []akinet.HTTPRes
 	}
 	for _, r := range resps {
 		r.ReleaseBuffers()
-	}
-}
-
-// TestStampSyntheticPairSeq_OnlyEmittedMessagesConsumeFIFO guards the emit-time
-// contract: a request that is accepted but never emitted must not take a FIFO
-// slot. Skipping stamp models "Accept then fail"; the next real exchange must
-// still match.
-func TestStampSyntheticPairSeq_OnlyEmittedMessagesConsumeFIFO(t *testing.T) {
-	p := newPairSequencer()
-
-	req1, ok := p.stampSyntheticPairSeq(akinet.HTTPRequest{Seq: -1}).(akinet.HTTPRequest)
-	if !ok {
-		t.Fatalf("expected HTTPRequest")
-	}
-	resp1, ok := p.stampSyntheticPairSeq(akinet.HTTPResponse{Seq: -1}).(akinet.HTTPResponse)
-	if !ok {
-		t.Fatalf("expected HTTPResponse")
-	}
-	if req1.Seq != resp1.Seq {
-		t.Fatalf("first exchange: req.Seq=%d resp.Seq=%d, want equal", req1.Seq, resp1.Seq)
-	}
-
-	// No stamp here = failed/abandoned parse. Must not skew the next exchange.
-	req2, _ := p.stampSyntheticPairSeq(akinet.HTTPRequest{Seq: -1}).(akinet.HTTPRequest)
-	resp2, _ := p.stampSyntheticPairSeq(akinet.HTTPResponse{Seq: -1}).(akinet.HTTPResponse)
-	if req2.Seq != resp2.Seq {
-		t.Fatalf("second exchange after a non-emitted accept: req.Seq=%d resp.Seq=%d, want equal", req2.Seq, resp2.Seq)
-	}
-	if req2.Seq == req1.Seq {
-		t.Fatalf("expected distinct ordinals across exchanges, both %d", req2.Seq)
 	}
 }

--- a/pcap/run.go
+++ b/pcap/run.go
@@ -42,6 +42,7 @@ func Collect(
 	telemetry telemetry.Tracker,
 	stats *capturestats.Stats,
 	telemetryEventReporter func(string),
+	directionHint *DirectionHint,
 ) error {
 	defer proc.Close()
 
@@ -59,6 +60,7 @@ func Collect(
 
 	parser := NewNetworkTrafficParser(serviceID, traceTags, bufferShare, telemetry, stats)
 	parser.useSyntheticPairing = syntheticTCPPairingEnabled()
+	parser.directionHint = directionHint
 
 	podName, ok := traceTags[tags.XAkitaKubernetesPod]
 	if !ok {

--- a/pcap/stream.go
+++ b/pcap/stream.go
@@ -143,22 +143,7 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 				f.handleUnparseable(sg.CaptureInfo(ignoreCount).Timestamp, pktData.Len())
 				return
 			}
-			if f.pairSeq != nil && isHTTPParserFactory(fact) {
-				// Synthetic pairing enabled, and this is an HTTP/1.x request or
-				// response: ignore the real TCP seq/ack and use a shared
-				// per-connection FIFO ordinal instead, mirroring
-				// ebpf/events/adapter.go's tlsConnState.pairSeqForFactory. See
-				// pairing.go for why the real numbers are unreliable here.
-				//
-				// Scoped to HTTP only -- TLS/HTTP2-preface/etc. keep the real
-				// seq/ack, even when the flag is on, since this fix only concerns
-				// HTTP/1.x pairing and other factories have no reason to see
-				// substituted values.
-				synthSeq := f.pairSeq.pairSeqForFactory(fact)
-				f.currentParser = fact.CreateParser(f.bidiID, synthSeq, synthSeq)
-			} else {
-				f.currentParser = fact.CreateParser(f.bidiID, ctx.seq, ctx.ack)
-			}
+			f.currentParser = fact.CreateParser(f.bidiID, ctx.seq, ctx.ack)
 			f.currentParserCtx = ctx
 		default:
 			printer.Errorf("unsupported decision type %s, treating data as raw bytes\n", decision)
@@ -193,7 +178,7 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 			f.stats.IncrNilAssemblerContextAfterParse()
 			parseEnd = parseStart
 		}
-		f.outChan <- f.toPNT(parseStart, parseEnd, pnc)
+		f.emitParsed(parseStart, parseEnd, pnc)
 
 		f.currentParser = nil
 		f.currentParserCtx = nil
@@ -218,6 +203,16 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 	}
 }
 
+// emitParsed stamps a synthetic FIFO ordinal onto HTTP messages (when
+// enabled) and sends them downstream. Stamping happens here -- not at
+// CreateParser -- so a failed or abandoned parse never consumes a slot.
+func (f *tcpFlow) emitParsed(firstPacketTime, lastPacketTime time.Time, pnc akinet.ParsedNetworkContent) {
+	if f.pairSeq != nil {
+		pnc = f.pairSeq.stampSyntheticPairSeq(pnc)
+	}
+	f.outChan <- f.toPNT(firstPacketTime, lastPacketTime, pnc)
+}
+
 // Marks this flow as finished.
 func (f *tcpFlow) reassemblyComplete() {
 	if f.currentParser != nil {
@@ -228,7 +223,7 @@ func (f *tcpFlow) reassemblyComplete() {
 			f.handleUnparseable(t, numBytesConsumed)
 		} else if pnc != nil {
 			printer.V(6).Infof("ReassemblyComplete parsed additional network traffic with ts: %v", t)
-			f.outChan <- f.toPNT(t, t, pnc)
+			f.emitParsed(t, t, pnc)
 			f.handleUnparseable(t, unused.Len())
 		}
 		f.currentParser = nil

--- a/pcap/stream.go
+++ b/pcap/stream.go
@@ -47,11 +47,19 @@ type tcpFlow struct {
 	// in pairing.go. Nil means use the real TCP seq/ack numbers, as before.
 	pairSeq *pairSequencer
 
+	// Netns-wide locals for Direction (shared across both flows).
+	directionHint *DirectionHint
+
 	// Non-nil if there is an active parser for this flow.
 	currentParser akinet.TCPParser
 
 	// Context for the FIRST packet that currentParser is processing.
 	currentParserCtx *assemblerCtxWithSeq
+
+	// Accept-time synthetic pair allocation for currentParser, if any. Rolled
+	// back if the parse fails or is abandoned before a successful emit.
+	currentPairSeq  reassembly.Sequence
+	currentPairKind pairAllocKind
 
 	// Data that was left unused when determining parser, awaiting for more data.
 	// This is a hack to flush data when the flow terminates before a parser has
@@ -61,7 +69,7 @@ type tcpFlow struct {
 	unusedAcceptBuf memview.MemView
 }
 
-func newTCPFlow(clock clockWrapper, bidiID akinet.TCPBidiID, nf, tf gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats, pairSeq *pairSequencer) *tcpFlow {
+func newTCPFlow(clock clockWrapper, bidiID akinet.TCPBidiID, nf, tf gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats, pairSeq *pairSequencer, directionHint *DirectionHint) *tcpFlow {
 	return &tcpFlow{
 		clock:           clock,
 		netFlow:         nf,
@@ -71,6 +79,7 @@ func newTCPFlow(clock clockWrapper, bidiID akinet.TCPBidiID, nf, tf gopacket.Flo
 		factorySelector: fs,
 		stats:           stats,
 		pairSeq:         pairSeq,
+		directionHint:   directionHint,
 	}
 }
 
@@ -143,7 +152,17 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 				f.handleUnparseable(sg.CaptureInfo(ignoreCount).Timestamp, pktData.Len())
 				return
 			}
-			f.currentParser = fact.CreateParser(f.bidiID, ctx.seq, ctx.ack)
+			if f.pairSeq != nil && isHTTPParserFactory(fact) {
+				// Synthetic pairing: ignore real TCP seq/ack; use per-connection
+				// FIFO ordinal (see pairing.go). Scoped to HTTP/1.x only.
+				synthSeq, kind := f.pairSeq.pairSeqForFactory(fact)
+				f.currentParser = fact.CreateParser(f.bidiID, synthSeq, synthSeq)
+				f.currentPairSeq = synthSeq
+				f.currentPairKind = kind
+			} else {
+				f.currentParser = fact.CreateParser(f.bidiID, ctx.seq, ctx.ack)
+				f.currentPairKind = pairAllocNone
+			}
 			f.currentParserCtx = ctx
 		default:
 			printer.Errorf("unsupported decision type %s, treating data as raw bytes\n", decision)
@@ -159,6 +178,7 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 		t := f.currentParserCtx.GetCaptureInfo().Timestamp
 		f.handleUnparseable(t, numBytesConsumed)
 
+		f.rollbackCurrentPairSeq()
 		f.currentParser = nil
 		f.currentParserCtx = nil
 
@@ -178,8 +198,9 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 			f.stats.IncrNilAssemblerContextAfterParse()
 			parseEnd = parseStart
 		}
-		f.emitParsed(parseStart, parseEnd, pnc)
+		f.outChan <- f.toPNT(parseStart, parseEnd, pnc)
 
+		f.currentPairKind = pairAllocNone
 		f.currentParser = nil
 		f.currentParserCtx = nil
 
@@ -203,14 +224,11 @@ func (f *tcpFlow) reassembledWithIgnore(ignoreCount int, sg reassembly.ScatterGa
 	}
 }
 
-// emitParsed stamps a synthetic FIFO ordinal onto HTTP messages (when
-// enabled) and sends them downstream. Stamping happens here -- not at
-// CreateParser -- so a failed or abandoned parse never consumes a slot.
-func (f *tcpFlow) emitParsed(firstPacketTime, lastPacketTime time.Time, pnc akinet.ParsedNetworkContent) {
-	if f.pairSeq != nil {
-		pnc = f.pairSeq.stampSyntheticPairSeq(pnc)
+func (f *tcpFlow) rollbackCurrentPairSeq() {
+	if f.pairSeq != nil && f.currentPairKind != pairAllocNone {
+		f.pairSeq.rollbackPairSeq(f.currentPairSeq, f.currentPairKind)
 	}
-	f.outChan <- f.toPNT(firstPacketTime, lastPacketTime, pnc)
+	f.currentPairKind = pairAllocNone
 }
 
 // Marks this flow as finished.
@@ -221,10 +239,15 @@ func (f *tcpFlow) reassemblyComplete() {
 		t := f.currentParserCtx.GetCaptureInfo().Timestamp
 		if err != nil {
 			f.handleUnparseable(t, numBytesConsumed)
+			f.rollbackCurrentPairSeq()
 		} else if pnc != nil {
 			printer.V(6).Infof("ReassemblyComplete parsed additional network traffic with ts: %v", t)
-			f.emitParsed(t, t, pnc)
+			f.outChan <- f.toPNT(t, t, pnc)
+			f.currentPairKind = pairAllocNone
 			f.handleUnparseable(t, unused.Len())
+		} else {
+			// Forced end with no complete message — undo Accept-time allocation.
+			f.rollbackCurrentPairSeq()
 		}
 		f.currentParser = nil
 		f.currentParserCtx = nil
@@ -277,33 +300,20 @@ func (f *tcpFlow) toPNT(firstPacketTime time.Time, lastPacketTime time.Time,
 	srcE, dstE := f.netFlow.Endpoints()
 	srcP, dstP := f.tcpFlow.Endpoints()
 
-	// TODO(direction): populate ParsedNetworkTraffic.Direction for the pcap path.
-	// The eBPF path already sets it (see ebpf/events/adapter.go: directionForPair),
-	// and trace.BackendCollector.toReport already maps it to the witness
-	// (INBOUND/OUTBOUND); pcap currently leaves it DirectionUnknown -> defaults to
-	// INBOUND. To implement:
-	//   - Plumb this host/interface's own IPs (already enumerated in
-	//     apidump.getInboundBPFFilter, net.go) into the pcap parser/stream.
-	//   - Same rule as eBPF, using the real packet IPs we have here:
-	//       HTTPRequest : DstIP in localIPs -> DirectionInbound  (we are the server)
-	//                     SrcIP in localIPs -> DirectionOutbound (we are the client)
-	//       HTTPResponse: invert the above.
-	//     (akinet.TCPConnectionMetadata.Initiator is an alternative signal but is
-	//     unreliable here because Accept() forces stream start without the SYN.)
-	// NOTE: this is only the tagging half. Outbound pcap traffic is currently
-	// routed to a DummyCollector (apidump.go, notMatchedFilter chain) and never
-	// uploaded, and the inbound/outbound BPF split only exists when --port/
-	// --bpf-filter is set. Actually surfacing outbound pcap witnesses is a
-	// separate, deliberate decision. Also depends on the backend accepting
-	// OUTBOUND. See the eBPF direction work for the shared-lib pieces.
+	srcIP := net.IP(srcE.Raw())
+	dstIP := net.IP(dstE.Raw())
+	srcPort := int(binary.BigEndian.Uint16(srcP.Raw()))
+	dstPort := int(binary.BigEndian.Uint16(dstP.Raw()))
+
 	return akinet.ParsedNetworkTraffic{
-		SrcIP:           net.IP(srcE.Raw()),
-		SrcPort:         int(binary.BigEndian.Uint16(srcP.Raw())),
-		DstIP:           net.IP(dstE.Raw()),
-		DstPort:         int(binary.BigEndian.Uint16(dstP.Raw())),
+		SrcIP:           srcIP,
+		SrcPort:         srcPort,
+		DstIP:           dstIP,
+		DstPort:         dstPort,
 		Content:         c,
 		ObservationTime: firstPacketTime,
 		FinalPacketTime: lastPacketTime,
+		Direction:       classifyHTTPDirection(c, srcIP, dstIP, srcPort, dstPort, f.directionHint),
 	}
 }
 
@@ -327,9 +337,11 @@ type tcpStream struct {
 	// Shared by both flows of this connection when synthetic TCP pairing is
 	// enabled; nil otherwise. See pairing.go.
 	pairSeq *pairSequencer
+
+	directionHint *DirectionHint
 }
 
-func newTCPStream(clock clockWrapper, netFlow gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats, useSyntheticPairing bool) *tcpStream {
+func newTCPStream(clock clockWrapper, netFlow gopacket.Flow, outChan chan<- akinet.ParsedNetworkTraffic, fs akinet.TCPParserFactorySelector, stats *capturestats.Stats, useSyntheticPairing bool, directionHint *DirectionHint) *tcpStream {
 	var pairSeq *pairSequencer
 	if useSyntheticPairing {
 		pairSeq = newPairSequencer()
@@ -342,6 +354,7 @@ func newTCPStream(clock clockWrapper, netFlow gopacket.Flow, outChan chan<- akin
 		outChan:         outChan,
 		stats:           stats,
 		pairSeq:         pairSeq,
+		directionHint:   directionHint,
 	}
 }
 
@@ -361,8 +374,8 @@ func (c *tcpStream) Accept(tcp *layers.TCP, _ gopacket.CaptureInfo, dir reassemb
 		// data from this tcpStream or it is garbage collected by the assembler
 		// after streamTimeout.
 		tf, _ := gopacket.FlowFromEndpoints(layers.NewTCPPortEndpoint(tcp.SrcPort), layers.NewTCPPortEndpoint(tcp.DstPort))
-		s1 := newTCPFlow(c.clock, c.bidiID, c.netFlow, tf, c.outChan, c.factorySelector, c.stats, c.pairSeq)
-		s2 := newTCPFlow(c.clock, c.bidiID, c.netFlow.Reverse(), tf.Reverse(), c.outChan, c.factorySelector, c.stats, c.pairSeq)
+		s1 := newTCPFlow(c.clock, c.bidiID, c.netFlow, tf, c.outChan, c.factorySelector, c.stats, c.pairSeq, c.directionHint)
+		s2 := newTCPFlow(c.clock, c.bidiID, c.netFlow.Reverse(), tf.Reverse(), c.outChan, c.factorySelector, c.stats, c.pairSeq, c.directionHint)
 		c.flows = map[reassembly.TCPFlowDirection]*tcpFlow{
 			dir:           s1,
 			dir.Reverse(): s2,

--- a/pcap/stream_test.go
+++ b/pcap/stream_test.go
@@ -85,7 +85,7 @@ func runTCPFlowTestCase(c tcpFlowTestCase) error {
 		princeParserFactory{},
 		pineappleParserFactory{},
 	})
-	f := newTCPFlow(&fakeClock{testTime}, dummyBidiID, dummyNetFlow, dummyTCPPacketFlow, out, fs, capturestats.New(), nil)
+	f := newTCPFlow(&fakeClock{testTime}, dummyBidiID, dummyNetFlow, dummyTCPPacketFlow, out, fs, capturestats.New(), nil, nil)
 
 	for i, input := range c.inputs {
 		sg.data = memview.New([]byte(input))

--- a/trace/drop_outbound.go
+++ b/trace/drop_outbound.go
@@ -1,0 +1,37 @@
+package trace
+
+import (
+	"github.com/akitasoftware/akita-libs/akinet"
+	"github.com/postmanlabs/postman-insights-agent/printer"
+)
+
+// dropOutboundCollector suppresses DirectionOutbound HTTP messages before they
+// reach rate-limit / pair cache. Backend/UI do not support OUTBOUND yet; this
+// also drops Istio REDIRECT outbound halves that slip past BPF.
+type dropOutboundCollector struct {
+	next                   Collector
+	telemetryEventReporter func(string)
+}
+
+// NewDropOutboundCollector wraps next and drops outbound-direction traffic.
+func NewDropOutboundCollector(next Collector, telemetryEventReporter func(string)) Collector {
+	return &dropOutboundCollector{next: next, telemetryEventReporter: telemetryEventReporter}
+}
+
+func (c *dropOutboundCollector) Process(t akinet.ParsedNetworkTraffic) error {
+	switch t.Content.(type) {
+	case akinet.HTTPRequest, akinet.HTTPResponse:
+		if t.Direction == akinet.DirectionOutbound {
+			printer.Debugf("Dropping outbound HTTP message (DirectionOutbound)\n")
+			if c.telemetryEventReporter != nil {
+				c.telemetryEventReporter("http_dropped_outbound")
+			}
+			return nil
+		}
+	}
+	return c.next.Process(t)
+}
+
+func (c *dropOutboundCollector) Close() error {
+	return c.next.Close()
+}


### PR DESCRIPTION
### Summary
Add a rolls back the ordinal when a parse fails or is abandoned, so keep-alive inbound traffic does not permanently skew pairing.
Auto-discovers application listen ports and local IPs in the capture netns, then applies an inbound-only cBPF filter (no `--port` required). Mesh/admin ports (`15000–15090`, ssh) are excluded.
Tags each HTTP message as inbound/outbound from packet IPs/ports and drops outbound before rate-limit / pair cache (backend does not support OUTBOUND yet; also removes Istio REDIRECT outbound halves).
Fixes DaemonSet discovery: read `/host/proc/<pid>/net/tcp{,6}` instead of stale `/proc/net` after `setns`, and retry briefly for late binds.

### Why
Istio iptables REDIRECT splits outbound into two StreamIDs, so FIFO cannot pair them. Product decision for pcap: keep inbound only; capture outbound later via eBPF.

### Test plan
- [ ] `go test ./pcap/ ./apidump/ ./trace/`
- [ ] DaemonSet on Istio pods: log shows `Auto inbound-only capture enabled: ports=[...]`
- [ ] Telemetry: `prefilter` ~= `postfilter`; `pcap_witness_paired` ~= `responses`; `pcap_response_dropped_no_matching_request` near zero; little/no `pcap_http_dropped_outbound` once BPF is engaged

### Notes
- Synthetic pairing still gated by POSTMAN_INSIGHTS_AGENT_SYNTHETIC_TCP_PAIRING=true.
- User --bpf-filter / --port still wins over auto inbound.