### PR TITLE
INS-153: update agent support email to help@postman.com

### DIFF
--- a/consts/contact.go
+++ b/consts/contact.go
@@ -1,3 +1,3 @@
 package consts
 
-const SupportEmail = "live.insights.alpha@postman.com"
+const SupportEmail = "help@postman.com"


### PR DESCRIPTION
## Summary
- Updates `consts.SupportEmail` from the old `live.insights.alpha@postman.com` to the standard support channel `help@postman.com`.

## Context
- Part of [INS-109](https://postmanlabs.atlassian.net/browse/INS-109): transition Postman Insights support from `observability-support@postman.com` (UI) / `live.insights.alpha@postman.com` (agent) to the standard support channel.
- This PR addresses [INS-153](https://postmanlabs.atlassian.net/browse/INS-153), the subtask scoped to the agent install scripts/codebase.

## Test plan
- [x] Confirmed via INS-109/INS-153 descriptions that `help@postman.com` is the intended standard address.
- [x] Grepped the repo for other references to the old email — `consts/contact.go` was the only occurrence.

[INS-109]: https://postmanlabs.atlassian.net/browse/INS-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INS-153]: https://postmanlabs.atlassian.net/browse/INS-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ